### PR TITLE
chore(env): Cloud Agent dev environment (PostgreSQL + fullstack)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "Neon Arsenal Market",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "dev:fullstack",
+      "command": "npm run dev:fullstack"
+    }
+  ],
+  "ports": [
+    { "name": "frontend", "port": 5173 },
+    { "name": "api", "port": 3001 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent install for Neon Arsenal Market.
+# Prepares: PostgreSQL 16, local dev .env files, npm deps (root + server),
+# Prisma client + migrations, server build, and seed data.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DB_USER="neon"
+DB_PASSWORD="neon_local_password"
+DB_NAME="neon_arsenal"
+DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}"
+
+# ─── 1. PostgreSQL (system package) ──────────────────────────────────────────
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  echo "==> Installing PostgreSQL 16"
+  # archive.ubuntu.com is unreliable from Cloud Agent VMs; use a mirror that is
+  # reachable and drop the unreachable security suite so apt-get update succeeds.
+  sudo tee /etc/apt/sources.list.d/ubuntu.sources >/dev/null <<'EOF'
+Types: deb
+URIs: http://mirrors.edge.kernel.org/ubuntu/
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+  sudo apt-get update -o Acquire::http::Timeout=30 -o Acquire::Retries=2
+  sudo apt-get install -y --no-install-recommends postgresql postgresql-contrib
+fi
+
+# ─── 2. Start the local cluster (needed for migrate/seed below) ──────────────
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+for _ in $(seq 1 30); do
+  sudo -u postgres pg_isready -q && break
+  sleep 1
+done
+
+# ─── 3. Role + database (idempotent) ─────────────────────────────────────────
+sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL
+DO \$\$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='${DB_USER}') THEN
+    CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}';
+  END IF;
+END \$\$;
+ALTER ROLE ${DB_USER} CREATEDB;
+SQL
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" \
+  | grep -q 1 || sudo -u postgres createdb -O "${DB_USER}" "${DB_NAME}"
+
+# ─── 4. Local dev env files (gitignored; created if absent) ──────────────────
+if [ ! -f server/.env ]; then
+  echo "==> Writing server/.env"
+  cat > server/.env <<EOF
+DATABASE_URL="${DATABASE_URL}"
+JWT_SECRET=local-dev-jwt-secret-change-me
+JWT_REFRESH_SECRET=local-dev-refresh-secret-change-me
+JWT_ACCESS_EXPIRES_IN=15m
+JWT_REFRESH_EXPIRES_IN=7d
+PAYPAL_CLIENT_ID=
+PAYPAL_SECRET=
+PAYPAL_MODE=sandbox
+PAYPAL_WEBHOOK_ID=
+PAYPAL_API_TIMEOUT_MS=10000
+PORT=3001
+NODE_ENV=development
+FRONTEND_URL=http://localhost:5173
+RESERVATION_TTL_MINUTES=15
+EOF
+fi
+if [ ! -f .env ]; then
+  echo "==> Writing .env (frontend)"
+  cat > .env <<EOF
+VITE_API_URL=http://localhost:3001
+POSTGRES_USER=${DB_USER}
+POSTGRES_PASSWORD=${DB_PASSWORD}
+POSTGRES_DB=${DB_NAME}
+EOF
+fi
+
+# ─── 5. Node dependencies ────────────────────────────────────────────────────
+echo "==> Installing npm dependencies (root)"
+npm install
+echo "==> Installing npm dependencies (server)"
+npm install --prefix server
+
+# ─── 6. Prisma client, migrations, build, seed ───────────────────────────────
+echo "==> Prisma generate + migrate deploy"
+npm run db:generate --prefix server
+npm run db:migrate:deploy --prefix server
+echo "==> Building server (tsc) + seeding"
+npm run build --prefix server
+npm run db:seed --prefix server
+
+echo "==> Install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Per-boot startup for Neon Arsenal Market: bring up the local PostgreSQL
+# cluster and confirm readiness. Dependency install and seeding live in
+# install.sh; this script only reconciles the per-boot database daemon.
+set -euo pipefail
+
+DB_USER="neon"
+DB_PASSWORD="neon_local_password"
+DB_NAME="neon_arsenal"
+
+# Start the cluster if it is not already running (idempotent).
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+
+# Wait for readiness.
+for _ in $(seq 1 30); do
+  sudo -u postgres pg_isready -q && break
+  sleep 1
+done
+
+# Ensure role + database exist (safe no-op when the snapshot already has them).
+sudo -u postgres psql -v ON_ERROR_STOP=1 <<SQL || true
+DO \$\$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='${DB_USER}') THEN
+    CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}';
+  END IF;
+END \$\$;
+SQL
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" \
+  | grep -q 1 || sudo -u postgres createdb -O "${DB_USER}" "${DB_NAME}"
+
+echo "PostgreSQL is ready."

--- a/server/src/shared/routes/docs.routes.ts
+++ b/server/src/shared/routes/docs.routes.ts
@@ -23,12 +23,13 @@ router.get("/docs", (_req, res) => {
 <body>
   <div id="swagger-ui"></div>
   <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js" crossorigin></script>
   <script>
     window.onload = () => {
       SwaggerUIBundle({
         spec: ${specJson},
         dom_id: '#swagger-ui',
-        presets: [SwaggerUIBundle.presets.apis, SwaggerUIBundle.SwaggerUIStandalonePreset],
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
         layout: 'StandaloneLayout',
         deepLinking: true,
         displayRequestDuration: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for Neon Arsenal Market and validates it end to end (backend API, PostgreSQL, and the React frontend).

The repo previously had no `.cursor/environment.json`, so Cloud Agents started with no database, no dependency bootstrap, and no running services. This adds an idempotent install/start pipeline and fixes two small pre-existing defects that blocked the documented dev workflow.

## Changes

- **`.cursor/environment.json`** — declares the environment: `install` → `.cursor/install.sh`, `start` → `.cursor/start.sh`, a `dev:fullstack` terminal, and exposed ports `5173` (frontend) / `3001` (API).
- **`.cursor/install.sh`** — idempotent bootstrap: installs PostgreSQL 16 (switching to a reachable Ubuntu mirror because `archive.ubuntu.com` is unreliable from the VM), starts the cluster, creates the `neon` role + `neon_arsenal` DB, writes gitignored local dev `.env` files, installs npm deps (root + server), runs `prisma generate` + `migrate deploy`, builds the server, and seeds demo data.
- **`.cursor/start.sh`** — per-boot: starts the PostgreSQL cluster and confirms readiness (dependency install/seed stays in `install.sh`).
- **`vitest.config.ts`** — use the installed `@vitejs/plugin-react` instead of the uninstalled `@vitejs/plugin-react-swc`, which made `npm test` fail to load its config.
- **`server/src/shared/routes/docs.routes.ts`** — load `swagger-ui-standalone-preset.js` and reference the correct `SwaggerUIStandalonePreset` global so the `/docs` Swagger UI renders (it previously errored with `No layout defined for "StandaloneLayout"`).

## Validation (local VM)

- `npm run typecheck` (root) — pass; `cd server && npm run typecheck` — pass.
- Frontend tests: `npm test` — 28/28 pass (after the vitest config fix).
- Server tests: `cd server && npx vitest run --no-file-parallelism` — 106/106 pass. Note: the two Postgres integration suites share one database, so they must run sequentially; the default `npm test` runs files in parallel and produces one false failure from cross-file interference.
- `install.sh` run twice — idempotent, exits 0.
- Live API: `/health` ok, `/ready` ready, catalog served, buyer login returns a JWT.
- Flagship transactional invariant: creating an order reserved a unique listing (`ACTIVE` → `RESERVED`, 15-min window, `reservedByOrderId` set) inside a DB transaction; a second reservation on the same listing was correctly rejected.
- Frontend browser walkthrough: marketplace loads, login, product detail, add-to-cart, cart totals; Swagger UI at `/docs` renders after the fix.

## Validation (clean environment build)

- Triggered a draft build off this branch with the default base image (no snapshot) so `install.sh` bootstrapped from scratch. Build `bld-20260905-389faa03-cce7-4d35-bacb-a4c07f6f4919` **SUCCEEDED** (~3 min); logs show PostgreSQL 16 install, `migrate deploy` (all migrations applied), server build, seed complete, "Install complete".
- Booted a fresh Cloud Agent from that build — all checks PASS: Node 22.14 / npm 10.9.7 / PostgreSQL 16.15; `start.sh` brings the cluster online (idempotent); 4 migrations applied + seed present (34 listings, 20 products, 4 users); `dev:fullstack` serves API `:3001` and frontend `:5173`; login → order → listing `RESERVED` verified against real PostgreSQL.

## Demo

[neon-arsenal-marketplace-e2e-demo.mp4](https://cursor.com/agents/bc-e061f19d-d2e4-472c-8c85-41e45f6700c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneon-arsenal-marketplace-e2e-demo.mp4)

## Notes / limitations

- PayPal env vars are intentionally left blank for local dev; live payment execution/webhooks require sandbox credentials (add via Secrets if needed). The core order/reservation flow does not require them.
- `.env` files are gitignored and generated by `install.sh` with dev-only placeholder JWT secrets.
- The committed root `package-lock.json` is out of sync with `package.json` (pre-existing), so `install.sh` uses `npm install` (as the README documents) rather than `npm ci`. Not modified here.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e061f19d-d2e4-472c-8c85-41e45f6700c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e061f19d-d2e4-472c-8c85-41e45f6700c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

