### PR TITLE
feat(observability): OpenTelemetry tracing and engineering metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The project focuses primarily on the backend and its business rules, including:
 - API documentation
 - Dockerized local infrastructure
 - Automated testing and CI
+- Optional OpenTelemetry traces and metrics
 
 ## Architecture
 
@@ -277,6 +278,16 @@ GET /ready
 
 `/health` checks process liveness, while `/ready` verifies database connectivity.
 
+## Observability
+
+The API keeps Pino and `X-Request-Id`. OpenTelemetry is **disabled by default**.
+
+```bash
+OTEL_ENABLED=true npm run dev --prefix server
+```
+
+Exporters: `none` (default), `console`, or `otlp`. A missing collector does not prevent the process from starting. See `docs/observability.md`.
+
 ## Engineering Notes
 
 This project is intentionally more than a CRUD application.
@@ -304,8 +315,8 @@ Potential next iterations include:
 - Improved monetary precision using database-native decimal operations
 - Asynchronous processing for non-critical workflows
 - Distributed rate limiting
-- Centralized observability and metrics
-- Background jobs for reservation expiration and payment reconciliation
+- Stronger production export of traces/metrics (collector, dashboards)
+- Benchmarks and query plans for the hottest checkout paths
 
 ## Project Status
 

--- a/docs/adr/0004-opentelemetry.md
+++ b/docs/adr/0004-opentelemetry.md
@@ -1,0 +1,36 @@
+# ADR 0004 — OpenTelemetry without an observability platform
+
+## Status
+
+Accepted.
+
+## Context
+
+Issue #7 needs enough tracing and metrics to diagnose latency, errors and business failures on order creation, reservation, PayPal webhooks and payment confirmation. The repository is a modular monolith whose local workflow is `npm run dev` plus PostgreSQL. Introducing Jaeger, Grafana, Prometheus, Tempo or an OpenTelemetry Collector would make local development depend on infrastructure the product does not need yet.
+
+Pino and `X-Request-Id` already exist. Replacing them would break current operators and tests.
+
+## Decision
+
+Use official OpenTelemetry JS SDK packages only. Enable them with `OTEL_ENABLED`. Default is off.
+
+Supported exporters:
+
+- `none` (default) — spans exist in-process for log correlation when enabled, nothing is shipped
+- `console` — only when `OTEL_EXPORTER=console`
+- `otlp` — optional HTTP OTLP; the process does not fail if the endpoint is down
+
+Keep the existing request ID. Add `trace_id` / `span_id` to the Pino mixin when a span is active. Propagate W3C `traceparent` when a client sends it.
+
+Instrument only critical boundaries: HTTP server, Prisma operations (no SQL text or parameters), PayPal client operations, and explicit workflow spans for order creation, reservation, payment confirmation, webhooks and reconciliation.
+
+Classify expected 4xx business results (`app.outcome`) without span `ERROR`. Reserve `ERROR` for 5xx, timeouts, provider failures and unexpected exceptions.
+
+Metric attributes are limited to low-cardinality keys: HTTP method/route/status, Prisma operation/collection, PayPal operation name. No user, order, listing, email or token labels.
+
+## Consequences
+
+- `npm run dev` and the test suites work without a collector.
+- Production can enable OTLP later without changing domain code.
+- Pending-order gauges are not scraped from PostgreSQL; use a query or a future metric if that becomes an operational need.
+- Automatic Prisma spans add some volume. They omit SQL and bind variables to avoid sensitive data and high cardinality.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -18,6 +18,7 @@ Read in this order:
 6. `docs/roadmap.md` — prioritized backlog.
 7. The relevant source code, schema, migrations, and tests.
 8. The relevant ADRs and operational documentation.
+9. `docs/observability.md` when the task touches logs, traces, metrics or request correlation.
 
 If code and documentation disagree, the agent must inspect the code and flag the documentation as stale. It must not silently invent behavior.
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -32,7 +32,9 @@ Express API --> PayPal
 Express API --> Resend
 ```
 
-The backend entrypoint is `server/src/app.ts`. It applies request IDs, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling.
+The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling.
+
+Observability is optional. `OTEL_ENABLED` defaults to off so `npm run dev` does not need a collector. See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
 
 ## Backend layering
 
@@ -84,6 +86,8 @@ Webhook handling:
 4. `confirmPayment` claims the pending order, sells held listings, and writes seller transactions in one PostgreSQL transaction.
 
 A process crash after PayPal capture is recovered by webhook retry (unique event id) or the in-process reconciliation job, which GETs PayPal order status for stale `PENDING` orders (every 60s, minimum age 2 minutes, batch 20) and reuses `confirmPayment`.
+
+Critical workflows emit explicit spans (`orders.create`, `listings.reserve`, `payments.confirm`, `paypal.webhook.*`, `payments.reconcile`) and low-cardinality business counters. Expected 4xx results use `app.outcome` and are not marked span `ERROR`. Prisma calls get `db.prisma` spans without SQL text or parameters. PayPal HTTP uses stable operation names such as `paypal.orders_create`.
 
 ## Testing
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,112 @@
+# Observability
+
+Neon Arsenal Market uses OpenTelemetry for traces and metrics, and Pino for logs. The goal is to diagnose latency, errors and business failures on the checkout path without running an observability platform locally.
+
+## Defaults
+
+Telemetry is **off** unless `OTEL_ENABLED=true`.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OTEL_ENABLED` | unset/false | Start the SDK |
+| `OTEL_EXPORTER` | `none` | `none`, `console`, or `otlp` |
+| `OTEL_SERVICE_NAME` | `neon-arsenal-api` | Resource service name |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | Base OTLP HTTP endpoint |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Overrides the traces URL |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset | Overrides the metrics URL |
+
+`npm run dev` does not need Docker extras, Jaeger, Grafana, Prometheus or a collector. If the chosen exporter is unreachable, request handling continues.
+
+## Correlation
+
+Every request still gets `X-Request-Id` from `requestId` middleware. The same value is stored in `AsyncLocalStorage` and written on the HTTP span as `request.id`.
+
+When a span is active, Pino adds `trace_id` and `span_id`. Correlate:
+
+```text
+X-Request-Id → request.id on http.server.request → child spans → logs
+```
+
+Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second correlation-ID scheme.
+
+## Spans
+
+| Span | Meaning |
+|---|---|
+| `http.server.request` | Inbound HTTP, except `/health` and `/ready` |
+| `orders.create` | Order creation, including idempotency outcomes |
+| `orders.create.transaction` | PostgreSQL transaction that reserves listings and writes the order |
+| `listings.reserve` | Reservation attempt (order path or standalone reserve) |
+| `listings.expire` | Expired-reservation sweep |
+| `payments.confirm` | Payment confirmation |
+| `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
+| `payments.reconcile` | PayPal GET reconciliation batch |
+| `paypal.webhook.verify` | Webhook signature verification |
+| `paypal.webhook.handle` | Event claim, ignore, confirm or fail |
+| `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP |
+| `db.prisma` | Prisma operation (`db.operation` + `db.collection` only) |
+
+`app.outcome` distinguishes expected business results from operational failures:
+
+| Outcome | Typical cause | Span status |
+|---|---|---|
+| `created` / `confirmed` | Success | UNSET |
+| `idempotency_replay` | Same key and listing set | UNSET |
+| `idempotency_conflict` | Same key, different request or in-progress | UNSET |
+| `reservation_conflict` | Listing already held | UNSET |
+| `reservation_expired` | Payment after expiry | UNSET |
+| `webhook_duplicate` / `webhook_ignored` | Duplicate or unsupported event | UNSET |
+| `timeout` / `provider_error` / `error` | PayPal/DB/unexpected | ERROR |
+
+## Metrics
+
+HTTP: `http.server.request.count`, `http.server.request.duration`, `http.server.errors`  
+Attributes: `http.request.method`, `http.route` (normalized Express route, or `unmatched`), `http.response.status_code`
+
+Database: `db.client.operation.duration`, `db.client.errors`  
+Attributes: `db.system=postgresql`, `db.operation`, `db.collection`
+
+PayPal: `paypal.client.request.count`, `paypal.client.errors`, `paypal.client.timeouts`, `paypal.client.request.duration`  
+Attribute: `paypal.operation` (`orders_create`, `orders_get`, `orders_capture`, `oauth_token`)
+
+Business counters (no labels):
+
+- `orders.created`, `orders.creation_failed`, `orders.idempotency_replay`, `orders.idempotency_conflict`
+- `reservations.created`, `reservations.conflict`, `reservations.expired`
+- `payments.confirmed`, `payments.failed`
+- `paypal.webhooks.received`, `paypal.webhooks.duplicate`, `paypal.webhooks.ignored`, `paypal.webhooks.failed`
+
+There is no `orders.pending` gauge. That would scrape PostgreSQL on a timer; query `Order` where `paymentStatus = PENDING` when you need the count.
+
+## Local export
+
+```bash
+# log correlation only (no exporter)
+OTEL_ENABLED=true npm run dev
+
+# print spans/metrics to stdout
+OTEL_ENABLED=true OTEL_EXPORTER=console npm run dev
+
+# optional collector; the API still starts if it is down
+OTEL_ENABLED=true OTEL_EXPORTER=otlp OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 npm run dev
+```
+
+Tests start an in-memory exporter via `startTestTelemetry()`. They do not need `OTEL_ENABLED`.
+
+## Security exclusions
+
+Telemetry must not include:
+
+- passwords
+- JWTs / refresh tokens
+- `Authorization` headers
+- PayPal access tokens
+- webhook signatures (`paypal-transmission-sig`)
+- payment credentials
+- SQL text or bind parameters
+- user / order / listing IDs as metric labels
+- raw URLs or query strings as metric dimensions
+
+`safeAttributes()` drops forbidden keys and bearer/JWT-looking values before they reach a span or metric.
+
+See `docs/adr/0004-opentelemetry.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,13 +57,15 @@ See `docs/testing.md`.
 
 ### P1.2 Observability
 
-Add:
+Implemented:
 
-- structured logs;
-- request/correlation IDs;
-- OpenTelemetry traces;
-- order/payment/webhook/reservation metrics;
-- database and external-provider latency/error metrics.
+- existing Pino logs plus `X-Request-Id`, with `trace_id` / `span_id` when a span is active;
+- optional OpenTelemetry SDK (`OTEL_ENABLED`, exporters `none` / `console` / `otlp`);
+- HTTP, Prisma, PayPal and critical workflow spans;
+- engineering and business counters with low-cardinality attributes;
+- expected business results distinguished from operational errors.
+
+See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
 
 ### P1.3 Resilience
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,3 +102,6 @@ Integration tests are not skipped when PostgreSQL is down. A missing or unreacha
 | `order.idempotency.integration.test.ts` | Replay, canonical listing order, conflicting key reuse, customer isolation, service-level rollback, concurrent same-key retries, reservation race. |
 | `reservation.lifecycle.integration.test.ts` | Reservation timestamps, concurrent buyers, expiration vs payment, no duplicate seller transactions. |
 | `paypal.webhook.integration.test.ts` | Duplicate/out-of-order events, expired capture, stale-order capture, payment rollback. PayPal remains isolated. |
+| `observability.integration.test.ts` | Order/reservation/payment/webhook spans and counters against real PostgreSQL. No secrets or high-cardinality labels. |
+
+OpenTelemetry is disabled for normal development. Telemetry tests start an in-memory exporter with `startTestTelemetry()` and do not require a collector. Unit tests also cover request-ID correlation, HTTP route cardinality, business-vs-operational span status, redaction and the disabled/OTLP-down paths. See `docs/observability.md`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -29,3 +29,12 @@ FRONTEND_URL=http://localhost:5173
 # ─── Reservations ─────────────────────────────────────────────────────────────
 # Checkout hold before a RESERVED listing returns to ACTIVE. Integer minutes.
 RESERVATION_TTL_MINUTES=15
+
+# ─── OpenTelemetry (optional; off by default) ─────────────────────────────────
+# Local `npm run dev` and tests do not need a collector.
+# OTEL_ENABLED=true
+# OTEL_EXPORTER=none
+# OTEL_SERVICE_NAME=neon-arsenal-api
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+# OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:4318/v1/traces
+# OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://127.0.0.1:4318/v1/metrics

--- a/server/README.md
+++ b/server/README.md
@@ -56,6 +56,16 @@ npm run test:integration
 
 A suíte de integração **não é skipped** se o banco estiver ausente — ela falha.
 
+## Observabilidade
+
+OpenTelemetry fica desligado por padrão. `npm run dev` não precisa de collector.
+
+```bash
+OTEL_ENABLED=true OTEL_EXPORTER=console npm run dev
+```
+
+Variáveis: `OTEL_ENABLED`, `OTEL_EXPORTER` (`none` | `console` | `otlp`), `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_*`. Ver `docs/observability.md`.
+
 ## Estrutura
 
 - `src/modules/` — Módulos por domínio (auth, users, sellers, products, orders, payments, commissions, reviews, admin).

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,15 @@
       "name": "neon-arsenal-market-api",
       "version": "1.0.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.11.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.222.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.222.0",
+        "@opentelemetry/resources": "^2.11.0",
+        "@opentelemetry/sdk-metrics": "^2.11.0",
+        "@opentelemetry/sdk-trace-base": "^2.11.0",
+        "@opentelemetry/sdk-trace-node": "^2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
         "@paypal/checkout-server-sdk": "^1.0.3",
         "@prisma/client": "^5.22.0",
         "bcrypt": "^5.1.1",
@@ -67,6 +76,237 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.222.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.222.0.tgz",
+      "integrity": "sha512-9mb1If+IF6u0ZVXkHQ6ogEae5HwA6ajIVUgpSDQyRASxft6BSXHvBvPooRle3yFN/fKnCdSOnuu0OC3PLcF6+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.11.0.tgz",
+      "integrity": "sha512-Tr79DyWI8itsBdg+jH+opjfrwLzX+erk1/ExkIwhWoAVjVrJIn2y5+cGjTC0Vy8fyNIA/y8wuJPZwr1T3xCZeQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.222.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.222.0.tgz",
+      "integrity": "sha512-6Ko+0bgNP6V4G/RsmNBSk5lO1B/lo9z6tvLpFY3ykPPevXNzFmOW3C9hEmTt0zKCvHovyrol3TYlg4HVb5gwjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/otlp-exporter-base": "0.222.0",
+        "@opentelemetry/otlp-transformer": "0.222.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/sdk-metrics": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.222.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.222.0.tgz",
+      "integrity": "sha512-RCnPWcHppwiquQ+cV3nWvNwdf0MG1w26e5jewW2T83nTZOlXgcg88sY9ulCVgagGHcq1mj0L0GP6YHgzk2v8oA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.222.0",
+        "@opentelemetry/otlp-transformer": "0.222.0",
+        "@opentelemetry/sdk-trace": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.222.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.222.0.tgz",
+      "integrity": "sha512-YbywG3veEm2Fb6TbdxRkuquWob6eVWXuA8/Ba1tXz9jHfUqpdE3keilOHEtPboC4CvS1bjeeVfNkWGOOrLj+lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/otlp-transformer": "0.222.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.222.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.222.0.tgz",
+      "integrity": "sha512-/F3BZ89+CJQnZkMh2tCrtcdB+XT2Dxhj4FFE+WPQ//413hmFL0/RfEX6vgOIWGhiSzrkHWTK3+6SiT7K5/g/jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.222.0",
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/sdk-logs": "0.222.0",
+        "@opentelemetry/sdk-metrics": "2.11.0",
+        "@opentelemetry/sdk-trace": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.222.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.222.0.tgz",
+      "integrity": "sha512-+19YHODIjaUCArxleaJtuufFZVpz/xvvK+VllQqE+W8hHolxdoRwHfK/s667zezwh1hkx6FFF+oYzetYgqK+Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.222.0",
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.11.0.tgz",
+      "integrity": "sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.11.0.tgz",
+      "integrity": "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.11.0.tgz",
+      "integrity": "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0",
+        "@opentelemetry/sdk-trace": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.11.0.tgz",
+      "integrity": "sha512-CuvCMJmZxswhNLlM2LfuLOW3h3fZujA4hsG4B+Sz4dX2zvaXO8Ng74cnDHWD64gLszTlhiG3c0iNUjj4g+0/sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.11.0",
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/sdk-trace-base": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@paypal/checkout-server-sdk": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,15 @@
     "seed": "node dist/seed.js"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/core": "^2.11.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.222.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.222.0",
+    "@opentelemetry/resources": "^2.11.0",
+    "@opentelemetry/sdk-metrics": "^2.11.0",
+    "@opentelemetry/sdk-trace-base": "^2.11.0",
+    "@opentelemetry/sdk-trace-node": "^2.11.0",
+    "@opentelemetry/semantic-conventions": "^1.43.0",
     "@paypal/checkout-server-sdk": "^1.0.3",
     "@prisma/client": "^5.22.0",
     "bcrypt": "^5.1.1",

--- a/server/src/__tests__/observability.integration.test.ts
+++ b/server/src/__tests__/observability.integration.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import { SpanStatusCode } from "@opentelemetry/api";
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from "vitest";
+import { prisma } from "../shared/database/index.js";
+import { listingsService } from "../modules/listings/listings.service.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import {
+  collectMetrics,
+  collectSpans,
+  resetTestTelemetry,
+  shutdownTelemetry,
+  spanOutcomes,
+  spansNamed,
+  sumMetric,
+  telemetryContainsSensitive,
+  useTestTelemetry,
+} from "../shared/observability/test.js";
+import { createCheckoutGraph, createOrder, createUser, orderKey } from "./helpers/index.js";
+
+function captureEvent(eventId: string, localOrderId: string) {
+  return {
+    id: eventId,
+    event_type: "PAYMENT.CAPTURE.COMPLETED",
+    resource: {
+      id: `CAPTURE-${eventId}`,
+      purchase_units: [{ reference_id: localOrderId }],
+    },
+  };
+}
+
+function approvedEvent(eventId: string, localOrderId: string) {
+  return {
+    id: eventId,
+    event_type: "CHECKOUT.ORDER.APPROVED",
+    resource: {
+      id: `PAYPAL-${localOrderId}`,
+      purchase_units: [{ reference_id: localOrderId }],
+    },
+  };
+}
+
+describe("critical-flow telemetry (postgres)", () => {
+  beforeAll(async () => {
+    await useTestTelemetry();
+  });
+
+  afterAll(async () => {
+    await shutdownTelemetry();
+  });
+
+  beforeEach(async () => {
+    await resetTestTelemetry();
+  });
+
+  it("records order creation spans and metrics, including database work", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("otel-create"));
+
+    expect(created.id).toBeTruthy();
+    const spans = await collectSpans();
+    expect(spansNamed(spans, "orders.create").length).toBeGreaterThanOrEqual(1);
+    expect(spansNamed(spans, "orders.create.transaction").length).toBeGreaterThanOrEqual(1);
+    expect(spansNamed(spans, "listings.reserve").length).toBeGreaterThanOrEqual(1);
+    expect(spansNamed(spans, "db.prisma").length).toBeGreaterThan(0);
+    expect(spanOutcomes(spans, "orders.create")).toContain("created");
+    expect(spansNamed(spans, "db.prisma")[0]?.attributes["db.system"]).toBe("postgresql");
+    expect(spansNamed(spans, "db.prisma")[0]?.attributes["db.statement"]).toBeUndefined();
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "orders.created")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "reservations.created")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "db.client.operation.duration")).toBeGreaterThan(0);
+    expect(telemetryContainsSensitive(spans, metrics)).toBe(false);
+  });
+
+  it("distinguishes idempotency replay from a conflicting key reuse", async () => {
+    const fixture = await createCheckoutGraph(2);
+    const key = orderKey("otel-replay");
+    const first = await createOrder(fixture.customer.id, [fixture.listings[0].id], key);
+    const replay = await createOrder(fixture.customer.id, [fixture.listings[0].id], key);
+    expect(replay.id).toBe(first.id);
+
+    await expect(createOrder(fixture.customer.id, [fixture.listings[1].id], key)).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    const spans = await collectSpans();
+    expect(spanOutcomes(spans, "orders.create")).toEqual(
+      expect.arrayContaining(["created", "idempotency_replay", "idempotency_conflict"])
+    );
+    const conflict = spansNamed(spans, "orders.create").find(
+      (span) => span.attributes["app.outcome"] === "idempotency_conflict"
+    );
+    expect(conflict?.status.code).toBe(SpanStatusCode.UNSET);
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "orders.idempotency_replay")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "orders.idempotency_conflict")).toBeGreaterThanOrEqual(1);
+    const listing = await prisma.listing.findUnique({ where: { id: fixture.listings[1].id } });
+    expect(listing?.status).toBe("ACTIVE");
+  });
+
+  it("records reservation success, conflict and expiration as distinct outcomes", async () => {
+    const fixture = await createCheckoutGraph();
+    const listingId = fixture.listings[0].id;
+    const otherBuyer = await createUser({ name: "Otel Buyer 2" });
+
+    const results = await Promise.allSettled([
+      createOrder(fixture.customer.id, [listingId], orderKey("otel-reserve-a")),
+      createOrder(otherBuyer.id, [listingId], orderKey("otel-reserve-b")),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+
+    const reserved = await prisma.listing.findUnique({ where: { id: listingId } });
+    await prisma.listing.update({
+      where: { id: listingId },
+      data: { reservationExpiresAt: new Date(Date.now() - 1000) },
+    });
+    const expired = await listingsService.expireReservations();
+    expect(expired.expiredListingCount).toBeGreaterThanOrEqual(1);
+
+    const spans = await collectSpans();
+    expect(spanOutcomes(spans, "orders.create")).toEqual(
+      expect.arrayContaining(["created", "reservation_conflict"])
+    );
+    expect(spansNamed(spans, "listings.expire").length).toBeGreaterThanOrEqual(1);
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "reservations.created")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "reservations.conflict")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "reservations.expired")).toBeGreaterThanOrEqual(1);
+    expect(reserved?.status).toBe("RESERVED");
+  });
+
+  it("records payment confirmation, failure and duplicate webhook outcomes", async () => {
+    const fixture = await createCheckoutGraph();
+    const order = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("otel-pay"));
+    const eventId = `WH-${randomUUID()}`;
+
+    await paymentsService.handleWebhook(approvedEvent(`WH-approved-${randomUUID()}`, order.id));
+    await paymentsService.handleWebhook(captureEvent(eventId, order.id));
+    await paymentsService.handleWebhook(captureEvent(eventId, order.id));
+
+    const paid = await prisma.order.findUnique({ where: { id: order.id } });
+    expect(paid?.paymentStatus).toBe("PAID");
+
+    const expiredFixture = await createCheckoutGraph();
+    const expiredOrder = await createOrder(
+      expiredFixture.customer.id,
+      [expiredFixture.listings[0].id],
+      orderKey("otel-pay-fail")
+    );
+    await prisma.listing.update({
+      where: { id: expiredFixture.listings[0].id },
+      data: { reservationExpiresAt: new Date(Date.now() - 1000) },
+    });
+    await paymentsService.handleWebhook(
+      captureEvent(`WH-expired-${randomUUID()}`, expiredOrder.id)
+    );
+
+    const spans = await collectSpans();
+    expect(spansNamed(spans, "paypal.webhook.handle").length).toBeGreaterThanOrEqual(3);
+    expect(spansNamed(spans, "payments.confirm").length).toBeGreaterThanOrEqual(1);
+    expect(spansNamed(spans, "payments.confirm.transaction").length).toBeGreaterThanOrEqual(1);
+    expect(spanOutcomes(spans, "paypal.webhook.handle")).toEqual(
+      expect.arrayContaining(["webhook_ignored", "confirmed", "webhook_duplicate", "reservation_expired"])
+    );
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "payments.confirmed")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "payments.failed")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "paypal.webhooks.received")).toBeGreaterThanOrEqual(4);
+    expect(sumMetric(metrics, "paypal.webhooks.duplicate")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "paypal.webhooks.ignored")).toBeGreaterThanOrEqual(1);
+    expect(sumMetric(metrics, "paypal.webhooks.failed")).toBeGreaterThanOrEqual(1);
+    expect(telemetryContainsSensitive(spans, metrics)).toBe(false);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import { errorHandler } from "./shared/errors/index.js";
 import { notFound, requestId } from "./shared/middlewares/index.js";
+import { httpTelemetry } from "./shared/observability/http.js";
 import { apiLimiter, authLimiter } from "./shared/middlewares/rateLimit.js";
 import { healthRoutes } from "./shared/routes/health.routes.js";
 import { docsRoutes } from "./shared/routes/docs.routes.js";
@@ -20,6 +21,7 @@ import { adminRoutes } from "./modules/admin/admin.routes.js";
 const app = express();
 
 app.use(requestId);
+app.use(httpTelemetry);
 
 // ─── CORS ────────────────────────────────────────────────────────────────────
 // Restrict to the configured frontend origin (defaults to localhost:5173 for dev)
@@ -43,7 +45,14 @@ app.use(
     },
     credentials: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization", "X-Request-Id", "Idempotency-Key"],
+    allowedHeaders: [
+      "Content-Type",
+      "Authorization",
+      "X-Request-Id",
+      "Idempotency-Key",
+      "traceparent",
+      "tracestate",
+    ],
   })
 );
 app.use(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,10 @@
-import { app } from "./app.js";
-import { startReservationExpiryJob } from "./shared/jobs/reservationExpiryJob.js";
-import { startPaypalReconciliationJob } from "./shared/jobs/paypalReconciliationJob.js";
+import { startTelemetry } from "./shared/observability/sdk.js";
+
+await startTelemetry();
+
+const { app } = await import("./app.js");
+const { startReservationExpiryJob } = await import("./shared/jobs/reservationExpiryJob.js");
+const { startPaypalReconciliationJob } = await import("./shared/jobs/paypalReconciliationJob.js");
 
 const PORT = process.env.PORT ?? 3001;
 

--- a/server/src/modules/listings/listings.service.ts
+++ b/server/src/modules/listings/listings.service.ts
@@ -10,6 +10,9 @@ import type {
   UpdateListingPriceInput,
   ListListingsQuery,
 } from "./listings.dto.js";
+import { appMetrics } from "../../shared/observability/metrics.js";
+import { markSpanOutcome } from "../../shared/observability/outcomes.js";
+import { withSpan } from "../../shared/observability/tracing.js";
 
 const VALID_STATUS_TRANSITIONS: Record<string, string[]> = {
   ACTIVE: ["RESERVED", "CANCELED"],
@@ -166,6 +169,7 @@ export const listingsService = {
   },
 
   async reserve(listingId: string) {
+    return withSpan("listings.reserve", {}, async (span) => {
     const now = new Date();
     const reservation = buildReservationWindow(now);
     const reserved = await prisma.listing.updateMany({
@@ -182,6 +186,7 @@ export const listingsService = {
     });
 
     if (reserved.count !== 1) {
+      appMetrics.reservationsConflict();
       const listing = await listingsRepository.findById(listingId);
       if (!listing) throw new AppError(404, "Listing not found");
       if (listing.tradeLockUntil && new Date(listing.tradeLockUntil) > now) {
@@ -192,7 +197,10 @@ export const listingsService = {
 
     const listing = await listingsRepository.findById(listingId);
     if (!listing) throw new AppError(404, "Listing not found");
+    markSpanOutcome(span, "created");
+    appMetrics.reservationsCreated();
     return listing;
+    });
   },
 
   async markAsSold(listingId: string) {
@@ -230,6 +238,7 @@ export const listingsService = {
    * orders) cannot deadlock against payment confirmation.
    */
   async expireReservations(now = new Date()) {
+    return withSpan("listings.expire", {}, async (span) => {
     const expiredListings = await prisma.listing.updateMany({
       where: {
         status: "RESERVED",
@@ -259,10 +268,15 @@ export const listingsService = {
         )
     `;
 
+    if (expiredListings.count > 0) {
+      appMetrics.reservationsExpired(expiredListings.count);
+    }
+    span.setAttribute("app.expired_listing_count", expiredListings.count);
     return {
       expiredListingCount: expiredListings.count,
       cancelledOrderCount: Number(cancelledOrders),
     };
+    });
   },
 
   async cancel(listingId: string, userId: string, role: string) {

--- a/server/src/modules/orders/orders.service.ts
+++ b/server/src/modules/orders/orders.service.ts
@@ -5,20 +5,29 @@ import { AppError } from "../../shared/errors/AppError.js";
 import { buildReservationWindow } from "../../shared/config/reservation.js";
 import type { CreateOrderInput, UpdateOrderTrackingInput } from "./orders.dto.js";
 import { Prisma } from "@prisma/client";
+import { appMetrics } from "../../shared/observability/metrics.js";
+import { markSpanOutcome } from "../../shared/observability/outcomes.js";
+import { withSpan } from "../../shared/observability/tracing.js";
 
 const IDEMPOTENCY_KEY_MAX_LENGTH = 128;
 
 export const ordersService = {
   async create(customerId: string, input: CreateOrderInput, idempotencyKey: string) {
+    return withSpan(
+      "orders.create",
+      { attributes: { "app.listing_count": input.items.length } },
+      async (span) => {
     const normalizedIdempotencyKey = normalizeIdempotencyKey(idempotencyKey);
     const listingIds = input.items.map((i) => i.listingId);
     if (new Set(listingIds).size !== listingIds.length) {
+      appMetrics.ordersCreationFailed();
       throw new AppError(400, "A listing can only appear once in an order");
     }
     const requestHash = createOrderRequestHash(input);
 
     try {
-      const result = await prisma.$transaction(async (tx) => {
+      const result = await withSpan("orders.create.transaction", {}, async () =>
+        prisma.$transaction(async (tx) => {
         await tx.orderIdempotencyKey.create({
           data: {
             customerId,
@@ -45,6 +54,10 @@ export const ordersService = {
           },
         });
 
+        await withSpan(
+          "listings.reserve",
+          { attributes: { "app.listing_count": listingIds.length } },
+          async () => {
         for (const listingId of listingIds) {
           // The status transition is conditional, so two concurrent orders cannot
           // both reserve the same listing. PostgreSQL performs this atomically.
@@ -94,6 +107,8 @@ export const ordersService = {
             priceSnapshot: listing.price,
           });
         }
+          }
+        );
 
         await tx.order.update({
           where: { id: order.id },
@@ -123,12 +138,22 @@ export const ordersService = {
         });
 
         return { ...order, totalAmount };
-      });
+      })
+      );
 
       const order = await ordersRepository.findById(result.id);
+      markSpanOutcome(span, "created");
+      appMetrics.ordersCreated();
+      appMetrics.reservationsCreated(listingIds.length);
       return { ...order!, totalAmount: result.totalAmount };
     } catch (err) {
-      if (!isIdempotencyKeyUniqueConstraintError(err)) throw err;
+      if (!isIdempotencyKeyUniqueConstraintError(err)) {
+        if (err instanceof AppError && /not available|not ACTIVE|trade locked/i.test(err.message)) {
+          appMetrics.reservationsConflict();
+        }
+        appMetrics.ordersCreationFailed();
+        throw err;
+      }
 
       const existing = await prisma.orderIdempotencyKey.findUnique({
         where: {
@@ -139,20 +164,33 @@ export const ordersService = {
         },
       });
 
-      if (!existing) throw err;
+      if (!existing) {
+        appMetrics.ordersCreationFailed();
+        throw err;
+      }
       if (existing.requestHash !== requestHash) {
+        markSpanOutcome(span, "idempotency_conflict");
+        appMetrics.ordersIdempotencyConflict();
         throw new AppError(409, "Idempotency key was already used with a different order request");
       }
       if (existing.status !== "COMPLETED" || !existing.orderId) {
+        markSpanOutcome(span, "idempotency_conflict");
+        appMetrics.ordersIdempotencyConflict();
         throw new AppError(409, "Order creation is still in progress for this idempotency key");
       }
 
       const order = await ordersRepository.findById(existing.orderId);
       if (!order) {
+        markSpanOutcome(span, "idempotency_conflict");
+        appMetrics.ordersIdempotencyConflict();
         throw new AppError(409, "Idempotency key references an order that no longer exists");
       }
+      markSpanOutcome(span, "idempotency_replay");
+      appMetrics.ordersIdempotencyReplay();
       return order;
     }
+      }
+    );
   },
 
   async getById(orderId: string, userId: string, role: string) {

--- a/server/src/modules/payments/__tests__/payments.webhook.telemetry.test.ts
+++ b/server/src/modules/payments/__tests__/payments.webhook.telemetry.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+
+vi.mock("../payments.service.js", () => ({
+  paymentsService: {
+    handleWebhook: vi.fn(),
+    createPaymentLink: vi.fn(),
+  },
+}));
+
+vi.mock("../../../shared/utils/paypalWebhook.js", () => ({
+  verifyPayPalWebhookSignature: vi.fn(),
+}));
+
+import { paymentsController } from "../payments.controller.js";
+import { paymentsService } from "../payments.service.js";
+import { verifyPayPalWebhookSignature } from "../../../shared/utils/paypalWebhook.js";
+import {
+  collectMetrics,
+  collectSpans,
+  resetTestTelemetry,
+  shutdownTelemetry,
+  spanOutcomes,
+  spansNamed,
+  sumMetric,
+  useTestTelemetry,
+} from "../../../shared/observability/test.js";
+
+function mockRes() {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+  };
+  return res as unknown as Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> };
+}
+
+describe("paymentsController webhook telemetry", () => {
+  beforeAll(async () => {
+    await useTestTelemetry();
+  });
+
+  afterAll(async () => {
+    await shutdownTelemetry();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await resetTestTelemetry();
+  });
+
+  it("records signature rejection without storing the webhook signature", async () => {
+    vi.mocked(verifyPayPalWebhookSignature).mockResolvedValue(false);
+    const req = {
+      rawBody: Buffer.from("{}"),
+      headers: { "paypal-transmission-sig": "super-secret-signature" },
+      body: { id: "WH-1" },
+      requestId: "r-webhook",
+    } as unknown as Request;
+    const res = mockRes();
+
+    await paymentsController.webhook(req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(paymentsService.handleWebhook).not.toHaveBeenCalled();
+
+    const spans = await collectSpans();
+    const verify = spansNamed(spans, "paypal.webhook.verify")[0];
+    expect(spanOutcomes(spans, "paypal.webhook.verify")).toEqual(["webhook_failed"]);
+    expect(verify?.attributes["paypal-transmission-sig"]).toBeUndefined();
+    expect(JSON.stringify(verify?.attributes ?? {})).not.toContain("super-secret-signature");
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "paypal.webhooks.received")).toBe(1);
+    expect(sumMetric(metrics, "paypal.webhooks.failed")).toBe(1);
+  });
+});

--- a/server/src/modules/payments/payments.controller.ts
+++ b/server/src/modules/payments/payments.controller.ts
@@ -2,6 +2,9 @@ import { Request, Response, NextFunction } from "express";
 import { paymentsService } from "./payments.service.js";
 import { getAuthUser } from "../../shared/helpers/getAuthUser.js";
 import { logger } from "../../shared/logger.js";
+import { appMetrics } from "../../shared/observability/metrics.js";
+import { markSpanOutcome } from "../../shared/observability/outcomes.js";
+import { withSpan } from "../../shared/observability/tracing.js";
 import { verifyPayPalWebhookSignature } from "../../shared/utils/paypalWebhook.js";
 
 export const paymentsController = {
@@ -17,26 +20,40 @@ export const paymentsController = {
 
   async webhook(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const rawBody = req.rawBody;
-      if (!rawBody) {
-        logger.warn({ requestId: req.requestId }, "paypal webhook missing raw body");
-        res.status(401).json({ error: "Invalid webhook signature" });
-        return;
-      }
+      const accepted = await withSpan("paypal.webhook.verify", {}, async (span) => {
+        const rawBody = req.rawBody;
+        if (!rawBody) {
+          logger.warn({ requestId: req.requestId }, "paypal webhook missing raw body");
+          markSpanOutcome(span, "webhook_failed");
+          appMetrics.webhooksReceived();
+          appMetrics.webhooksFailed();
+          return false;
+        }
 
-      const verified = await verifyPayPalWebhookSignature({
-        rawBody,
-        headers: {
-          "paypal-transmission-id": headerValue(req.headers["paypal-transmission-id"]),
-          "paypal-transmission-time": headerValue(req.headers["paypal-transmission-time"]),
-          "paypal-transmission-sig": headerValue(req.headers["paypal-transmission-sig"]),
-          "paypal-cert-url": headerValue(req.headers["paypal-cert-url"]),
-          "paypal-auth-algo": headerValue(req.headers["paypal-auth-algo"]),
-        },
+        const verified = await verifyPayPalWebhookSignature({
+          rawBody,
+          headers: {
+            "paypal-transmission-id": headerValue(req.headers["paypal-transmission-id"]),
+            "paypal-transmission-time": headerValue(req.headers["paypal-transmission-time"]),
+            "paypal-transmission-sig": headerValue(req.headers["paypal-transmission-sig"]),
+            "paypal-cert-url": headerValue(req.headers["paypal-cert-url"]),
+            "paypal-auth-algo": headerValue(req.headers["paypal-auth-algo"]),
+          },
+        });
+
+        if (!verified) {
+          logger.warn({ requestId: req.requestId }, "paypal webhook signature rejected");
+          markSpanOutcome(span, "webhook_failed");
+          appMetrics.webhooksReceived();
+          appMetrics.webhooksFailed();
+          return false;
+        }
+
+        markSpanOutcome(span, "confirmed");
+        return true;
       });
 
-      if (!verified) {
-        logger.warn({ requestId: req.requestId }, "paypal webhook signature rejected");
+      if (!accepted) {
         res.status(401).json({ error: "Invalid webhook signature" });
         return;
       }

--- a/server/src/modules/payments/payments.service.ts
+++ b/server/src/modules/payments/payments.service.ts
@@ -17,6 +17,9 @@ import {
 } from "../../shared/config/paypal.js";
 import { Prisma } from "@prisma/client";
 import type { CreatePaymentInput } from "./payments.dto.js";
+import { appMetrics } from "../../shared/observability/metrics.js";
+import { markSpanOutcome } from "../../shared/observability/outcomes.js";
+import { withSpan } from "../../shared/observability/tracing.js";
 
 const WEBHOOK_PROVIDER = "PAYPAL";
 
@@ -51,12 +54,21 @@ export const paymentsService = {
   },
 
   async handleWebhook(body: unknown) {
+    return withSpan(
+      "paypal.webhook.handle",
+      { attributes: { "paypal.event_type": "unknown" } },
+      async (span) => {
     const parsed = parsePayPalWebhookEvent(body);
     if (!parsed) {
       logger.warn("paypal webhook missing event id or type");
+      markSpanOutcome(span, "webhook_failed");
+      appMetrics.webhooksReceived();
+      appMetrics.webhooksFailed();
       return;
     }
 
+    span.setAttribute("paypal.event_type", parsed.eventType);
+    appMetrics.webhooksReceived();
     logger.info(
       { eventId: parsed.eventId, eventType: parsed.eventType },
       "paypal webhook received"
@@ -64,6 +76,8 @@ export const paymentsService = {
 
     const claim = await claimWebhookEvent(parsed.eventId, parsed.eventType);
     if (claim === "duplicate") {
+      markSpanOutcome(span, "webhook_duplicate");
+      appMetrics.webhooksDuplicate();
       logger.info(
         { eventId: parsed.eventId, eventType: parsed.eventType },
         "paypal webhook duplicate ignored"
@@ -87,6 +101,7 @@ export const paymentsService = {
         }
         await this.confirmPayment(orderId);
         await markWebhookEvent(parsed.eventId, { status: "PROCESSED", orderId });
+        markSpanOutcome(span, "confirmed");
         logger.info(
           { eventId: parsed.eventId, eventType: parsed.eventType, orderId },
           "paypal capture webhook processed"
@@ -101,6 +116,8 @@ export const paymentsService = {
           orderId,
           failureReason: "intermediate_event",
         });
+        markSpanOutcome(span, "webhook_ignored");
+        appMetrics.webhooksIgnored();
         logger.info(
           { eventId: parsed.eventId, eventType: parsed.eventType, orderId },
           "paypal approved webhook stored without capture confirmation"
@@ -112,6 +129,8 @@ export const paymentsService = {
         status: "IGNORED",
         failureReason: "unhandled_event_type",
       });
+      markSpanOutcome(span, "webhook_ignored");
+      appMetrics.webhooksIgnored();
       logger.info(
         { eventId: parsed.eventId, eventType: parsed.eventType },
         "paypal webhook ignored: event type not applied locally"
@@ -122,6 +141,8 @@ export const paymentsService = {
           status: "FAILED",
           failureReason: "reservation_expired",
         });
+        markSpanOutcome(span, "reservation_expired");
+        appMetrics.webhooksFailed();
         logger.warn(
           { eventId: parsed.eventId, eventType: parsed.eventType },
           "paypal webhook not applied: reservation expired"
@@ -129,18 +150,26 @@ export const paymentsService = {
         return;
       }
       if (err instanceof AppError && err.statusCode === 503) {
+        appMetrics.webhooksFailed();
         throw err;
       }
       await markWebhookEvent(parsed.eventId, {
         status: "FAILED",
         failureReason: "processing_error",
       });
+      appMetrics.webhooksFailed();
       throw err;
     }
+      }
+    );
   },
 
   async confirmPayment(orderId: string) {
-    await prisma.$transaction(async (tx) => {
+    return withSpan("payments.confirm", {}, async (span) => {
+    let claimedCount = 0;
+    try {
+    await withSpan("payments.confirm.transaction", {}, async () =>
+    prisma.$transaction(async (tx) => {
       // Claim unpaid pending orders only. Duplicate webhooks and cancelled
       // expired orders see count = 0 and do not issue another seller payout.
       const claimed = await tx.order.updateMany({
@@ -152,6 +181,7 @@ export const paymentsService = {
         data: { paymentStatus: "PAID", status: "CONFIRMED" },
       });
 
+      claimedCount = claimed.count;
       if (claimed.count === 0) return;
 
       const order = await tx.order.findUnique({
@@ -220,10 +250,23 @@ export const paymentsService = {
           data: { balance: { increment: netAmount } },
         });
       }
+    })
+    );
+      if (claimedCount === 0) {
+        markSpanOutcome(span, "already_confirmed");
+        return;
+      }
+      markSpanOutcome(span, "confirmed");
+      appMetrics.paymentsConfirmed();
+    } catch (err) {
+      appMetrics.paymentsFailed();
+      throw err;
+    }
     });
   },
 
   async reconcilePendingPaypalOrders() {
+    return withSpan("payments.reconcile", {}, async (span) => {
     const cutoff = new Date(Date.now() - PAYPAL_RECONCILE_MIN_AGE_MS);
     const pending = await prisma.order.findMany({
       where: {
@@ -254,7 +297,10 @@ export const paymentsService = {
         logger.warn({ err, orderId: order.id }, "paypal reconciliation lookup failed");
       }
     }
+    span.setAttribute("app.reconcile_scanned", pending.length);
+    span.setAttribute("app.reconcile_confirmed", confirmed);
     return { scanned: pending.length, confirmed };
+    });
   },
 };
 

--- a/server/src/shared/database/prisma.ts
+++ b/server/src/shared/database/prisma.ts
@@ -1,13 +1,16 @@
 import { PrismaClient } from "@prisma/client";
+import { withPrismaObservability } from "../observability/prisma.js";
 
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+const globalForPrisma = globalThis as unknown as { prismaBase?: PrismaClient };
 
-export const prisma =
-  globalForPrisma.prisma ??
+const baseClient =
+  globalForPrisma.prismaBase ??
   new PrismaClient({
     log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
   });
 
 if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
+  globalForPrisma.prismaBase = baseClient;
 }
+
+export const prisma = withPrismaObservability(baseClient);

--- a/server/src/shared/errors/errorHandler.ts
+++ b/server/src/shared/errors/errorHandler.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { Prisma } from "@prisma/client";
 import { AppError } from "./AppError.js";
 import { logger } from "../logger.js";
+import { getLogBindings } from "../observability/context.js";
 
 export function errorHandler(
   err: unknown,
@@ -9,11 +10,12 @@ export function errorHandler(
   res: Response,
   _next: NextFunction
 ): void {
-  const requestId = req.requestId;
+  const bindings = getLogBindings();
+  const requestId = req.requestId ?? bindings.requestId;
 
   if (err instanceof AppError) {
     if (err.statusCode >= 500) {
-      logger.error({ err, requestId }, err.message);
+      logger.error({ err, ...bindings, requestId }, err.message);
     }
     res.status(err.statusCode).json({ error: err.message });
     return;
@@ -30,6 +32,6 @@ export function errorHandler(
     }
   }
 
-  logger.error({ err, requestId }, "Unhandled error");
+  logger.error({ err, ...bindings, requestId }, "Unhandled error");
   res.status(500).json({ error: "Internal server error." });
 }

--- a/server/src/shared/logger.ts
+++ b/server/src/shared/logger.ts
@@ -1,9 +1,13 @@
 import pino from "pino";
+import { getLogBindings } from "./observability/context.js";
 
 const isDev = process.env.NODE_ENV !== "production";
 
 export const logger = pino({
   level: process.env.LOG_LEVEL ?? (isDev ? "debug" : "info"),
+  mixin() {
+    return getLogBindings();
+  },
   ...(isDev && {
     transport: {
       target: "pino-pretty",

--- a/server/src/shared/middlewares/requestId.ts
+++ b/server/src/shared/middlewares/requestId.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { randomUUID } from "crypto";
+import { runWithRequestId } from "../observability/context.js";
 
 declare global {
   // Express module augmentation (Request.requestId / rawBody)
@@ -12,7 +13,8 @@ declare global {
   }
 }
 
-export function requestId(req: Request, _res: Response, next: NextFunction): void {
+export function requestId(req: Request, res: Response, next: NextFunction): void {
   req.requestId = (req.headers["x-request-id"] as string) || randomUUID();
-  next();
+  res.setHeader("X-Request-Id", req.requestId);
+  runWithRequestId(req.requestId, () => next());
 }

--- a/server/src/shared/observability/__tests__/config.test.ts
+++ b/server/src/shared/observability/__tests__/config.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readTelemetryConfig } from "../config.js";
+
+describe("readTelemetryConfig", () => {
+  const keys = [
+    "OTEL_ENABLED",
+    "OTEL_EXPORTER",
+    "OTEL_SERVICE_NAME",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+  ] as const;
+  const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+
+  afterEach(() => {
+    for (const key of keys) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+  });
+
+  it("is disabled by default and does not select an exporter", () => {
+    for (const key of keys) delete process.env[key];
+    expect(readTelemetryConfig()).toMatchObject({
+      enabled: false,
+      exporter: "none",
+      serviceName: "neon-arsenal-api",
+    });
+  });
+
+  it("accepts only known exporters", () => {
+    process.env.OTEL_ENABLED = "true";
+    process.env.OTEL_EXPORTER = "console";
+    expect(readTelemetryConfig().exporter).toBe("console");
+    process.env.OTEL_EXPORTER = "otlp";
+    expect(readTelemetryConfig().exporter).toBe("otlp");
+    process.env.OTEL_EXPORTER = "jaeger";
+    expect(readTelemetryConfig().exporter).toBe("none");
+  });
+});

--- a/server/src/shared/observability/__tests__/disable.test.ts
+++ b/server/src/shared/observability/__tests__/disable.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { startTelemetry, shutdownTelemetry } from "../sdk.js";
+import { collectSpans } from "../test.js";
+import { withSpan } from "../tracing.js";
+
+describe("telemetry disable and exporter isolation", () => {
+  afterAll(async () => {
+    await shutdownTelemetry();
+    delete process.env.OTEL_ENABLED;
+    delete process.env.OTEL_EXPORTER;
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  });
+
+  it("does not require an exporter and stays no-op when disabled", async () => {
+    delete process.env.OTEL_ENABLED;
+    delete process.env.OTEL_EXPORTER;
+    await shutdownTelemetry();
+    const started = await startTelemetry();
+    expect(started).toBeUndefined();
+
+    await expect(
+      withSpan("orders.create", {}, async () => {
+        return { ok: true };
+      })
+    ).resolves.toEqual({ ok: true });
+    expect(await collectSpans()).toEqual([]);
+  });
+
+  it("does not crash when an OTLP exporter URL is unreachable", async () => {
+    process.env.OTEL_ENABLED = "true";
+    process.env.OTEL_EXPORTER = "otlp";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:1/v1/traces";
+    await shutdownTelemetry();
+    const started = await startTelemetry();
+    expect(started).toBeDefined();
+    await expect(withSpan("orders.create", {}, async () => "ok")).resolves.toBe("ok");
+    await shutdownTelemetry();
+  });
+});

--- a/server/src/shared/observability/__tests__/outcomes.test.ts
+++ b/server/src/shared/observability/__tests__/outcomes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "../../errors/AppError.js";
+import { classifyThrownError, isBusinessError } from "../outcomes.js";
+
+describe("telemetry error semantics", () => {
+  it("treats expected 4xx AppErrors as business outcomes", () => {
+    expect(classifyThrownError(new AppError(409, "Idempotency key was already used"))).toBe(
+      "idempotency_conflict"
+    );
+    expect(classifyThrownError(new AppError(400, "Listing x is not available (status: RESERVED)"))).toBe(
+      "reservation_conflict"
+    );
+    expect(classifyThrownError(new AppError(409, "Reservation expired or listing is no longer reserved"))).toBe(
+      "reservation_expired"
+    );
+    expect(isBusinessError(new AppError(409, "Idempotency key was already used"))).toBe(true);
+  });
+
+  it("treats timeouts, provider failures and unexpected errors as operational", () => {
+    expect(classifyThrownError(new AppError(504, "PayPal OrdersCreate timed out"))).toBe("timeout");
+    expect(classifyThrownError(new AppError(502, "PayPal OrdersGet failed: 500"))).toBe("provider_error");
+    expect(classifyThrownError(new Error("ECONNREFUSED"))).toBe("error");
+    expect(isBusinessError(new AppError(502, "PayPal OrdersGet failed: 500"))).toBe(false);
+  });
+});

--- a/server/src/shared/observability/__tests__/redact.test.ts
+++ b/server/src/shared/observability/__tests__/redact.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { containsSensitiveTelemetry, safeAttributes } from "../redact.js";
+
+describe("telemetry redaction", () => {
+  it("drops secret keys and bearer/jwt values", () => {
+    const attributes = safeAttributes({
+      password: "hunter2",
+      authorization: "Bearer abc.def",
+      "paypal-transmission-sig": "sig-value",
+      access_token: "paypal-token",
+      jwt: "eyJhbGciOiJIUzI1NiJ9.e30.sig",
+      "http.request.method": "POST",
+      note: "Bearer eyJhbGciOiJIUzI1NiJ9.e30.sig",
+    });
+
+    expect(attributes).toEqual({ "http.request.method": "POST" });
+  });
+
+  it("detects sensitive objects used in tests", () => {
+    expect(containsSensitiveTelemetry({ authorization: "Bearer token" })).toBe(true);
+    expect(containsSensitiveTelemetry({ "http.route": "/orders" })).toBe(false);
+  });
+});

--- a/server/src/shared/observability/__tests__/telemetry.test.ts
+++ b/server/src/shared/observability/__tests__/telemetry.test.ts
@@ -1,0 +1,219 @@
+import { createServer } from "node:http";
+import { SpanStatusCode } from "@opentelemetry/api";
+import express from "express";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AppError } from "../../errors/AppError.js";
+import { errorHandler } from "../../errors/errorHandler.js";
+import { requestId } from "../../middlewares/requestId.js";
+import { getLogBindings, getRequestId } from "../context.js";
+import { httpTelemetry } from "../http.js";
+import { appMetrics } from "../metrics.js";
+import { withPaypalOperation } from "../paypal.js";
+import {
+  collectMetrics,
+  collectSpans,
+  metricAttributeKeys,
+  resetTestTelemetry,
+  shutdownTelemetry,
+  spansNamed,
+  sumMetric,
+  telemetryContainsSensitive,
+  useTestTelemetry,
+} from "../test.js";
+import { withSpan } from "../tracing.js";
+
+describe("OpenTelemetry runtime", () => {
+  let server: ReturnType<typeof createServer>;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    await useTestTelemetry();
+    const app = express();
+    app.use(requestId);
+    app.use(httpTelemetry);
+    app.get("/health", (_req, res) => {
+      res.json({ status: "ok" });
+    });
+    app.get("/orders/:id", (req, res) => {
+      const bindings = getLogBindings();
+      res.json({
+        requestId: req.requestId,
+        alsRequestId: getRequestId(),
+        trace_id: bindings.trace_id,
+        span_id: bindings.span_id,
+      });
+    });
+    app.get("/boom", () => {
+      throw new Error("unexpected boom");
+    });
+    app.use((_req, res) => {
+      res.status(404).json({ error: "not found" });
+    });
+    app.use(errorHandler);
+
+    await new Promise<void>((resolve) => {
+      server = createServer(app);
+      server.listen(0, () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await shutdownTelemetry();
+  });
+
+  beforeEach(async () => {
+    await resetTestTelemetry();
+  });
+
+  it("preserves the existing request ID and correlates it with the server span", async () => {
+    const res = await fetch(`${baseUrl}/orders/abc`, {
+      headers: { "x-request-id": "req-correlation-1" },
+    });
+    const body = (await res.json()) as {
+      requestId?: string;
+      alsRequestId?: string;
+      trace_id?: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-request-id")).toBe("req-correlation-1");
+    expect(body.requestId).toBe("req-correlation-1");
+    expect(body.alsRequestId).toBe("req-correlation-1");
+    expect(body.trace_id).toMatch(/^[0-9a-f]{32}$/);
+
+    const spans = await collectSpans();
+    const serverSpans = spansNamed(spans, "http.server.request");
+    expect(serverSpans).toHaveLength(1);
+    expect(serverSpans[0]?.attributes["request.id"]).toBe("req-correlation-1");
+    expect(serverSpans[0]?.attributes["http.route"]).toBe("/orders/:id");
+    expect(serverSpans[0]?.attributes["http.request.method"]).toBe("GET");
+    expect(serverSpans[0]?.spanContext().traceId).toBe(body.trace_id);
+  });
+
+  it("records low-cardinality HTTP metrics and skips /health", async () => {
+    await fetch(`${baseUrl}/health`);
+    await fetch(`${baseUrl}/orders/xyz`);
+    await fetch(`${baseUrl}/missing-path`);
+
+    const spans = await collectSpans();
+    expect(spansNamed(spans, "http.server.request").map((span) => span.attributes["http.route"])).toEqual(
+      expect.arrayContaining(["/orders/:id", "unmatched"])
+    );
+    expect(spans.some((span) => span.attributes["url.path"] === "/health")).toBe(false);
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "http.server.request.count")).toBeGreaterThanOrEqual(2);
+    expect(metricAttributeKeys(metrics, "http.server.request.count")).toEqual(
+      new Set(["http.request.method", "http.route", "http.response.status_code"])
+    );
+    const routes = metrics
+      .find((metric) => metric.descriptor.name === "http.server.request.count")
+      ?.dataPoints.map((point) => point.attributes["http.route"]);
+    expect(routes).toEqual(expect.arrayContaining(["/orders/:id", "unmatched"]));
+    expect(routes?.some((route) => route === "/orders/xyz" || route === "/missing-path")).toBe(false);
+  });
+
+  it("marks unexpected HTTP 5xx as errors without leaking the exception payload into attributes", async () => {
+    const res = await fetch(`${baseUrl}/boom`);
+    expect(res.status).toBe(500);
+
+    const spans = await collectSpans();
+    const serverSpan = spansNamed(spans, "http.server.request")[0];
+    expect(serverSpan?.status.code).toBe(SpanStatusCode.ERROR);
+    expect(serverSpan?.attributes["http.response.status_code"]).toBe(500);
+    expect(JSON.stringify(serverSpan?.attributes)).not.toMatch(/unexpected boom/);
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "http.server.errors")).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not mark expected business errors as span ERROR", async () => {
+    await expect(
+      withSpan("orders.create", {}, async () => {
+        throw new AppError(409, "Idempotency key was already used with a different order request");
+      })
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    const spans = await collectSpans();
+    const span = spansNamed(spans, "orders.create")[0];
+    expect(span?.attributes["app.outcome"]).toBe("idempotency_conflict");
+    expect(span?.status.code).toBe(SpanStatusCode.UNSET);
+  });
+
+  it("marks operational failures as ERROR and records PayPal timeout metrics", async () => {
+    await expect(
+      withPaypalOperation("orders_create", async () => {
+        throw new AppError(504, "PayPal OrdersCreate timed out");
+      })
+    ).rejects.toMatchObject({ statusCode: 504 });
+
+    const spans = await collectSpans();
+    const span = spansNamed(spans, "paypal.orders_create")[0];
+    expect(span?.attributes["paypal.operation"]).toBe("orders_create");
+    expect(span?.attributes["app.outcome"]).toBe("timeout");
+    expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span?.name).not.toContain("PAYPAL-");
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "paypal.client.timeouts")).toBe(1);
+    expect(metricAttributeKeys(metrics, "paypal.client.request.count")).toEqual(
+      new Set(["paypal.operation"])
+    );
+  });
+
+  it("records business counters without high-cardinality attributes", async () => {
+    appMetrics.ordersCreated();
+    appMetrics.ordersIdempotencyReplay();
+    appMetrics.ordersIdempotencyConflict();
+    appMetrics.reservationsCreated();
+    appMetrics.reservationsConflict();
+    appMetrics.reservationsExpired();
+    appMetrics.paymentsConfirmed();
+    appMetrics.paymentsFailed();
+    appMetrics.webhooksReceived();
+    appMetrics.webhooksDuplicate();
+    appMetrics.webhooksIgnored();
+    appMetrics.webhooksFailed();
+
+    const metrics = await collectMetrics();
+    expect(sumMetric(metrics, "orders.created")).toBe(1);
+    expect(sumMetric(metrics, "orders.idempotency_replay")).toBe(1);
+    expect(sumMetric(metrics, "orders.idempotency_conflict")).toBe(1);
+    expect(sumMetric(metrics, "reservations.conflict")).toBe(1);
+    expect(sumMetric(metrics, "paypal.webhooks.duplicate")).toBe(1);
+    expect(telemetryContainsSensitive(await collectSpans(), metrics)).toBe(false);
+  });
+
+  it("strips secrets from span attributes", async () => {
+    await withSpan(
+      "security.check",
+      {
+        attributes: {
+          authorization: "Bearer secret-token",
+          password: "hunter2",
+          jwt: "eyJhbGciOiJIUzI1NiJ9.e30.sig",
+          "paypal-transmission-sig": "sig",
+          access_token: "PAYPAL-ACCESS",
+          "http.request.method": "POST",
+        },
+      },
+      async () => "ok"
+    );
+
+    const spans = await collectSpans();
+    const span = spansNamed(spans, "security.check")[0];
+    expect(span?.attributes["http.request.method"]).toBe("POST");
+    expect(span?.attributes.authorization).toBeUndefined();
+    expect(span?.attributes.password).toBeUndefined();
+    expect(span?.attributes.jwt).toBeUndefined();
+    expect(span?.attributes["paypal-transmission-sig"]).toBeUndefined();
+    expect(span?.attributes.access_token).toBeUndefined();
+    expect(telemetryContainsSensitive(spans, await collectMetrics())).toBe(false);
+  });
+});

--- a/server/src/shared/observability/config.ts
+++ b/server/src/shared/observability/config.ts
@@ -1,0 +1,27 @@
+export type TelemetryExporterKind = "none" | "console" | "otlp";
+
+function parseBoolean(value: string | undefined, fallback: boolean) {
+  if (value === undefined || value === "") return fallback;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+export function readTelemetryConfig() {
+  const enabled = parseBoolean(process.env.OTEL_ENABLED, false);
+  const rawExporter = (process.env.OTEL_EXPORTER ?? "none").trim().toLowerCase();
+  const exporter: TelemetryExporterKind =
+    rawExporter === "console" || rawExporter === "otlp" ? rawExporter : "none";
+
+  return {
+    enabled,
+    exporter,
+    serviceName: process.env.OTEL_SERVICE_NAME?.trim() || "neon-arsenal-api",
+    otlpTracesUrl: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT?.trim()
+      || process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim(),
+    otlpMetricsUrl: process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT?.trim()
+      || process.env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim(),
+  };
+}
+
+export function isTelemetryEnabled() {
+  return readTelemetryConfig().enabled;
+}

--- a/server/src/shared/observability/context.ts
+++ b/server/src/shared/observability/context.ts
@@ -1,0 +1,33 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { context, trace } from "@opentelemetry/api";
+
+type RequestStore = { requestId: string };
+
+const requestStore = new AsyncLocalStorage<RequestStore>();
+
+export function runWithRequestId<T>(requestId: string, fn: () => T): T {
+  return requestStore.run({ requestId }, fn);
+}
+
+export function getRequestId() {
+  return requestStore.getStore()?.requestId;
+}
+
+export function getTraceContext() {
+  const span = trace.getSpan(context.active());
+  const spanContext = span?.spanContext();
+  if (!spanContext || !spanContext.traceId || spanContext.traceId === "00000000000000000000000000000000") {
+    return {};
+  }
+  return {
+    trace_id: spanContext.traceId,
+    span_id: spanContext.spanId,
+  };
+}
+
+export function getLogBindings() {
+  return {
+    requestId: getRequestId(),
+    ...getTraceContext(),
+  };
+}

--- a/server/src/shared/observability/http.ts
+++ b/server/src/shared/observability/http.ts
@@ -1,0 +1,72 @@
+import { context, propagation, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
+import type { NextFunction, Request, Response } from "express";
+import { getRequestId } from "./context.js";
+import { appMetrics } from "./metrics.js";
+import { safeAttributes } from "./redact.js";
+
+const SKIP_ROUTES = new Set(["/health", "/ready"]);
+
+function normalizeRoute(req: Request) {
+  const routePath = req.route?.path;
+  if (typeof routePath === "string") {
+    return `${req.baseUrl || ""}${routePath}` || "unmatched";
+  }
+  if (Array.isArray(routePath) && routePath[0]) {
+    return `${req.baseUrl || ""}${String(routePath[0])}`;
+  }
+  return "unmatched";
+}
+
+export function httpTelemetry(req: Request, res: Response, next: NextFunction): void {
+  if (SKIP_ROUTES.has(req.path)) {
+    next();
+    return;
+  }
+
+  const start = process.hrtime.bigint();
+  const extracted = propagation.extract(context.active(), req.headers);
+
+  const span = trace.getTracer("neon-arsenal-api").startSpan(
+    "http.server.request",
+    {
+      kind: SpanKind.SERVER,
+      attributes: safeAttributes({
+        "http.request.method": req.method,
+        "url.path": req.path,
+        "request.id": getRequestId() ?? req.requestId,
+      }),
+    },
+    extracted
+  );
+
+  const spanContext = trace.setSpan(extracted, span);
+
+  const finish = () => {
+    res.off("finish", finish);
+    res.off("close", finish);
+    const route = normalizeRoute(req);
+    const statusCode = res.statusCode || 500;
+    const durationSeconds = Number(process.hrtime.bigint() - start) / 1e9;
+    span.setAttributes(
+      safeAttributes({
+        "http.route": route,
+        "http.response.status_code": statusCode,
+      })
+    );
+    if (statusCode >= 500) {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+    }
+    appMetrics.recordHttpRequest({ method: req.method, route, statusCode }, durationSeconds);
+    span.end();
+  };
+
+  res.on("finish", finish);
+  res.on("close", finish);
+
+  context.with(spanContext, () => next());
+}
+
+export function injectTraceHeaders(headers: Record<string, string> = {}) {
+  propagation.inject(context.active(), headers);
+  return headers;
+}

--- a/server/src/shared/observability/index.ts
+++ b/server/src/shared/observability/index.ts
@@ -1,0 +1,9 @@
+export { readTelemetryConfig, isTelemetryEnabled } from "./config.js";
+export { getLogBindings, getRequestId, runWithRequestId } from "./context.js";
+export { httpTelemetry } from "./http.js";
+export { appMetrics } from "./metrics.js";
+export { withPrismaObservability } from "./prisma.js";
+export { containsSensitiveTelemetry, safeAttributes } from "./redact.js";
+export { startTelemetry, startTestTelemetry, shutdownTelemetry } from "./sdk.js";
+export { withSpan, currentSpan } from "./tracing.js";
+export { markSpanOutcome, type BusinessOutcome } from "./outcomes.js";

--- a/server/src/shared/observability/metrics.ts
+++ b/server/src/shared/observability/metrics.ts
@@ -1,0 +1,172 @@
+import { metrics, type Attributes, type Counter, type Histogram, type Meter } from "@opentelemetry/api";
+import { safeAttributes } from "./redact.js";
+
+const METER_NAME = "neon-arsenal-api";
+
+type Instruments = {
+  httpRequestDuration: Histogram;
+  httpRequestCount: Counter;
+  httpErrorCount: Counter;
+  dbDuration: Histogram;
+  dbErrors: Counter;
+  paypalRequestCount: Counter;
+  paypalErrorCount: Counter;
+  paypalTimeoutCount: Counter;
+  paypalDuration: Histogram;
+  ordersCreated: Counter;
+  ordersCreationFailed: Counter;
+  ordersIdempotencyReplay: Counter;
+  ordersIdempotencyConflict: Counter;
+  reservationsCreated: Counter;
+  reservationsConflict: Counter;
+  reservationsExpired: Counter;
+  paymentsConfirmed: Counter;
+  paymentsFailed: Counter;
+  webhooksReceived: Counter;
+  webhooksDuplicate: Counter;
+  webhooksIgnored: Counter;
+  webhooksFailed: Counter;
+};
+
+let instruments: Instruments | undefined;
+
+function createInstruments(meter: Meter): Instruments {
+  return {
+    httpRequestDuration: meter.createHistogram("http.server.request.duration", {
+      description: "HTTP server request duration",
+      unit: "s",
+    }),
+    httpRequestCount: meter.createCounter("http.server.request.count", {
+      description: "HTTP server requests",
+    }),
+    httpErrorCount: meter.createCounter("http.server.errors", {
+      description: "HTTP server 5xx responses",
+    }),
+    dbDuration: meter.createHistogram("db.client.operation.duration", {
+      description: "Prisma/PostgreSQL operation duration",
+      unit: "s",
+    }),
+    dbErrors: meter.createCounter("db.client.errors", {
+      description: "Prisma/PostgreSQL operation errors",
+    }),
+    paypalRequestCount: meter.createCounter("paypal.client.request.count", {
+      description: "PayPal HTTP requests",
+    }),
+    paypalErrorCount: meter.createCounter("paypal.client.errors", {
+      description: "PayPal HTTP errors",
+    }),
+    paypalTimeoutCount: meter.createCounter("paypal.client.timeouts", {
+      description: "PayPal HTTP timeouts",
+    }),
+    paypalDuration: meter.createHistogram("paypal.client.request.duration", {
+      description: "PayPal HTTP request duration",
+      unit: "s",
+    }),
+    ordersCreated: meter.createCounter("orders.created", { description: "Orders created" }),
+    ordersCreationFailed: meter.createCounter("orders.creation_failed", {
+      description: "Order creation failures",
+    }),
+    ordersIdempotencyReplay: meter.createCounter("orders.idempotency_replay", {
+      description: "Idempotent order replays",
+    }),
+    ordersIdempotencyConflict: meter.createCounter("orders.idempotency_conflict", {
+      description: "Idempotency key conflicts",
+    }),
+    reservationsCreated: meter.createCounter("reservations.created", {
+      description: "Listings reserved",
+    }),
+    reservationsConflict: meter.createCounter("reservations.conflict", {
+      description: "Reservation conflicts",
+    }),
+    reservationsExpired: meter.createCounter("reservations.expired", {
+      description: "Reservations expired",
+    }),
+    paymentsConfirmed: meter.createCounter("payments.confirmed", {
+      description: "Payments confirmed",
+    }),
+    paymentsFailed: meter.createCounter("payments.failed", {
+      description: "Payment confirmation failures",
+    }),
+    webhooksReceived: meter.createCounter("paypal.webhooks.received", {
+      description: "PayPal webhooks received",
+    }),
+    webhooksDuplicate: meter.createCounter("paypal.webhooks.duplicate", {
+      description: "Duplicate PayPal webhooks",
+    }),
+    webhooksIgnored: meter.createCounter("paypal.webhooks.ignored", {
+      description: "Ignored PayPal webhooks",
+    }),
+    webhooksFailed: meter.createCounter("paypal.webhooks.failed", {
+      description: "Failed PayPal webhooks",
+    }),
+  };
+}
+
+function getInstruments(): Instruments {
+  if (!instruments) {
+    instruments = createInstruments(metrics.getMeter(METER_NAME));
+  }
+  return instruments;
+}
+
+export function resetMetricInstruments() {
+  instruments = undefined;
+}
+
+function add(instrument: Counter, attrs?: Attributes, value = 1) {
+  instrument.add(value, safeAttributes(attrs));
+}
+
+export const appMetrics = {
+  recordHttpRequest(attrs: { method: string; route: string; statusCode: number }, durationSeconds: number) {
+    const current = getInstruments();
+    const attributes = {
+      "http.request.method": attrs.method,
+      "http.route": attrs.route,
+      "http.response.status_code": attrs.statusCode,
+    };
+    current.httpRequestCount.add(1, attributes);
+    current.httpRequestDuration.record(durationSeconds, attributes);
+    if (attrs.statusCode >= 500) {
+      current.httpErrorCount.add(1, attributes);
+    }
+  },
+
+  recordDbOperation(attrs: { operation: string; model: string }, durationSeconds: number, failed: boolean) {
+    const current = getInstruments();
+    const attributes = { "db.system": "postgresql", "db.operation": attrs.operation, "db.collection": attrs.model };
+    current.dbDuration.record(durationSeconds, attributes);
+    if (failed) current.dbErrors.add(1, attributes);
+  },
+
+  recordPaypalRequest(
+    operation: string,
+    durationSeconds: number,
+    result: "success" | "error" | "timeout",
+    statusCode?: number
+  ) {
+    const current = getInstruments();
+    const attributes = {
+      "paypal.operation": operation,
+      ...(statusCode !== undefined ? { "http.response.status_code": statusCode } : {}),
+    };
+    current.paypalRequestCount.add(1, attributes);
+    current.paypalDuration.record(durationSeconds, attributes);
+    if (result === "error") current.paypalErrorCount.add(1, attributes);
+    if (result === "timeout") current.paypalTimeoutCount.add(1, attributes);
+  },
+
+  ordersCreated: (value = 1) => add(getInstruments().ordersCreated, undefined, value),
+  ordersCreationFailed: (value = 1) => add(getInstruments().ordersCreationFailed, undefined, value),
+  ordersIdempotencyReplay: (value = 1) => add(getInstruments().ordersIdempotencyReplay, undefined, value),
+  ordersIdempotencyConflict: (value = 1) => add(getInstruments().ordersIdempotencyConflict, undefined, value),
+  reservationsCreated: (value = 1) => add(getInstruments().reservationsCreated, undefined, value),
+  reservationsConflict: (value = 1) => add(getInstruments().reservationsConflict, undefined, value),
+  reservationsExpired: (value = 1) => add(getInstruments().reservationsExpired, undefined, value),
+  paymentsConfirmed: (value = 1) => add(getInstruments().paymentsConfirmed, undefined, value),
+  paymentsFailed: (value = 1) => add(getInstruments().paymentsFailed, undefined, value),
+  webhooksReceived: (value = 1) => add(getInstruments().webhooksReceived, undefined, value),
+  webhooksDuplicate: (value = 1) => add(getInstruments().webhooksDuplicate, undefined, value),
+  webhooksIgnored: (value = 1) => add(getInstruments().webhooksIgnored, undefined, value),
+  webhooksFailed: (value = 1) => add(getInstruments().webhooksFailed, undefined, value),
+};

--- a/server/src/shared/observability/outcomes.ts
+++ b/server/src/shared/observability/outcomes.ts
@@ -1,0 +1,47 @@
+import { SpanStatusCode, type Span } from "@opentelemetry/api";
+import { AppError } from "../errors/AppError.js";
+
+export type BusinessOutcome =
+  | "created"
+  | "confirmed"
+  | "already_confirmed"
+  | "idempotency_replay"
+  | "idempotency_conflict"
+  | "reservation_conflict"
+  | "reservation_expired"
+  | "webhook_duplicate"
+  | "webhook_ignored"
+  | "webhook_failed"
+  | "validation_error"
+  | "not_found"
+  | "timeout"
+  | "provider_error"
+  | "error";
+
+export function isBusinessError(err: unknown) {
+  return err instanceof AppError && err.statusCode < 500;
+}
+
+export function markSpanOutcome(span: Span, outcome: BusinessOutcome) {
+  span.setAttribute("app.outcome", outcome);
+  if (outcome === "error" || outcome === "timeout" || outcome === "provider_error") {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: outcome });
+    return;
+  }
+  span.setStatus({ code: SpanStatusCode.UNSET });
+}
+
+export function classifyThrownError(err: unknown): BusinessOutcome {
+  if (err instanceof AppError) {
+    if (err.statusCode === 504) return "timeout";
+    if (err.statusCode === 502) return "provider_error";
+    if (err.statusCode === 409 && /idempotency/i.test(err.message)) return "idempotency_conflict";
+    if (err.statusCode === 409 && /reserv/i.test(err.message)) return "reservation_expired";
+    if (err.statusCode === 400 && /not available|not ACTIVE|trade locked/i.test(err.message)) {
+      return "reservation_conflict";
+    }
+    if (err.statusCode === 404) return "not_found";
+    if (err.statusCode < 500) return "validation_error";
+  }
+  return "error";
+}

--- a/server/src/shared/observability/paypal.ts
+++ b/server/src/shared/observability/paypal.ts
@@ -1,0 +1,49 @@
+import { SpanKind } from "@opentelemetry/api";
+import { AppError } from "../errors/AppError.js";
+import { appMetrics } from "./metrics.js";
+import { markSpanOutcome } from "./outcomes.js";
+import { withSpan } from "./tracing.js";
+
+export async function withPaypalOperation<T>(
+  operation: string,
+  fn: () => Promise<T>,
+  readStatus?: (result: T) => number | undefined
+): Promise<T> {
+  const started = process.hrtime.bigint();
+  return withSpan(
+    `paypal.${operation}`,
+    {
+      kind: SpanKind.CLIENT,
+      attributes: { "paypal.operation": operation },
+    },
+    async (span) => {
+      try {
+        const result = await fn();
+        const statusCode = readStatus?.(result);
+        if (statusCode !== undefined) {
+          span.setAttribute("http.response.status_code", statusCode);
+        }
+        markSpanOutcome(span, "confirmed");
+        appMetrics.recordPaypalRequest(
+          operation,
+          Number(process.hrtime.bigint() - started) / 1e9,
+          "success",
+          statusCode
+        );
+        return result;
+      } catch (err) {
+        const timeout = err instanceof AppError && err.statusCode === 504;
+        const statusMatch =
+          err instanceof Error ? err.message.match(/PayPal OrdersGet failed: (\d+)/) : null;
+        const statusCode = statusMatch ? Number(statusMatch[1]) : undefined;
+        appMetrics.recordPaypalRequest(
+          operation,
+          Number(process.hrtime.bigint() - started) / 1e9,
+          timeout ? "timeout" : "error",
+          statusCode
+        );
+        throw err;
+      }
+    }
+  );
+}

--- a/server/src/shared/observability/prisma.ts
+++ b/server/src/shared/observability/prisma.ts
@@ -1,0 +1,42 @@
+import type { PrismaClient } from "@prisma/client";
+import { SpanKind } from "@opentelemetry/api";
+import { appMetrics } from "./metrics.js";
+import { withSpan } from "./tracing.js";
+
+type PrismaClientLike = PrismaClient & {
+  $extends: (extension: unknown) => PrismaClient;
+};
+
+export function withPrismaObservability(client: PrismaClient): PrismaClient {
+  const observable = (client as PrismaClientLike).$extends({
+    query: {
+      async $allOperations({ model, operation, args, query }) {
+        const collection = model ?? "raw";
+        const started = process.hrtime.bigint();
+        let failed = false;
+        try {
+          return await withSpan(
+            "db.prisma",
+            {
+              kind: SpanKind.CLIENT,
+              attributes: {
+                "db.system": "postgresql",
+                "db.operation": operation,
+                "db.collection": collection,
+              },
+            },
+            () => query(args)
+          );
+        } catch (err) {
+          failed = true;
+          throw err;
+        } finally {
+          const durationSeconds = Number(process.hrtime.bigint() - started) / 1e9;
+          appMetrics.recordDbOperation({ operation, model: collection }, durationSeconds, failed);
+        }
+      },
+    },
+  });
+
+  return observable as PrismaClient;
+}

--- a/server/src/shared/observability/redact.ts
+++ b/server/src/shared/observability/redact.ts
@@ -1,0 +1,43 @@
+import type { Attributes, AttributeValue } from "@opentelemetry/api";
+
+const FORBIDDEN_KEY = /password|passwd|secret|token|authorization|cookie|jwt|signature|credential|paypal-transmission-sig|access_token/i;
+
+const FORBIDDEN_VALUE = /bearer\s+[a-z0-9._-]+|eyj[a-z0-9_-]+\.[a-z0-9_-]+|-----begin /i;
+
+export function isForbiddenAttributeKey(key: string) {
+  return FORBIDDEN_KEY.test(key);
+}
+
+export function sanitizeAttributeValue(value: AttributeValue): AttributeValue | undefined {
+  if (typeof value === "string" && FORBIDDEN_VALUE.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+export function safeAttributes(input: Record<string, AttributeValue | undefined> = {}): Attributes {
+  const attributes: Attributes = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || isForbiddenAttributeKey(key)) continue;
+    const sanitized = sanitizeAttributeValue(value);
+    if (sanitized === undefined) continue;
+    attributes[key] = sanitized;
+  }
+  return attributes;
+}
+
+export function containsSensitiveTelemetry(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") {
+    return FORBIDDEN_KEY.test(value) || FORBIDDEN_VALUE.test(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsSensitiveTelemetry);
+  }
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).some(
+      ([key, nested]) => isForbiddenAttributeKey(key) || containsSensitiveTelemetry(nested)
+    );
+  }
+  return false;
+}

--- a/server/src/shared/observability/sdk.ts
+++ b/server/src/shared/observability/sdk.ts
@@ -39,7 +39,10 @@ function buildResource(serviceName: string) {
 function createTraceExporter(kind: ReturnType<typeof readTelemetryConfig>["exporter"], otlpUrl?: string) {
   if (kind === "console") return new ConsoleSpanExporter();
   if (kind === "otlp") {
-    return new OTLPTraceExporter(otlpUrl ? { url: otlpUrl } : undefined);
+    return new OTLPTraceExporter({
+      ...(otlpUrl ? { url: otlpUrl } : {}),
+      timeoutMillis: 2_000,
+    });
   }
   return undefined;
 }
@@ -47,7 +50,10 @@ function createTraceExporter(kind: ReturnType<typeof readTelemetryConfig>["expor
 function createMetricExporter(kind: ReturnType<typeof readTelemetryConfig>["exporter"], otlpUrl?: string) {
   if (kind === "console") return new ConsoleMetricExporter();
   if (kind === "otlp") {
-    return new OTLPMetricExporter(otlpUrl ? { url: otlpUrl } : undefined);
+    return new OTLPMetricExporter({
+      ...(otlpUrl ? { url: otlpUrl } : {}),
+      timeoutMillis: 2_000,
+    });
   }
   return undefined;
 }

--- a/server/src/shared/observability/sdk.ts
+++ b/server/src/shared/observability/sdk.ts
@@ -1,0 +1,142 @@
+import { metrics, trace } from "@opentelemetry/api";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import {
+  BatchSpanProcessor,
+  ConsoleSpanExporter,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  type SpanExporter,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import {
+  AggregationTemporality,
+  ConsoleMetricExporter,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  type PushMetricExporter,
+} from "@opentelemetry/sdk-metrics";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { readTelemetryConfig } from "./config.js";
+import { resetMetricInstruments } from "./metrics.js";
+
+type StartedTelemetry = {
+  tracerProvider: NodeTracerProvider;
+  meterProvider: MeterProvider;
+  spanExporter?: SpanExporter;
+  metricExporter?: PushMetricExporter;
+};
+
+let started: StartedTelemetry | undefined;
+
+function buildResource(serviceName: string) {
+  return resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName });
+}
+
+function createTraceExporter(kind: ReturnType<typeof readTelemetryConfig>["exporter"], otlpUrl?: string) {
+  if (kind === "console") return new ConsoleSpanExporter();
+  if (kind === "otlp") {
+    return new OTLPTraceExporter(otlpUrl ? { url: otlpUrl } : undefined);
+  }
+  return undefined;
+}
+
+function createMetricExporter(kind: ReturnType<typeof readTelemetryConfig>["exporter"], otlpUrl?: string) {
+  if (kind === "console") return new ConsoleMetricExporter();
+  if (kind === "otlp") {
+    return new OTLPMetricExporter(otlpUrl ? { url: otlpUrl } : undefined);
+  }
+  return undefined;
+}
+
+function createSpanProcessor(exporter?: SpanExporter, mode: "batch" | "simple" = "batch"): SpanProcessor[] {
+  if (!exporter) return [];
+  return [mode === "simple" ? new SimpleSpanProcessor(exporter) : new BatchSpanProcessor(exporter)];
+}
+
+export async function startTelemetry(options?: {
+  forceEnabled?: boolean;
+  exporter?: ReturnType<typeof readTelemetryConfig>["exporter"];
+  spanExporter?: SpanExporter;
+  metricExporter?: PushMetricExporter;
+  exportIntervalMillis?: number;
+}) {
+  if (started) return started;
+
+  const config = readTelemetryConfig();
+  const enabled = options?.forceEnabled ?? config.enabled;
+  if (!enabled) return undefined;
+
+  try {
+    const exporterKind = options?.exporter ?? config.exporter;
+    const spanExporter = options?.spanExporter ?? createTraceExporter(exporterKind, config.otlpTracesUrl);
+    const metricExporter = options?.metricExporter ?? createMetricExporter(exporterKind, config.otlpMetricsUrl);
+    const resource = buildResource(config.serviceName);
+
+    const tracerProvider = new NodeTracerProvider({
+      resource,
+      spanProcessors: createSpanProcessor(spanExporter, options?.spanExporter ? "simple" : "batch"),
+    });
+    tracerProvider.register();
+
+    const readers = metricExporter
+      ? [
+          new PeriodicExportingMetricReader({
+            exporter: metricExporter,
+            exportIntervalMillis: options?.exportIntervalMillis ?? (options?.metricExporter ? 60_000 : 15_000),
+          }),
+        ]
+      : [];
+
+    const meterProvider = new MeterProvider({ resource, readers });
+    metrics.setGlobalMeterProvider(meterProvider);
+    resetMetricInstruments();
+
+    started = { tracerProvider, meterProvider, spanExporter, metricExporter };
+    return started;
+  } catch {
+    resetMetricInstruments();
+    return undefined;
+  }
+}
+
+export async function startTestTelemetry() {
+  await shutdownTelemetry();
+  const spanExporter = new InMemorySpanExporter();
+  const metricExporter = new InMemoryMetricExporter(AggregationTemporality.DELTA);
+  return startTelemetry({
+    forceEnabled: true,
+    spanExporter,
+    metricExporter,
+    exportIntervalMillis: 60_000,
+  });
+}
+
+export function getStartedTelemetry() {
+  return started;
+}
+
+export async function flushTelemetry() {
+  if (!started) return;
+  await started.tracerProvider.forceFlush().catch(() => undefined);
+  await started.meterProvider.forceFlush().catch(() => undefined);
+}
+
+export async function shutdownTelemetry() {
+  if (!started) {
+    trace.disable();
+    metrics.disable();
+    resetMetricInstruments();
+    return;
+  }
+  const current = started;
+  started = undefined;
+  await current.tracerProvider.shutdown().catch(() => undefined);
+  await current.meterProvider.shutdown().catch(() => undefined);
+  trace.disable();
+  metrics.disable();
+  resetMetricInstruments();
+}

--- a/server/src/shared/observability/test.ts
+++ b/server/src/shared/observability/test.ts
@@ -1,0 +1,89 @@
+import { InMemorySpanExporter, type ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import {
+  InMemoryMetricExporter,
+  type MetricData,
+} from "@opentelemetry/sdk-metrics";
+import { flushTelemetry, getStartedTelemetry, startTestTelemetry, shutdownTelemetry } from "./sdk.js";
+
+export async function useTestTelemetry() {
+  const started = await startTestTelemetry();
+  if (!started) {
+    throw new Error("Test telemetry failed to start");
+  }
+  return started;
+}
+
+export async function resetTestTelemetry() {
+  const started = getStartedTelemetry();
+  if (started?.spanExporter instanceof InMemorySpanExporter) {
+    started.spanExporter.reset();
+  }
+  if (started?.metricExporter instanceof InMemoryMetricExporter) {
+    started.metricExporter.reset();
+  }
+}
+
+export async function collectSpans(): Promise<ReadableSpan[]> {
+  await flushTelemetry();
+  const started = getStartedTelemetry();
+  if (!(started?.spanExporter instanceof InMemorySpanExporter)) return [];
+  return started.spanExporter.getFinishedSpans();
+}
+
+export async function collectMetrics(): Promise<MetricData[]> {
+  await flushTelemetry();
+  const started = getStartedTelemetry();
+  if (!(started?.metricExporter instanceof InMemoryMetricExporter)) return [];
+  return started.metricExporter.getMetrics().flatMap((resource) => resource.scopeMetrics.flatMap((scope) => scope.metrics));
+}
+
+export function metricByName(metrics: MetricData[], name: string) {
+  return metrics.find((metric) => metric.descriptor.name === name);
+}
+
+export function metricPoints(metrics: MetricData[], name: string) {
+  return metricByName(metrics, name)?.dataPoints ?? [];
+}
+
+export function sumMetric(metrics: MetricData[], name: string) {
+  return metricPoints(metrics, name).reduce((total, point) => {
+    const value = point.value;
+    if (typeof value === "number") return total + value;
+    return total + value.count;
+  }, 0);
+}
+
+export function spanNames(spans: ReadableSpan[]) {
+  return spans.map((span) => span.name);
+}
+
+export function spansNamed(spans: ReadableSpan[], name: string) {
+  return spans.filter((span) => span.name === name);
+}
+
+export function spanOutcomes(spans: ReadableSpan[], name: string) {
+  return spansNamed(spans, name).map((span) => span.attributes["app.outcome"]);
+}
+
+const FORBIDDEN_ATTR_KEYS = /password|passwd|secret|token|authorization|cookie|jwt|signature|credential|access_token|paypal-transmission-sig/i;
+const HIGH_CARDINALITY_KEYS = /user[_]?id|order[_]?id|listing[_]?id|email|customer[_]?id/i;
+
+export function telemetryContainsSensitive(spans: ReadableSpan[], metrics: MetricData[]) {
+  const spanHit = spans.some((span) =>
+    Object.entries(span.attributes).some(
+      ([key, value]) => FORBIDDEN_ATTR_KEYS.test(key) || (typeof value === "string" && FORBIDDEN_ATTR_KEYS.test(value))
+    )
+  );
+  const metricHit = metrics.some((metric) =>
+    metric.dataPoints.some((point) =>
+      Object.keys(point.attributes ?? {}).some((key) => FORBIDDEN_ATTR_KEYS.test(key) || HIGH_CARDINALITY_KEYS.test(key))
+    )
+  );
+  return spanHit || metricHit;
+}
+
+export function metricAttributeKeys(metrics: MetricData[], name: string) {
+  return new Set(metricPoints(metrics, name).flatMap((point) => Object.keys(point.attributes ?? {})));
+}
+
+export { shutdownTelemetry };

--- a/server/src/shared/observability/tracing.ts
+++ b/server/src/shared/observability/tracing.ts
@@ -1,0 +1,51 @@
+import { context, SpanKind, SpanStatusCode, trace, type Span, type AttributeValue } from "@opentelemetry/api";
+import { safeAttributes } from "./redact.js";
+import { classifyThrownError, isBusinessError, markSpanOutcome, type BusinessOutcome } from "./outcomes.js";
+
+function getTracer() {
+  return trace.getTracer("neon-arsenal-api");
+}
+
+export async function withSpan<T>(
+  name: string,
+  options: {
+    kind?: SpanKind;
+    attributes?: Record<string, AttributeValue | undefined>;
+    outcomeOnSuccess?: BusinessOutcome;
+  },
+  fn: (span: Span) => Promise<T> | T
+): Promise<T> {
+  return getTracer().startActiveSpan(
+    name,
+    {
+      kind: options.kind ?? SpanKind.INTERNAL,
+      attributes: safeAttributes(options.attributes),
+    },
+    async (span) => {
+      try {
+        const result = await fn(span);
+        if (options.outcomeOnSuccess) {
+          markSpanOutcome(span, options.outcomeOnSuccess);
+        }
+        return result;
+      } catch (err) {
+        const outcome = classifyThrownError(err);
+        markSpanOutcome(span, outcome);
+        if (!isBusinessError(err)) {
+          span.recordException(err instanceof Error ? err : new Error("unknown_error"));
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err instanceof Error ? err.name : "unknown_error",
+          });
+        }
+        throw err;
+      } finally {
+        span.end();
+      }
+    }
+  );
+}
+
+export function currentSpan() {
+  return trace.getSpan(context.active());
+}

--- a/server/src/shared/utils/paypal.ts
+++ b/server/src/shared/utils/paypal.ts
@@ -2,6 +2,7 @@ import paypal from "@paypal/checkout-server-sdk";
 import { AppError } from "../errors/AppError.js";
 import { logger } from "../logger.js";
 import { getPayPalApiBaseUrl, getPayPalApiTimeoutMs } from "../config/paypal.js";
+import { withPaypalOperation } from "../observability/paypal.js";
 
 function environment() {
   const clientId = process.env.PAYPAL_CLIENT_ID ?? "";
@@ -46,75 +47,83 @@ export async function createPayPalOrder(amount: string, currency = "BRL", orderI
       },
     ],
   });
-  // OrdersCreate is not retried: a retry can create a second PayPal order.
-  const response = await withTimeout(client.execute(request), "PayPal OrdersCreate");
-  return response.result;
+  return withPaypalOperation("orders_create", async () => {
+    // OrdersCreate is not retried: a retry can create a second PayPal order.
+    const response = await withTimeout(client.execute(request), "PayPal OrdersCreate");
+    return response.result;
+  });
 }
 
 export async function capturePayPalOrder(orderId: string) {
   const request = new paypal.orders.OrdersCaptureRequest(orderId);
   request.requestBody({});
-  const response = await withTimeout(client.execute(request), "PayPal OrdersCapture");
-  return response.result;
+  return withPaypalOperation("orders_capture", async () => {
+    const response = await withTimeout(client.execute(request), "PayPal OrdersCapture");
+    return response.result;
+  });
 }
 
 export async function getPayPalOrder(paypalOrderId: string): Promise<{ id?: string; status?: string }> {
-  const token = await getPayPalAccessToken();
-  const url = `${getPayPalApiBaseUrl()}/v2/checkout/orders/${encodeURIComponent(paypalOrderId)}`;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
-    try {
-      const response = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
-      });
-      if (response.status >= 500 || response.status === 429) {
-        lastError = new AppError(502, `PayPal OrdersGet failed: ${response.status}`);
+  return withPaypalOperation("orders_get", async () => {
+    const token = await getPayPalAccessToken();
+    const url = `${getPayPalApiBaseUrl()}/v2/checkout/orders/${encodeURIComponent(paypalOrderId)}`;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        const response = await fetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
+        });
+        if (response.status >= 500 || response.status === 429) {
+          lastError = new AppError(502, `PayPal OrdersGet failed: ${response.status}`);
+          if (attempt < 3) await delay(200 * attempt);
+          continue;
+        }
+        if (!response.ok) {
+          throw new AppError(502, `PayPal OrdersGet failed: ${response.status}`);
+        }
+        return (await response.json()) as { id?: string; status?: string };
+      } catch (err) {
+        if (err instanceof AppError && !isRetryablePayPalLookupError(err)) {
+          throw err;
+        }
+        lastError = err;
         if (attempt < 3) await delay(200 * attempt);
-        continue;
       }
-      if (!response.ok) {
-        throw new AppError(502, `PayPal OrdersGet failed: ${response.status}`);
-      }
-      return (await response.json()) as { id?: string; status?: string };
-    } catch (err) {
-      if (err instanceof AppError && !isRetryablePayPalLookupError(err)) {
-        throw err;
-      }
-      lastError = err;
-      if (attempt < 3) await delay(200 * attempt);
     }
-  }
-  logger.warn({ err: lastError, paypalOrderId }, "PayPal OrdersGet exhausted retries");
-  throw lastError instanceof Error ? lastError : new AppError(502, "PayPal OrdersGet failed");
+    logger.warn({ err: lastError }, "PayPal OrdersGet exhausted retries");
+    throw lastError instanceof Error ? lastError : new AppError(502, "PayPal OrdersGet failed");
+  });
 }
 
 export async function getPayPalAccessToken(): Promise<string> {
   if (tokenCache && Date.now() < tokenCache.expiresAt) {
     return tokenCache.token;
   }
-  const clientId = process.env.PAYPAL_CLIENT_ID ?? "";
-  const secret = process.env.PAYPAL_SECRET ?? "";
-  const credentials = Buffer.from(`${clientId}:${secret}`).toString("base64");
-  const response = await fetch(`${getPayPalApiBaseUrl()}/v1/oauth2/token`, {
-    method: "POST",
-    headers: {
-      Authorization: `Basic ${credentials}`,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: "grant_type=client_credentials",
-    signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
+  return withPaypalOperation("oauth_token", async () => {
+    const clientId = process.env.PAYPAL_CLIENT_ID ?? "";
+    const secret = process.env.PAYPAL_SECRET ?? "";
+    const credentials = Buffer.from(`${clientId}:${secret}`).toString("base64");
+    const response = await fetch(`${getPayPalApiBaseUrl()}/v1/oauth2/token`, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: "grant_type=client_credentials",
+      signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
+    });
+    if (!response.ok) {
+      throw new AppError(502, "PayPal OAuth token request failed");
+    }
+    const body = (await response.json()) as { access_token?: string; expires_in?: number };
+    if (!body.access_token) {
+      throw new AppError(502, "PayPal OAuth token missing");
+    }
+    const ttlMs = Math.max(30_000, ((body.expires_in ?? 300) - 30) * 1000);
+    tokenCache = { token: body.access_token, expiresAt: Date.now() + ttlMs };
+    return body.access_token;
   });
-  if (!response.ok) {
-    throw new AppError(502, "PayPal OAuth token request failed");
-  }
-  const body = (await response.json()) as { access_token?: string; expires_in?: number };
-  if (!body.access_token) {
-    throw new AppError(502, "PayPal OAuth token missing");
-  }
-  const ttlMs = Math.max(30_000, ((body.expires_in ?? 300) - 30) * 1000);
-  tokenCache = { token: body.access_token, expiresAt: Date.now() + ttlMs };
-  return body.access_token;
 }
 
 export function getPayPalOrderIdFromResult(result: { id?: string }): string | undefined {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub Issue #7 (P1.2): enough OpenTelemetry tracing and metrics to diagnose latency, errors and business failures on the checkout path, without adding Jaeger/Grafana/Prometheus/Collector or changing domain invariants.

- Optional SDK (`OTEL_ENABLED` defaults off). Exporters: `none` | `console` | `otlp`. A down collector does not crash the API.
- Keeps existing `X-Request-Id` + Pino. Adds `trace_id` / `span_id` to logs when a span is active. Accepts W3C `traceparent`.
- Spans for HTTP, Prisma (no SQL/params), PayPal operations, order creation, reservation, payment confirmation, webhook verify/handle, and reconciliation.
- Expected 4xx business results use `app.outcome` and are **not** span `ERROR`.
- Low-cardinality HTTP/DB/PayPal metrics plus business counters (`orders.*`, `reservations.*`, `payments.*`, `paypal.webhooks.*`).
- Secrets, tokens, webhook signatures and IDs are excluded from attributes/labels.
- OTLP HTTP export timeout is 2s so an unreachable collector cannot stall shutdown.

See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.

## Local verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` (server) | pass |
| `npm run test:unit` | 114 passed / 18 files |
| `npm run test:integration` | 41 passed / 6 files |
| `npm run build` (server) | pass |
| `npm run lint` (repo) | 0 errors, 9 pre-existing warnings |
| `npx tsc --noEmit -p tsconfig.app.json` | pass |
| `npm run build` (frontend) | pass |

Domain invariants (reservation, payment, idempotency, order creation) still pass on the existing PostgreSQL suites.

## Testing notes

- Unit: request-ID correlation, HTTP route cardinality, business vs operational span status, redaction, disabled/OTLP-down paths, webhook signature failure.
- Integration (Issue #6 harness): order create/replay/conflict, reservation success/conflict/expiry, payment confirm/fail/duplicate webhook. No SQLite, no Prisma mocks, no arbitrary sleeps.

Commits: `673837ac56e07692722226e76301ca13987f4776`, `91b7951`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

