### PR TITLE
[P-front] F0.1 — Frontend sprint contract and next-activity orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 .env
 .env.local
+__pycache__/
+*.py[cod]
 
 # SQLite database (local dev fallback)
 server/prisma/*.db

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -26,6 +26,8 @@ If code and documentation disagree, the agent must inspect the code and flag the
 
 The team is intentionally **sequential by default**. Parallel agents are used only when their work has no overlapping files or semantic dependencies.
 
+The P-front UI rebuild is one explicit parallel track (`src/` only). Agents must follow `docs/agents/p-front-orchestrator.md` and pick work with `python3 scripts/p-front/next.py` instead of hand-pasted issue prompts.
+
 Recommended roles:
 
 - **Planner** — converts a roadmap item into an implementation plan and acceptance criteria.

--- a/docs/agents/p-front-orchestrator.md
+++ b/docs/agents/p-front-orchestrator.md
@@ -1,0 +1,71 @@
+# P-front orchestrator
+
+Turns the frontend rebuild into a one-prompt loop that still obeys `AGENTS.md`.
+
+This is a control-plane convention, not a new runtime and not part of the application architecture.
+
+## Human loop
+
+You do three things:
+
+1. Tell a Cloud Agent: `next` (or `Execute the next P-front activity`).
+2. Review the draft PR.
+3. Merge. Repeat from 1.
+
+Do not paste issue bodies. Do not write a custom prompt per activity. The repo already knows what is next.
+
+## Agent loop
+
+When the human says `next` / `execute next P-front activity`:
+
+1. Read the mandatory agent docs (`AGENTS.md`, `docs/agents/*`, `docs/architecture/domain-invariants.md`).
+2. Read `docs/frontend-sprint.md`.
+3. Run `python3 scripts/p-front/next.py` (use `--json` if needed).
+4. Implement **only** `next.id`.
+5. Open a draft PR titled `[P-front] <ID> — <title>` from `cursor/p-front-<id>-ef90`.
+6. Stop. Do not start the following activity in the same PR.
+
+If `next.py` exits 2 (blocked on in-progress PRs), report the URLs and wait. Do not invent work.
+
+If several activities are ready and the human asked for parallel sub-agents, launch one agent per ready item **only when `ownerFiles` do not overlap**. Default sequential pick is the first ready activity (S2 before A1/C1 when all three are ready, because it is listed first after F0.4).
+
+## Prompt (reuse as-is)
+
+```text
+Execute the next unblocked P-front activity.
+
+Run: python3 scripts/p-front/next.py --prompt
+Then follow that printed prompt exactly.
+
+Mandatory reading order still applies (AGENTS.md and docs/agents/*).
+Do not edit server/. Do not add features. Do not merge. Do not close issues.
+```
+
+`python3 scripts/p-front/next.py --prompt` prints the scoped prompt for the current activity, including files, acceptance criteria, and verify commands.
+
+## Roles
+
+Use the smallest set from `docs/agents/roles.md`:
+
+| Activity | Roles |
+|---|---|
+| F0.1 | Planner + Verification |
+| F0.2 F0.3 F0.4 S1 | Implementation + Verification (+ Test when tests exist) |
+| S2 S3 D1 Q2 | Implementation + Test + Verification |
+| A1 C1 | Implementation + Security + Verification (+ Test for C1) |
+| D2 Q1 Q3 | Implementation or Verification as listed in `activities.json` |
+
+Do not invoke Database/Concurrency. Do not change payment or reservation semantics. C1 may fix dishonest checkout copy only.
+
+## Isolation
+
+- One activity, one branch, one PR.
+- Owner files in `activities.json` are exclusive until that PR merges.
+- Failure budget: the same root cause failing verification twice → HUMAN (`docs/agents/execution-protocol.md`).
+- Handoff: `docs/agents/handoff-template.md`.
+
+## Why not fifteen GitHub issues
+
+The orchestrator contract says a GitHub issue is the usual intake. For this sprint the issue would only repeat `activities.json`. Duplicating that by hand is not required for correctness.
+
+If GitHub tracking is wanted, create them in one command (`python3 scripts/p-front/create-issues.py`) on a write-capable machine. Agents still treat the files as source of truth.

--- a/docs/frontend-sprint.md
+++ b/docs/frontend-sprint.md
@@ -1,0 +1,81 @@
+# P-front — Frontend rebuild (no new features)
+
+Parallel sprint to backend P1. Rebuild the existing React/Vite client with modern UX. Do not add product functionality.
+
+## Locked decisions
+
+| Decision | Value |
+|---|---|
+| Brand | **Neon Arsenal**. Remove SKINMARKET / SkinMarket / “CS2 Skin Marketplace”. |
+| Visual | **Dark editorial**. No neon glow, scan-lines, grid-pattern, or global uppercase headings. |
+| Seller IA | Keep both routes. `/seller/listings` = unique-item CRUD. `/seller/products` = **read-only** Product catalog (`listProducts`). Seller cannot create/update/delete Product (API is ADMIN-only). |
+
+## Out of scope
+
+- New routes, search, reviews, buyer order history, real skin images, i18n, PWA
+- Any change under `server/`, Prisma, auth/payment/reservation semantics
+- Weakening CORS, rate limits, auth, or tests
+- Inventing APIs or environment variables
+
+## How this sprint is executed
+
+Do **not** open or paste fifteen GitHub issues by hand.
+
+1. Source of truth is this file plus `scripts/p-front/activities.json`.
+2. A Cloud Agent runs `python3 scripts/p-front/next.py` and implements **only** the printed activity.
+3. PR title must be `[P-front] <ID> — <title>`.
+4. Human reviews and merges.
+5. Human (or the same conversation after merge) says `next`. The agent repeats from step 2.
+
+Optional GitHub issues, one command on a machine with `gh` write access:
+
+```bash
+python3 scripts/p-front/create-issues.py
+```
+
+This Cloud Agent cannot create issues (`gh` is read-only here). Issues are optional metadata. Agents must follow the files above even if no issue exists.
+
+## Inventory (current app)
+
+| Surface | Routes | Behavior to preserve |
+|---|---|---|
+| Storefront | `/`, `/products`, `/listing/:id` | Home: 8 ACTIVE listings. Market: exterior / StatTrak / price / client-side sort / pagination. Detail: float, pattern, trade lock, price history, related, cart. |
+| Purchase | `/cart`, `/checkout` | Local cart. Checkout only `CUSTOMER`. `createOrder` + PayPal. 5% display total stays unless a later issue says otherwise. |
+| Auth | `/login`, `/register` | Login. Register 2-step email code. `CUSTOMER` or `SELLER` + `storeName`. |
+| Seller | `/seller`, `/seller/products`, `/seller/listings`, `/seller/orders` | Stats, listing CRUD on listings, orders. Products page must stop being a second listing CRUD. |
+| Admin | `/admin`, `/admin/sellers`, `/admin/orders`, `/admin/users` | Stats, approve seller, orders, users, commission display. |
+| Shell | `MainLayout`, `DashboardLayout`, `Header` | Nav, auth, cart. Dashboard needs mobile nav (today sidebar is `lg` only). |
+
+Dead template (remove in F0.4 if unused): `src/pages/ProductDetail.tsx`, `src/services/mock-data.ts`.
+
+## Graph
+
+```text
+F0.1 → F0.2 → F0.3 → F0.4
+                      ↓
+            ┌─────────┼─────────┐
+            S2        A1        C1
+            ↓
+          S1 + S3
+            ↓
+          D1 ∥ D2
+            ↓
+        Q1 → Q2 → Q3
+```
+
+S2 owns `ListingCard` / `ProductCard`. S1 and S3 wait for S2 to merge. D1/D2 must not edit Header or layouts after F0.3.
+
+## Activities
+
+See `scripts/p-front/activities.json` for acceptance criteria, owner files, and verify commands. Status is **not** edited in this file (avoids merge conflicts). Compute it with:
+
+```bash
+python3 scripts/p-front/next.py
+```
+
+Done = a commit on `origin/main` whose subject contains `[P-front] <ID>`.
+In progress = an open PR whose title contains `[P-front] <ID>`.
+
+## Parallelism with backend
+
+Backend P1 (`server/` only) may run in a separate agent/PR at the same time. Do not mix `src/` and `server/` in one PR.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,8 +136,16 @@ Maintain:
 
 Documentation is part of the implementation whenever a design or operational decision changes.
 
+## P-front — Frontend rebuild (parallel to P1, `src/` only)
+
+Rebuild the existing Vite/React client. No new product features. Locked decisions and activity graph: `docs/frontend-sprint.md`. Agent loop: `docs/agents/p-front-orchestrator.md`. Next activity: `python3 scripts/p-front/next.py`.
+
+May run beside backend P1 only while PRs stay disjoint (`src/` vs `server/`).
+
 ## Agent execution rule
 
 Only one roadmap item should normally be in active implementation at a time. Split a roadmap item into small tasks when it is too large for one reviewable change.
 
 A lower-priority item must not distract the team from a known unresolved correctness problem.
+
+P-front is an explicit exception for **file-disjoint** parallelism with P1: frontend agents own `src/` and `docs/frontend-sprint.md`; backend agents own `server/`.

--- a/scripts/p-front-next.sh
+++ b/scripts/p-front-next.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec python3 "$(dirname "$0")/p-front/next.py" "$@"

--- a/scripts/p-front/activities.json
+++ b/scripts/p-front/activities.json
@@ -1,0 +1,249 @@
+{
+  "sprint": "P-front",
+  "brand": "Neon Arsenal",
+  "visual": "dark-editorial",
+  "prTitlePrefix": "[P-front]",
+  "commitConvention": "[P-front] <ID> — <short title>",
+  "forbiddenGlobally": [
+    "server/",
+    "server/prisma/"
+  ],
+  "lockedDecisions": {
+    "brand": "Neon Arsenal. Remove SKINMARKET / SkinMarket / “CS2 Skin Marketplace”.",
+    "visual": "Dark editorial. No neon glow, scan-lines, grid-pattern, or global uppercase headings.",
+    "seller": "Keep /seller/products and /seller/listings. Listings = unique-item CRUD. Products = read-only Product catalog via listProducts. Seller cannot create/update/delete Product (ADMIN-only API)."
+  },
+  "activities": [
+    {
+      "id": "F0.1",
+      "title": "Contrato de superfície do frontend",
+      "dependsOn": [],
+      "ownerFiles": [
+        "docs/frontend-sprint.md",
+        "docs/agents/p-front-orchestrator.md",
+        "docs/roadmap.md",
+        "scripts/p-front/"
+      ],
+      "roles": ["Planner", "Verification"],
+      "verify": ["docs-only diff"],
+      "acceptance": [
+        "Later agents can implement one screen without inventing a route, field, or endpoint.",
+        "Seller IA is written: listings = CRUD; products = read-only catalog.",
+        "Out-of-scope list is explicit."
+      ]
+    },
+    {
+      "id": "F0.2",
+      "title": "Tokens e tema dark editorial",
+      "dependsOn": ["F0.1"],
+      "ownerFiles": ["src/index.css", "tailwind.config.ts", "index.html"],
+      "roles": ["Implementation", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint"],
+      "acceptance": [
+        "Tokens define canvas, accent, muted, rarity without scan-line/glow utilities.",
+        "Chakra Petch is not the heading default.",
+        "No server/ changes."
+      ]
+    },
+    {
+      "id": "F0.3",
+      "title": "Shell, primitivos e chrome compartilhado",
+      "dependsOn": ["F0.2"],
+      "ownerFiles": [
+        "src/layouts/MainLayout.tsx",
+        "src/layouts/DashboardLayout.tsx",
+        "src/components/Header.tsx",
+        "src/App.tsx"
+      ],
+      "roles": ["Implementation", "Test", "Verification"],
+      "verify": ["npm test", "npm run typecheck", "npm run lint"],
+      "acceptance": [
+        "Header shows Neon Arsenal; role links unchanged.",
+        "Dashboard has usable mobile navigation.",
+        "ProtectedRoute behavior unchanged.",
+        "No new routes."
+      ]
+    },
+    {
+      "id": "F0.4",
+      "title": "Higiene: código morto do template",
+      "dependsOn": ["F0.3"],
+      "ownerFiles": [
+        "src/pages/ProductDetail.tsx",
+        "src/services/mock-data.ts"
+      ],
+      "roles": ["Implementation", "Verification"],
+      "verify": ["npm run typecheck", "npm test", "npm run lint"],
+      "acceptance": [
+        "Unrouted ProductDetail and unused mock-data are removed if nothing imports them.",
+        "If a supposedly dead file is still imported, stop and ask HUMAN.",
+        "No server/ changes."
+      ]
+    },
+    {
+      "id": "S2",
+      "title": "Market e ListingCard",
+      "dependsOn": ["F0.4"],
+      "parallelGroup": "storefront-critical",
+      "ownerFiles": [
+        "src/pages/Products.tsx",
+        "src/components/ProductCard.tsx",
+        "src/components/__tests__/ListingCard.test.tsx"
+      ],
+      "roles": ["Implementation", "Test", "Verification"],
+      "verify": [
+        "npm test -- src/components/__tests__/ListingCard.test.tsx",
+        "npm run typecheck",
+        "npm run lint"
+      ],
+      "acceptance": [
+        "Filters unchanged: exterior, StatTrak, min/max price, client-side sort, pagination, ACTIVE.",
+        "Loading / empty / error states.",
+        "This PR owns ListingCard. Other agents must not edit it until merge."
+      ]
+    },
+    {
+      "id": "A1",
+      "title": "Login e registro",
+      "dependsOn": ["F0.4"],
+      "parallelGroup": "auth",
+      "ownerFiles": ["src/pages/Login.tsx", "src/pages/Register.tsx"],
+      "roles": ["Implementation", "Security", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint", "npm test"],
+      "acceptance": [
+        "Same auth API calls and role rules.",
+        "2-step email verification, CUSTOMER | SELLER, storeName, redirect from.",
+        "Do not change token/refresh/verify semantics."
+      ]
+    },
+    {
+      "id": "C1",
+      "title": "Carrinho e checkout (UX only)",
+      "dependsOn": ["F0.4"],
+      "parallelGroup": "checkout",
+      "ownerFiles": ["src/pages/CartPage.tsx", "src/pages/Checkout.tsx"],
+      "roles": ["Implementation", "Test", "Security", "Verification"],
+      "verify": [
+        "npm test -- src/contexts/__tests__/CartContext.test.tsx",
+        "npm run typecheck",
+        "npm run lint"
+      ],
+      "acceptance": [
+        "Empty cart and CUSTOMER-only pay gate unchanged.",
+        "createOrder + createPaymentLink unchanged.",
+        "Copy must not claim payment succeeded before PayPal return."
+      ]
+    },
+    {
+      "id": "S1",
+      "title": "Home Neon Arsenal",
+      "dependsOn": ["S2"],
+      "ownerFiles": ["src/pages/Index.tsx"],
+      "roles": ["Implementation", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint", "npm test"],
+      "acceptance": [
+        "Still fetches ACTIVE listings limit 8.",
+        "Loading / empty / error.",
+        "No new sections or routes.",
+        "Consumes ListingCard; do not edit the card."
+      ]
+    },
+    {
+      "id": "S3",
+      "title": "Detalhe do listing",
+      "dependsOn": ["S2"],
+      "ownerFiles": ["src/pages/ListingDetail.tsx"],
+      "roles": ["Implementation", "Test", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint", "npm test"],
+      "acceptance": [
+        "Keep rarity, float, pattern, StatTrak, seller, trade lock, price, history, related, add to cart.",
+        "Unavailable / trade-lock / not found remain non-purchasable when already disabled.",
+        "Do not edit ListingCard except a trivial import."
+      ]
+    },
+    {
+      "id": "D1",
+      "title": "Dashboard seller",
+      "dependsOn": ["S1", "S3", "A1", "C1"],
+      "parallelGroup": "dashboards",
+      "ownerFiles": [
+        "src/pages/SellerDashboard.tsx",
+        "src/pages/seller/SellerListings.tsx",
+        "src/pages/seller/SellerProducts.tsx",
+        "src/pages/seller/SellerOrders.tsx"
+      ],
+      "roles": ["Implementation", "Test", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint", "npm test"],
+      "acceptance": [
+        "Both seller routes remain.",
+        "Listings stays unique-item CRUD.",
+        "Products becomes read-only catalog (listProducts). Stop duplicate listing CRUD.",
+        "Do not edit Header or DashboardLayout."
+      ]
+    },
+    {
+      "id": "D2",
+      "title": "Dashboard admin",
+      "dependsOn": ["S1", "S3", "A1", "C1"],
+      "parallelGroup": "dashboards",
+      "ownerFiles": [
+        "src/pages/AdminDashboard.tsx",
+        "src/pages/admin/AdminSellers.tsx",
+        "src/pages/admin/AdminOrders.tsx",
+        "src/pages/admin/AdminUsers.tsx"
+      ],
+      "roles": ["Implementation", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint", "npm test"],
+      "acceptance": [
+        "adminApproveSeller and current lists unchanged in contract.",
+        "No new admin actions.",
+        "Do not edit Header or DashboardLayout."
+      ]
+    },
+    {
+      "id": "Q1",
+      "title": "Estados vazios e acessibilidade",
+      "dependsOn": ["D1", "D2"],
+      "ownerFiles": [],
+      "roles": ["Implementation", "Verification"],
+      "verify": ["npm run typecheck", "npm run lint", "npm test"],
+      "acceptance": [
+        "Every existing route has loading, empty, error, disabled where applicable.",
+        "Focus, labels, contrast, 44px mobile targets, dialog/menu aria.",
+        "No new features."
+      ]
+    },
+    {
+      "id": "Q2",
+      "title": "Testes de contrato da UI",
+      "dependsOn": ["Q1"],
+      "ownerFiles": [
+        "src/components/__tests__/ListingCard.test.tsx",
+        "src/contexts/__tests__/CartContext.test.tsx"
+      ],
+      "roles": ["Test", "Verification"],
+      "verify": ["npm test", "npm run typecheck", "npm run lint"],
+      "acceptance": [
+        "ListingCard and CartContext coverage remain meaningful.",
+        "Root npm test passes."
+      ]
+    },
+    {
+      "id": "Q3",
+      "title": "Passada visual desktop/mobile",
+      "dependsOn": ["Q2"],
+      "ownerFiles": [],
+      "roles": ["Verification"],
+      "verify": [
+        "npm run typecheck",
+        "npm run lint",
+        "npm test",
+        "browser walkthrough"
+      ],
+      "acceptance": [
+        "Browser walkthrough of home, market, listing, cart, login, seller listings, admin sellers.",
+        "No leftover SKINMARKET / scan-lines / neon-text in src/."
+      ]
+    }
+  ]
+}

--- a/scripts/p-front/create-issues.py
+++ b/scripts/p-front/create-issues.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Optional: create GitHub issues from scripts/p-front/activities.json.
+
+This Cloud Agent cannot create issues (gh is read-only here).
+Run on a machine with write access:
+
+  python3 scripts/p-front/create-issues.py --dry-run
+  python3 scripts/p-front/create-issues.py
+
+Idempotent: skips an activity if an open or closed issue already
+has "[P-front] <ID>" in the title.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTIVITIES_PATH = Path(__file__).resolve().parent / "activities.json"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=ROOT, text=True, capture_output=True)
+
+
+def existing_titles() -> set[str]:
+    result = run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "200",
+            "--json",
+            "title",
+        ]
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr or "gh issue list failed")
+    return {item["title"] for item in json.loads(result.stdout)}
+
+
+def issue_body(activity: dict, catalog: dict) -> str:
+    deps = ", ".join(activity.get("dependsOn") or []) or "none"
+    files = "\n".join(f"- `{path}`" for path in activity.get("ownerFiles") or [])
+    acceptance = "\n".join(f"- [ ] {item}" for item in activity.get("acceptance") or [])
+    verify = "\n".join(f"- `{cmd}`" for cmd in activity.get("verify") or [])
+    roles = ", ".join(activity.get("roles") or [])
+    return f"""## Objective
+{activity["title"]}
+
+## Sprint
+P-front. Source of truth: `docs/frontend-sprint.md` and `scripts/p-front/activities.json`.
+Prefer the orchestrator (`python3 scripts/p-front/next.py`) over hand-picking issues.
+
+## Locked decisions
+- {catalog["lockedDecisions"]["brand"]}
+- {catalog["lockedDecisions"]["visual"]}
+- {catalog["lockedDecisions"]["seller"]}
+
+## Depends on
+{deps}
+
+## Scope files
+{files or "- (see sprint doc)"}
+
+## Out of scope
+- `server/`
+- New routes, endpoints, fields, or features
+- Auth / payment / reservation semantics
+
+## Acceptance criteria
+{acceptance}
+
+## Verify
+{verify}
+
+## Required review
+{roles}
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--label", default="enhancement")
+    args = parser.parse_args()
+
+    catalog = json.loads(ACTIVITIES_PATH.read_text(encoding="utf-8"))
+    titles = existing_titles()
+    created = 0
+    skipped = 0
+
+    parent_title = "[P-front] Redesign frontend — Neon Arsenal, dark editorial, sem feature nova"
+    if parent_title not in titles and not args.dry_run:
+        body = f"""## Objective
+Refazer o frontend existente com marca Neon Arsenal e visual dark editorial, sem adicionar funcionalidade.
+
+## Execution
+Do not paste activities by hand. After this issue exists, agents run:
+
+```text
+python3 scripts/p-front/next.py --prompt
+```
+
+and implement only the printed activity.
+
+## Locked decisions
+- {catalog["lockedDecisions"]["brand"]}
+- {catalog["lockedDecisions"]["visual"]}
+- {catalog["lockedDecisions"]["seller"]}
+
+## Source of truth
+- `docs/frontend-sprint.md`
+- `docs/agents/p-front-orchestrator.md`
+- `scripts/p-front/activities.json`
+"""
+        result = run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                parent_title,
+                "--body",
+                body,
+                "--label",
+                args.label,
+            ]
+        )
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            return result.returncode
+        print(result.stdout.strip())
+        created += 1
+    else:
+        skipped += 1
+        print(f"skip parent ({'exists' if parent_title in titles else 'dry-run'})")
+
+    for activity in catalog["activities"]:
+        title = f"[P-front] {activity['id']} — {activity['title']}"
+        if title in titles:
+            print(f"skip {activity['id']} (exists)")
+            skipped += 1
+            continue
+        body = issue_body(activity, catalog)
+        if args.dry_run:
+            print(f"dry-run {title}")
+            skipped += 1
+            continue
+        result = run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                args.label,
+            ]
+        )
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            return result.returncode
+        print(result.stdout.strip())
+        created += 1
+
+    print(f"created={created} skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p-front/next.py
+++ b/scripts/p-front/next.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Pick the next unblocked P-front activity from git history and open PRs.
+
+Done  = commit on origin/main whose subject contains "[P-front] <ID>"
+Busy  = open PR whose title contains "[P-front] <ID>"
+Next  = first activity whose dependsOn are all done and which is not done/busy
+
+Usage:
+  python3 scripts/p-front/next.py
+  python3 scripts/p-front/next.py --json
+  python3 scripts/p-front/next.py --prompt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTIVITIES_PATH = Path(__file__).resolve().parent / "activities.json"
+
+
+def run(args: list[str]) -> str:
+    result = subprocess.run(args, cwd=ROOT, text=True, capture_output=True)
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def load_catalog() -> dict:
+    return json.loads(ACTIVITIES_PATH.read_text(encoding="utf-8"))
+
+
+def marker(activity_id: str) -> str:
+    return f"[P-front] {activity_id}"
+
+
+def done_ids() -> set[str]:
+    log = run(["git", "log", "origin/main", "--pretty=%s"])
+    found: set[str] = set()
+    catalog = load_catalog()
+    for activity in catalog["activities"]:
+        if marker(activity["id"]) in log:
+            found.add(activity["id"])
+    return found
+
+
+def busy_ids() -> dict[str, str]:
+    raw = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "50",
+            "--json",
+            "title,url,number",
+        ]
+    )
+    busy: dict[str, str] = {}
+    if not raw.strip():
+        return busy
+    try:
+        prs = json.loads(raw)
+    except json.JSONDecodeError:
+        return busy
+    catalog = load_catalog()
+    for activity in catalog["activities"]:
+        token = marker(activity["id"])
+        for pr in prs:
+            title = pr.get("title") or ""
+            if token in title:
+                busy[activity["id"]] = pr.get("url") or f"#{pr.get('number')}"
+    return busy
+
+
+def select_next(catalog: dict, done: set[str], busy: dict[str, str]) -> list[dict]:
+    ready: list[dict] = []
+    for activity in catalog["activities"]:
+        activity_id = activity["id"]
+        if activity_id in done or activity_id in busy:
+            continue
+        deps = set(activity.get("dependsOn") or [])
+        if deps <= done:
+            ready.append(activity)
+    return ready
+
+
+def agent_prompt(activity: dict, catalog: dict) -> str:
+    owner = "\n".join(f"- {path}" for path in activity.get("ownerFiles") or ["(see sprint doc)"])
+    acceptance = "\n".join(f"- {item}" for item in activity.get("acceptance") or [])
+    verify = "\n".join(f"- `{cmd}`" for cmd in activity.get("verify") or [])
+    return f"""Execute SOMENTE a atividade {activity["id"]} — {activity["title"]}.
+
+Obrigatório ler, nesta ordem:
+1. AGENTS.md
+2. docs/agents/README.md
+3. docs/agents/roles.md
+4. docs/agents/context-policy.md
+5. docs/agents/decision-policy.md
+6. docs/agents/execution-protocol.md
+7. docs/architecture/domain-invariants.md
+8. docs/frontend-sprint.md
+9. docs/agents/p-front-orchestrator.md
+10. só os arquivos do escopo abaixo
+
+Decisões travadas:
+- {catalog["lockedDecisions"]["brand"]}
+- {catalog["lockedDecisions"]["visual"]}
+- {catalog["lockedDecisions"]["seller"]}
+
+Arquivos desta atividade:
+{owner}
+
+Não pode:
+- editar server/
+- nova rota, endpoint, campo ou feature
+- enfraquecer auth, CORS, rate limit ou testes
+- começar outra atividade no mesmo PR
+
+Critérios de aceite:
+{acceptance}
+
+Verificação:
+{verify}
+
+Branch: cursor/p-front-{activity["id"].lower().replace(".", "")}-ef90
+Título do PR: [P-front] {activity["id"]} — {activity["title"]}
+PR draft até Verification PASS. Não mergear. Não fechar issue.
+Handoff no formato docs/agents/handoff-template.md.
+Parar quando os critérios de aceite estiverem provados.
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--prompt", action="store_true")
+    args = parser.parse_args()
+
+    catalog = load_catalog()
+    done = done_ids()
+    busy = busy_ids()
+    ready = select_next(catalog, done, busy)
+
+    payload = {
+        "done": sorted(done),
+        "inProgress": busy,
+        "ready": [
+            {
+                "id": item["id"],
+                "title": item["title"],
+                "parallelGroup": item.get("parallelGroup"),
+            }
+            for item in ready
+        ],
+        "next": ready[0] if ready else None,
+        "complete": not ready and len(done) == len(catalog["activities"]),
+    }
+
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+
+    if payload["complete"]:
+        print("P-front complete. No remaining activities.")
+        return 0
+
+    if not ready:
+        print("No unblocked activity. Waiting on in-progress work:")
+        for activity_id, url in busy.items():
+            print(f"  {activity_id}: {url}")
+        return 2
+
+    nxt = ready[0]
+    if args.prompt:
+        sys.stdout.write(agent_prompt(nxt, catalog))
+        return 0
+
+    print(f"next: {nxt['id']} — {nxt['title']}")
+    if len(ready) > 1:
+        extras = ", ".join(f"{item['id']} ({item['title']})" for item in ready[1:])
+        print(f"also unblocked (parallel if files are disjoint): {extras}")
+    if done:
+        print("done: " + ", ".join(sorted(done)))
+    if busy:
+        print("in progress: " + ", ".join(f"{k}={v}" for k, v in busy.items()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Stop opening fifteen GitHub issues by hand. The P-front rebuild is now a versioned backlog plus a picker that tells the next Cloud Agent exactly what to do.

## Locked decisions (already in the repo)

- Brand: **Neon Arsenal**
- Visual: **dark editorial**
- Seller: keep both routes. Listings = unique-item CRUD. Products = read-only catalog (`listProducts`). No seller Product writes (ADMIN-only API).

## What you do after merge

1. Open a Cloud Agent (or this same chat).
2. Send only: `next`
3. Review the draft PR.
4. Merge (keep the `[P-front] <ID>` prefix if you squash).
5. Repeat.

Optional, on your machine if you still want GitHub issues:

```bash
python3 scripts/p-front/create-issues.py
```

This environment cannot create issues (`gh` is read-only).

## Verification

- `python3 scripts/p-front/next.py` → `F0.1` while this is unmerged; after merge it should advance to `F0.2`
- `python3 scripts/p-front/create-issues.py --dry-run` lists all activities without writing
- `select_next` assertions for F0.1 and the S2/A1/C1 wave
- Client + server `tsc --noEmit` via pre-commit

## Out of scope

No `src/` or `server/` product-code changes in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

