### PR TITLE
[P-front] F0.2 — Tokens e tema dark editorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SkinMarket — Marketplace Gamer</title>
-    <meta name="description" content="O marketplace definitivo para skins, contas e serviços de CS." />
+    <title>Neon Arsenal</title>
+    <meta name="description" content="Marketplace de skins CS2. Listings únicos, reserva e pagamento." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,51 +1,50 @@
-@import url('https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
-    --background: 222 25% 6%;
-    --foreground: 180 10% 92%;
-    --card: 222 20% 10%;
-    --card-foreground: 180 10% 92%;
-    --popover: 222 20% 12%;
-    --popover-foreground: 180 10% 92%;
-    --primary: 145 100% 42%;
-    --primary-foreground: 222 25% 6%;
-    --secondary: 25 100% 55%;
-    --secondary-foreground: 0 0% 100%;
-    --muted: 222 15% 16%;
-    --muted-foreground: 222 10% 55%;
-    --accent: 25 100% 55%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 84% 60%;
+    /* Near-black canvas, one brass accent — dark editorial, not neon. */
+    --background: 240 6% 4.5%;
+    --foreground: 40 8% 93%;
+    --card: 240 5% 7%;
+    --card-foreground: 40 8% 93%;
+    --popover: 240 5% 8.5%;
+    --popover-foreground: 40 8% 93%;
+    --primary: 38 42% 56%;
+    --primary-foreground: 240 6% 6%;
+    --secondary: 240 4% 13%;
+    --secondary-foreground: 40 8% 92%;
+    --muted: 240 4% 12%;
+    --muted-foreground: 240 4% 58%;
+    --accent: 38 22% 16%;
+    --accent-foreground: 38 36% 78%;
+    --destructive: 4 72% 48%;
     --destructive-foreground: 0 0% 100%;
-    --border: 222 15% 18%;
-    --input: 222 15% 14%;
-    --ring: 145 100% 42%;
-    --radius: 0.5rem;
+    --border: 240 4% 14%;
+    --input: 240 4% 11%;
+    --ring: 38 42% 56%;
+    --radius: 0.375rem;
 
-    --rank-bronze: 25 70% 40%;
-    --rank-silver: 220 10% 70%;
-    --rank-gold: 45 90% 55%;
-    --rank-elite: 145 100% 42%;
+    --rank-bronze: 25 42% 44%;
+    --rank-silver: 220 6% 62%;
+    --rank-gold: 42 52% 50%;
+    --rank-elite: 38 42% 56%;
 
-    --rarity-common: 220 10% 50%;
-    --rarity-uncommon: 210 70% 55%;
-    --rarity-rare: 270 70% 60%;
-    --rarity-epic: 320 70% 55%;
-    --rarity-legendary: 40 95% 55%;
+    --rarity-common: 220 6% 52%;
+    --rarity-uncommon: 200 28% 48%;
+    --rarity-rare: 262 28% 56%;
+    --rarity-epic: 312 26% 52%;
+    --rarity-legendary: 40 58% 50%;
 
-    --sidebar-background: 222 25% 8%;
-    --sidebar-foreground: 180 10% 85%;
-    --sidebar-primary: 145 100% 42%;
-    --sidebar-primary-foreground: 222 25% 6%;
-    --sidebar-accent: 222 15% 14%;
-    --sidebar-accent-foreground: 180 10% 92%;
-    --sidebar-border: 222 15% 15%;
-    --sidebar-ring: 145 100% 42%;
+    --sidebar-background: 240 6% 5.5%;
+    --sidebar-foreground: 40 6% 86%;
+    --sidebar-primary: 38 42% 56%;
+    --sidebar-primary-foreground: 240 6% 6%;
+    --sidebar-accent: 240 4% 12%;
+    --sidebar-accent-foreground: 40 8% 93%;
+    --sidebar-border: 240 4% 13%;
+    --sidebar-ring: 38 42% 56%;
   }
 }
 
@@ -53,77 +52,102 @@
   * {
     @apply border-border;
   }
+
+  html {
+    @apply bg-background text-foreground antialiased;
+  }
+
   body {
     @apply bg-background text-foreground;
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: Geist, ui-sans-serif, system-ui, sans-serif;
+    font-feature-settings: "ss01" on, "cv11" on;
   }
-  h1, h2, h3, h4, h5, h6 {
-    font-family: 'Chakra Petch', sans-serif;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: Geist, ui-sans-serif, system-ui, sans-serif;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    text-transform: none;
   }
 }
 
-/* Custom scrollbar */
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: hsl(var(--background)); }
-::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: hsl(var(--primary) / 0.5); }
-
-/* Scan line overlay */
-.scan-lines::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    0deg,
-    transparent,
-    transparent 2px,
-    hsl(var(--primary) / 0.03) 2px,
-    hsl(var(--primary) / 0.03) 4px
-  );
-  pointer-events: none;
+@layer utilities {
+  .tabular-price,
+  .tabular-float {
+    font-variant-numeric: tabular-nums lining-nums;
+  }
 }
 
-/* Neon text glow */
-.neon-text {
-  text-shadow: 0 0 10px hsl(var(--primary) / 0.6), 0 0 40px hsl(var(--primary) / 0.2);
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: hsl(var(--background));
+}
+::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.45);
 }
 
-/* Orange text glow */
-.orange-text {
-  text-shadow: 0 0 10px hsl(var(--secondary) / 0.6), 0 0 40px hsl(var(--secondary) / 0.2);
+/* Rank and rarity stay as status signals — flat tint, no glow. */
+.rank-bronze {
+  color: hsl(var(--rank-bronze));
+  background: hsl(var(--rank-bronze) / 0.12);
+  border-color: hsl(var(--rank-bronze) / 0.35);
+}
+.rank-silver {
+  color: hsl(var(--rank-silver));
+  background: hsl(var(--rank-silver) / 0.12);
+  border-color: hsl(var(--rank-silver) / 0.35);
+}
+.rank-gold {
+  color: hsl(var(--rank-gold));
+  background: hsl(var(--rank-gold) / 0.12);
+  border-color: hsl(var(--rank-gold) / 0.35);
+}
+.rank-elite {
+  color: hsl(var(--rank-elite));
+  background: hsl(var(--rank-elite) / 0.12);
+  border-color: hsl(var(--rank-elite) / 0.35);
 }
 
-/* Grid pattern */
-.grid-pattern {
-  background-image:
-    linear-gradient(hsl(var(--primary) / 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, hsl(var(--primary) / 0.05) 1px, transparent 1px);
-  background-size: 40px 40px;
+.rarity-bg-common {
+  background: hsl(var(--rarity-common) / 0.12);
+}
+.rarity-bg-uncommon {
+  background: hsl(var(--rarity-uncommon) / 0.12);
+}
+.rarity-bg-rare {
+  background: hsl(var(--rarity-rare) / 0.12);
+}
+.rarity-bg-epic {
+  background: hsl(var(--rarity-epic) / 0.12);
+}
+.rarity-bg-legendary {
+  background: hsl(var(--rarity-legendary) / 0.14);
 }
 
-/* Rank badge styles */
-.rank-bronze { color: hsl(var(--rank-bronze)); background: hsl(var(--rank-bronze) / 0.1); border-color: hsl(var(--rank-bronze) / 0.3); }
-.rank-silver { color: hsl(var(--rank-silver)); background: hsl(var(--rank-silver) / 0.1); border-color: hsl(var(--rank-silver) / 0.3); }
-.rank-gold { color: hsl(var(--rank-gold)); background: hsl(var(--rank-gold) / 0.1); border-color: hsl(var(--rank-gold) / 0.3); }
-.rank-elite { color: hsl(var(--rank-elite)); background: hsl(var(--rank-elite) / 0.1); border-color: hsl(var(--rank-elite) / 0.3); }
-
-/* Rarity backgrounds */
-.rarity-bg-common { background: linear-gradient(135deg, hsl(var(--rarity-common) / 0.25), hsl(var(--rarity-common) / 0.05)); }
-.rarity-bg-uncommon { background: linear-gradient(135deg, hsl(var(--rarity-uncommon) / 0.25), hsl(var(--rarity-uncommon) / 0.05)); }
-.rarity-bg-rare { background: linear-gradient(135deg, hsl(var(--rarity-rare) / 0.25), hsl(var(--rarity-rare) / 0.05)); }
-.rarity-bg-epic { background: linear-gradient(135deg, hsl(var(--rarity-epic) / 0.25), hsl(var(--rarity-epic) / 0.05)); }
-.rarity-bg-legendary { background: linear-gradient(135deg, hsl(var(--rarity-legendary) / 0.35), hsl(var(--rarity-legendary) / 0.08)); }
-
-/* Rarity border top accents */
-.rarity-accent-common { border-top: 2px solid hsl(var(--rarity-common)); }
-.rarity-accent-uncommon { border-top: 2px solid hsl(var(--rarity-uncommon)); }
-.rarity-accent-rare { border-top: 2px solid hsl(var(--rarity-rare)); }
-.rarity-accent-epic { border-top: 2px solid hsl(var(--rarity-epic)); }
-.rarity-accent-legendary { border-top: 2px solid hsl(var(--rarity-legendary)); }
-
-/* Neon glow box shadow */
-.neon-glow { box-shadow: 0 0 15px hsl(var(--primary) / 0.3), 0 0 45px hsl(var(--primary) / 0.1); }
-.orange-glow { box-shadow: 0 0 15px hsl(var(--secondary) / 0.3), 0 0 45px hsl(var(--secondary) / 0.1); }
+.rarity-accent-common {
+  border-top: 2px solid hsl(var(--rarity-common));
+}
+.rarity-accent-uncommon {
+  border-top: 2px solid hsl(var(--rarity-uncommon));
+}
+.rarity-accent-rare {
+  border-top: 2px solid hsl(var(--rarity-rare));
+}
+.rarity-accent-epic {
+  border-top: 2px solid hsl(var(--rarity-epic));
+}
+.rarity-accent-legendary {
+  border-top: 2px solid hsl(var(--rarity-legendary));
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,9 +1,11 @@
 import type { Config } from "tailwindcss";
 import tailwindcssAnimate from "tailwindcss-animate";
 
+const geist = ["Geist", "ui-sans-serif", "system-ui", "sans-serif"];
+
 export default {
   darkMode: ["class"],
-  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}", "./index.html"],
   prefix: "",
   theme: {
     container: {
@@ -15,8 +17,9 @@ export default {
     },
     extend: {
       fontFamily: {
-        heading: ["Chakra Petch", "sans-serif"],
-        body: ["Inter", "system-ui", "sans-serif"],
+        sans: geist,
+        heading: geist,
+        body: geist,
       },
       colors: {
         border: "hsl(var(--border))",
@@ -62,8 +65,6 @@ export default {
           border: "hsl(var(--sidebar-border))",
           ring: "hsl(var(--sidebar-ring))",
         },
-        neon: "hsl(var(--primary))",
-        orange: "hsl(var(--secondary))",
       },
       borderRadius: {
         lg: "var(--radius)",
@@ -79,30 +80,10 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
-        "pulse-neon": {
-          "0%, 100%": { opacity: "1" },
-          "50%": { opacity: "0.5" },
-        },
-        float: {
-          "0%, 100%": { transform: "translateY(0)" },
-          "50%": { transform: "translateY(-10px)" },
-        },
-        "slide-up": {
-          "0%": { transform: "translateY(20px)", opacity: "0" },
-          "100%": { transform: "translateY(0)", opacity: "1" },
-        },
-        "scan": {
-          "0%": { transform: "translateY(-100%)" },
-          "100%": { transform: "translateY(100%)" },
-        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
-        "pulse-neon": "pulse-neon 2s ease-in-out infinite",
-        float: "float 3s ease-in-out infinite",
-        "slide-up": "slide-up 0.5s ease-out",
-        scan: "scan 3s linear infinite",
       },
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Activity

F0.2 — tokens and dark editorial theme. Next after merged F0.1 (#18).

## What changed

- `index.html`: title/description Neon Arsenal; Geist instead of Chakra Petch + Inter
- `src/index.css`: near-black canvas, one brass accent, no uppercase headings, no glow/scan-line/grid utilities
- `tailwind.config.ts`: `font-heading` / `font-sans` / `font-body` → Geist; removed neon/orange colors and gimmick animations
- Rarity/rank tokens stay as flat tints (functional signals)

Pages that still use `scan-lines` / `neon-text` / `SKINMARKET` compile; those class names are now no-ops until later activities restyle the screens.

## Out of scope

No `server/`. No page rewrites. No new routes.

## Verification

- `npm run typecheck` → pass (client `tsc --noEmit`)
- `npm run lint` → 0 errors (9 pre-existing warnings in untouched `ui/` + contexts)
- `npx vite build` → pass
- `rg Chakra|scan-lines|neon-glow` on owner files and `dist/` → no matches
- `python3 scripts/p-front/next.py` → F0.2 in progress on this PR

## After merge

Say `next` for F0.3 (shell / Header / layouts). Keep the `[P-front] F0.2` prefix if you squash.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

