### PR TITLE
[P-front] F0.3 — Shell, primitivos e chrome compartilhado

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
@@ -35,36 +34,91 @@ const App = () => (
         <CartProvider>
           <TooltipProvider>
             <Toaster />
-            <Sonner />
             <BrowserRouter>
-            <Routes>
-              <Route element={<MainLayout />}>
-                <Route path="/" element={<Index />} />
-                <Route path="/products" element={<Products />} />
-                <Route path="/listing/:id" element={<ListingDetail />} />
-                <Route path="/cart" element={<CartPage />} />
-                <Route path="/checkout" element={<Checkout />} />
-              </Route>
-              <Route path="/login" element={<Login />} />
-              <Route path="/register" element={<Register />} />
-              <Route
-                element={
-                  <ProtectedRoute>
-                    <DashboardLayout />
-                  </ProtectedRoute>
-                }
-              >
-                <Route path="/seller" element={<ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}><SellerDashboard /></ProtectedRoute>} />
-                <Route path="/seller/products" element={<ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}><SellerProducts /></ProtectedRoute>} />
-                <Route path="/seller/listings" element={<ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}><SellerListings /></ProtectedRoute>} />
-                <Route path="/seller/orders" element={<ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}><SellerOrders /></ProtectedRoute>} />
-                <Route path="/admin" element={<ProtectedRoute allowedRoles={["ADMIN"]}><AdminDashboard /></ProtectedRoute>} />
-                <Route path="/admin/sellers" element={<ProtectedRoute allowedRoles={["ADMIN"]}><AdminSellers /></ProtectedRoute>} />
-                <Route path="/admin/orders" element={<ProtectedRoute allowedRoles={["ADMIN"]}><AdminOrders /></ProtectedRoute>} />
-                <Route path="/admin/users" element={<ProtectedRoute allowedRoles={["ADMIN"]}><AdminUsers /></ProtectedRoute>} />
-              </Route>
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+              <Routes>
+                <Route element={<MainLayout />}>
+                  <Route path="/" element={<Index />} />
+                  <Route path="/products" element={<Products />} />
+                  <Route path="/listing/:id" element={<ListingDetail />} />
+                  <Route path="/cart" element={<CartPage />} />
+                  <Route path="/checkout" element={<Checkout />} />
+                </Route>
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
+                <Route
+                  element={
+                    <ProtectedRoute>
+                      <DashboardLayout />
+                    </ProtectedRoute>
+                  }
+                >
+                  <Route
+                    path="/seller"
+                    element={
+                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                        <SellerDashboard />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/seller/products"
+                    element={
+                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                        <SellerProducts />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/seller/listings"
+                    element={
+                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                        <SellerListings />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/seller/orders"
+                    element={
+                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                        <SellerOrders />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminDashboard />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/sellers"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminSellers />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/orders"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminOrders />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/users"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminUsers />
+                      </ProtectedRoute>
+                    }
+                  />
+                </Route>
+                <Route path="*" element={<NotFound />} />
+              </Routes>
             </BrowserRouter>
           </TooltipProvider>
         </CartProvider>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,73 +1,140 @@
-import { Link, useNavigate } from 'react-router-dom';
-import { ShoppingCart, User, Menu, X, Crosshair } from 'lucide-react';
-import { useState } from 'react';
-import { useCart } from '@/contexts/CartContext';
-import { useAuth } from '@/contexts/AuthContext';
-import { Button } from '@/components/ui/button';
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Menu, ShoppingCart, X } from "lucide-react";
+import { useState } from "react";
+import { useCart } from "@/contexts/CartContext";
+import { useAuth } from "@/contexts/AuthContext";
+import { Button } from "@/components/ui/button";
+
+function brandMark() {
+  return (
+    <Link to="/" className="flex items-center gap-2.5">
+      <span className="h-4 w-4 rounded-sm bg-primary" aria-hidden />
+      <span className="text-[15px] font-semibold tracking-tight text-foreground">
+        Neon Arsenal
+      </span>
+    </Link>
+  );
+}
 
 export function Header() {
   const { totalItems } = useCart();
   const { user, logout, isAuthenticated } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const navLinks = [
-    { to: '/', label: 'Home' },
-    { to: '/products', label: 'Market' },
-    ...(user?.role === 'SELLER' ? [{ to: '/seller', label: 'Dashboard' }] : []),
-    ...(user?.role === 'ADMIN' ? [{ to: '/admin', label: 'Admin' }] : []),
+    { to: "/", label: "Home" },
+    { to: "/products", label: "Market" },
+    ...(user?.role === "SELLER" ? [{ to: "/seller", label: "Dashboard" }] : []),
+    ...(user?.role === "ADMIN" ? [{ to: "/admin", label: "Admin" }] : []),
   ];
 
-  return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background/90 backdrop-blur-md">
-      <div className="container flex h-16 items-center justify-between">
-        <Link to="/" className="flex items-center gap-2">
-          <Crosshair className="h-6 w-6 text-primary" />
-          <span className="font-heading text-xl text-primary neon-text tracking-wider">SKINMARKET</span>
-        </Link>
+  const linkClass = (to: string) => {
+    const active =
+      to === "/" ? location.pathname === "/" : location.pathname.startsWith(to);
+    return `text-sm transition-colors ${
+      active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+    }`;
+  };
 
-        <nav className="hidden md:flex items-center gap-6">
-          {navLinks.map(l => (
-            <Link key={l.to} to={l.to} className="text-sm text-muted-foreground hover:text-primary transition-colors font-medium">
-              {l.label}
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <div className="container flex h-14 items-center justify-between">
+        {brandMark()}
+
+        <nav
+          className="hidden items-center gap-6 md:flex"
+          aria-label="Principal"
+        >
+          {navLinks.map((item) => (
+            <Link key={item.to} to={item.to} className={linkClass(item.to)}>
+              {item.label}
             </Link>
           ))}
         </nav>
 
-        <div className="flex items-center gap-3">
-          <Link to="/cart" className="relative p-2 hover:text-primary transition-colors text-muted-foreground">
-            <ShoppingCart className="h-5 w-5" />
+        <div className="flex items-center gap-1.5">
+          <Link
+            to="/cart"
+            className="relative rounded-md p-2 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label={
+              totalItems > 0 ? `Carrinho, ${totalItems} itens` : "Carrinho"
+            }
+          >
+            <ShoppingCart className="h-4 w-4" />
             {totalItems > 0 && (
-              <span className="absolute -top-0.5 -right-0.5 bg-secondary text-secondary-foreground text-[10px] rounded-full h-5 w-5 flex items-center justify-center font-bold">
+              <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
                 {totalItems}
               </span>
             )}
           </Link>
 
           {isAuthenticated ? (
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground hidden sm:inline">{user?.name}</span>
-              <Button variant="ghost" size="sm" onClick={logout}>Sair</Button>
+            <div className="hidden items-center gap-2 sm:flex">
+              <span className="max-w-[10rem] truncate text-sm text-muted-foreground">
+                {user?.name}
+              </span>
+              <Button variant="ghost" size="sm" onClick={logout}>
+                Sair
+              </Button>
             </div>
           ) : (
-            <Button size="sm" onClick={() => navigate('/login')}>
-              <User className="h-4 w-4 mr-1" /> Login
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => navigate("/login")}
+            >
+              Login
             </Button>
           )}
 
-          <Button variant="ghost" size="icon" className="md:hidden" onClick={() => setMenuOpen(!menuOpen)}>
-            {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            aria-expanded={menuOpen}
+            aria-controls="mobile-nav"
+            onClick={() => setMenuOpen((open) => !open)}
+          >
+            {menuOpen ? (
+              <X className="h-4 w-4" />
+            ) : (
+              <Menu className="h-4 w-4" />
+            )}
+            <span className="sr-only">Menu</span>
           </Button>
         </div>
       </div>
 
       {menuOpen && (
-        <nav className="md:hidden border-t border-border p-4 space-y-1 bg-background">
-          {navLinks.map(l => (
-            <Link key={l.to} to={l.to} className="block text-sm text-muted-foreground hover:text-primary py-2 px-3 rounded-md hover:bg-muted transition-colors" onClick={() => setMenuOpen(false)}>
-              {l.label}
+        <nav
+          id="mobile-nav"
+          className="space-y-1 border-t border-border bg-background p-3 md:hidden"
+          aria-label="Principal"
+        >
+          {navLinks.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              className={`block rounded-md px-3 py-2.5 text-sm ${linkClass(item.to)}`}
+              onClick={() => setMenuOpen(false)}
+            >
+              {item.label}
             </Link>
           ))}
+          {isAuthenticated ? (
+            <button
+              type="button"
+              className="block w-full rounded-md px-3 py-2.5 text-left text-sm text-muted-foreground"
+              onClick={() => {
+                logout();
+                setMenuOpen(false);
+              }}
+            >
+              Sair
+            </button>
+          ) : null}
         </nav>
       )}
     </header>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
+import { PageSkeleton } from "@/components/page-state";
 import type { Role } from "@/types/api";
 
 interface ProtectedRouteProps {
@@ -7,26 +8,31 @@ interface ProtectedRouteProps {
   allowedRoles?: Role[];
 }
 
-export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) {
+export function ProtectedRoute({
+  children,
+  allowedRoles,
+}: ProtectedRouteProps) {
   const { user, isAuthenticated, isLoading } = useAuth();
   const location = useLocation();
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <p className="text-muted-foreground">Carregando...</p>
-      </div>
-    );
+    return <PageSkeleton />;
   }
 
   if (!isAuthenticated || !user) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
-  if (allowedRoles && allowedRoles.length > 0 && !allowedRoles.includes(user.role)) {
+  if (
+    allowedRoles &&
+    allowedRoles.length > 0 &&
+    !allowedRoles.includes(user.role)
+  ) {
     return (
       <div className="container py-20 text-center">
-        <p className="text-muted-foreground font-heading text-xl">Acesso negado.</p>
+        <p className="text-muted-foreground font-heading text-xl">
+          Acesso negado.
+        </p>
       </div>
     );
   }

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,9 @@
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-border">
+      <div className="container py-6 text-sm text-muted-foreground">
+        Neon Arsenal
+      </div>
+    </footer>
+  );
+}

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Header } from "../Header";
+import type { User } from "@/types/api";
+
+const authState = {
+  user: null as User | null,
+  isAuthenticated: false,
+  logout: vi.fn(),
+};
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/contexts/CartContext", () => ({
+  useCart: () => ({ totalItems: 0 }),
+}));
+
+function renderHeader(path = "/") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Header />
+    </MemoryRouter>,
+  );
+}
+
+describe("Header", () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.logout.mockReset();
+  });
+
+  it("shows Neon Arsenal brand and storefront links", () => {
+    renderHeader();
+    expect(screen.getAllByText("Neon Arsenal").length).toBeGreaterThan(0);
+    expect(screen.getByText("Home")).toBeTruthy();
+    expect(screen.getByText("Market")).toBeTruthy();
+    expect(screen.getByText("Login")).toBeTruthy();
+    expect(screen.queryByText("SKINMARKET")).toBeNull();
+  });
+
+  it("shows Dashboard for a seller", () => {
+    authState.user = {
+      id: "s1",
+      name: "Seller",
+      email: "seller@test.com",
+      role: "SELLER",
+    };
+    authState.isAuthenticated = true;
+    renderHeader();
+    expect(screen.getByText("Dashboard")).toBeTruthy();
+    expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.getByText("Sair")).toBeTruthy();
+  });
+
+  it("shows Admin for an admin", () => {
+    authState.user = {
+      id: "a1",
+      name: "Admin",
+      email: "admin@test.com",
+      role: "ADMIN",
+    };
+    authState.isAuthenticated = true;
+    renderHeader();
+    expect(screen.getByText("Admin")).toBeTruthy();
+    expect(screen.queryByText("Dashboard")).toBeNull();
+  });
+});

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -65,7 +65,10 @@ describe("Header", () => {
     };
     authState.isAuthenticated = true;
     renderHeader();
-    expect(screen.getByText("Admin")).toBeTruthy();
-    expect(screen.queryByText("Dashboard")).toBeNull();
+    expect(screen.getByRole("link", { name: "Admin" })).toHaveAttribute(
+      "href",
+      "/admin",
+    );
+    expect(screen.queryByRole("link", { name: "Dashboard" })).toBeNull();
   });
 });

--- a/src/components/page-state.tsx
+++ b/src/components/page-state.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type Action = ReactNode;
+
+export function PageSkeleton({ label = "Carregando" }: { label?: string }) {
+  return (
+    <div className="container space-y-4 py-10" role="status" aria-label={label}>
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-4 w-80 max-w-full" />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    </div>
+  );
+}
+
+export function EmptyState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: Action;
+}) {
+  return (
+    <div className="mx-auto max-w-md py-16 text-center">
+      <h2 className="text-lg font-semibold tracking-tight text-foreground">
+        {title}
+      </h2>
+      {description ? (
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      ) : null}
+      {action ? <div className="mt-6">{action}</div> : null}
+    </div>
+  );
+}
+
+export function ErrorState({
+  title = "Algo deu errado",
+  description,
+  action,
+}: {
+  title?: string;
+  description?: string;
+  action?: Action;
+}) {
+  return (
+    <div className="mx-auto max-w-md py-16 text-center">
+      <h2 className="text-lg font-semibold tracking-tight text-foreground">
+        {title}
+      </h2>
+      {description ? (
+        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      ) : null}
+      {action ? <div className="mt-6">{action}</div> : null}
+    </div>
+  );
+}

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -1,13 +1,23 @@
+import { useState } from "react";
 import { Outlet, useLocation, Link } from "react-router-dom";
-import { Header } from "@/components/Header";
 import {
   BarChart3,
+  Menu,
   Package,
   ShoppingBag,
   Users,
   Shield,
   Tag,
 } from "lucide-react";
+import { Header } from "@/components/Header";
+import { SiteFooter } from "@/components/SiteFooter";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 const sellerItems = [
   { icon: BarChart3, label: "Visão Geral", href: "/seller" },
@@ -23,37 +33,89 @@ const adminItems = [
   { icon: Shield, label: "Usuários", href: "/admin/users" },
 ];
 
+function isActive(pathname: string, href: string) {
+  if (href === "/seller" || href === "/admin") return pathname === href;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function NavItems({
+  items,
+  pathname,
+  onNavigate,
+}: {
+  items: typeof sellerItems;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <nav className="space-y-1" aria-label="Painel">
+      {items.map((item) => {
+        const active = isActive(pathname, item.href);
+        return (
+          <Link
+            key={item.href}
+            to={item.href}
+            onClick={onNavigate}
+            className={`flex min-h-11 items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors ${
+              active
+                ? "bg-secondary text-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+            }`}
+          >
+            <item.icon className="h-4 w-4 shrink-0" />
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
 export default function DashboardLayout() {
   const location = useLocation();
   const isAdmin = location.pathname.startsWith("/admin");
   const items = isAdmin ? adminItems : sellerItems;
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <Header />
-      <div className="flex">
-        <aside className="hidden lg:flex w-56 flex-col border-r border-border sticky top-16 h-[calc(100vh-4rem)] p-4">
-          <nav className="space-y-1">
-            {items.map((item) => (
-              <Link
-                key={item.label}
-                to={item.href}
-                className={`flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium transition-colors ${
-                  location.pathname === item.href
-                    ? "bg-primary/10 text-primary"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
-                }`}
-              >
-                <item.icon className="h-4 w-4" />
-                {item.label}
-              </Link>
-            ))}
-          </nav>
+      <div className="flex flex-1">
+        <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r border-border p-4 lg:flex lg:flex-col">
+          <NavItems items={items} pathname={location.pathname} />
         </aside>
-        <main className="flex-1 p-6">
-          <Outlet />
-        </main>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="border-b border-border px-4 py-2 lg:hidden">
+            <Button
+              variant="outline"
+              size="sm"
+              className="min-h-11"
+              onClick={() => setOpen(true)}
+            >
+              <Menu className="mr-2 h-4 w-4" />
+              Menu do painel
+            </Button>
+            <Sheet open={open} onOpenChange={setOpen}>
+              <SheetContent side="left" className="w-72">
+                <SheetHeader>
+                  <SheetTitle>{isAdmin ? "Admin" : "Dashboard"}</SheetTitle>
+                </SheetHeader>
+                <div className="mt-4">
+                  <NavItems
+                    items={items}
+                    pathname={location.pathname}
+                    onNavigate={() => setOpen(false)}
+                  />
+                </div>
+              </SheetContent>
+            </Sheet>
+          </div>
+          <main className="flex-1 p-6">
+            <Outlet />
+          </main>
+        </div>
       </div>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,13 +1,15 @@
-import { Outlet } from 'react-router-dom';
-import { Header } from '@/components/Header';
+import { Outlet } from "react-router-dom";
+import { Header } from "@/components/Header";
+import { SiteFooter } from "@/components/SiteFooter";
 
 export default function MainLayout() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex min-h-screen flex-col bg-background">
       <Header />
-      <main>
+      <main className="flex-1">
         <Outlet />
       </main>
+      <SiteFooter />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Activity

F0.3 — shared chrome after merged F0.2 (#19).

## What changed

- Header: Neon Arsenal wordmark; Home / Market / Dashboard / Admin / cart / login / logout unchanged
- Main + dashboard layouts share footer chrome
- Dashboard mobile nav via Sheet (`Menu do painel`) — sidebar still `lg+`
- `EmptyState` / `ErrorState` / `PageSkeleton` for later screens
- Single toast: keep `Toaster` (`useToast` is used). Remove unused Sonner from `App.tsx`
- ProtectedRoute loading uses `PageSkeleton` (redirect/role rules unchanged)

## Out of scope

No `server/`. No new routes. Login/register pages are A1.

## Verification

- `npm test -- src/components/__tests__/Header.test.tsx` → 3 passed
- `ListingCard` + `CartContext` still pass
- `npm run typecheck` → pass
- `npm run lint` → 0 errors (9 pre-existing warnings)

Keep `[P-front] F0.3` if you squash. Next is F0.4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

