### PR TITLE
[P-front] C1 — Carrinho e checkout (UX only)

### DIFF
--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,106 +1,110 @@
 import { Link } from "react-router-dom";
-import { Trash2, ShoppingBag } from "lucide-react";
-import { motion } from "framer-motion";
+import { Trash2 } from "lucide-react";
 import { useCart } from "@/contexts/CartContext";
+import { EmptyState } from "@/components/page-state";
 import { Button } from "@/components/ui/button";
+
+function listingLabel(listing: {
+  product: { weapon: string; skinName: string; exterior: string };
+}) {
+  return `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
+}
 
 export default function CartPage() {
   const { items, removeItem, totalPrice, totalItems } = useCart();
+  const serviceFee = totalPrice * 0.05;
+  const total = totalPrice * 1.05;
 
   if (items.length === 0) {
     return (
-      <div className="container py-20 text-center">
-        <ShoppingBag className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
-        <h1 className="text-2xl font-heading text-foreground mb-2">
-          Carrinho Vazio
-        </h1>
-        <p className="text-muted-foreground mb-6">
-          Adicione itens do marketplace para começar
-        </p>
-        <Button asChild>
-          <Link to="/products">Explorar Market</Link>
-        </Button>
+      <div className="container py-8">
+        <h1 className="sr-only">Carrinho</h1>
+        <EmptyState
+          title="Carrinho vazio"
+          description="Adicione itens do marketplace para começar."
+          action={
+            <Button asChild>
+              <Link to="/products">Explorar Market</Link>
+            </Button>
+          }
+        />
       </div>
     );
   }
 
   return (
     <div className="container py-8">
-      <h1 className="text-3xl font-heading text-foreground mb-8">
-        Carrinho ({totalItems})
-      </h1>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Carrinho</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {totalItems} item{totalItems !== 1 ? "s" : ""} · item único
+        </p>
+      </div>
 
-      <div className="grid lg:grid-cols-3 gap-8">
-        <div className="lg:col-span-2 space-y-4">
+      <div className="grid gap-8 lg:grid-cols-3">
+        <ul className="space-y-3 lg:col-span-2">
           {items.map(({ listing }) => {
-            const productName = `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
+            const name = listingLabel(listing);
             return (
-              <motion.div
+              <li
                 key={listing.id}
-                layout
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="flex items-center gap-4 p-4 rounded-lg border border-border bg-card"
+                className="flex items-center gap-4 rounded-md border border-border bg-card p-4"
               >
-                <div className="h-20 w-20 rounded-md bg-muted flex items-center justify-center flex-shrink-0">
-                  <span className="text-xs font-heading text-foreground/60 line-clamp-2 px-1">
-                    {productName}
-                  </span>
+                <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-md bg-muted px-1 text-center text-[10px] leading-tight text-muted-foreground">
+                  {listing.product.weapon}
                 </div>
-                <div className="flex-1 min-w-0">
+                <div className="min-w-0 flex-1">
                   <Link
                     to={`/listing/${listing.id}`}
-                    className="font-heading text-sm text-foreground hover:text-primary transition-colors truncate block normal-case"
+                    className="block truncate text-sm font-medium text-foreground hover:underline"
                   >
-                    {productName}
+                    {name}
                   </Link>
-                  <div className="text-xs text-muted-foreground mt-1">
-                    <span>Float: {Number(listing.floatValue).toFixed(8)}</span>
-                    {listing.pattern && (
-                      <span className="ml-2">Pattern: {listing.pattern}</span>
-                    )}
-                  </div>
-                  <span className="text-primary font-heading text-lg">
+                  <p className="mt-1 text-xs tabular-float text-muted-foreground">
+                    Float {Number(listing.floatValue).toFixed(8)}
+                    {listing.pattern ? ` · Pattern ${listing.pattern}` : ""}
+                  </p>
+                  <p className="mt-1 text-sm tabular-price text-foreground">
                     ${Number(listing.price).toFixed(2)}
-                  </span>
+                  </p>
                 </div>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8 text-destructive"
+                  className="h-10 w-10 text-muted-foreground hover:text-destructive"
                   onClick={() => removeItem(listing.id)}
+                  aria-label={`Remover ${name}`}
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
-              </motion.div>
+              </li>
             );
           })}
-        </div>
+        </ul>
 
-        {/* Summary */}
-        <div className="p-6 rounded-lg border border-border bg-card h-fit space-y-4 sticky top-24">
-          <h2 className="font-heading text-lg text-foreground">Resumo</h2>
-          <div className="space-y-2 text-sm">
+        <aside className="h-fit space-y-4 rounded-md border border-border bg-card p-6 lg:sticky lg:top-20">
+          <h2 className="text-sm font-semibold tracking-tight">Resumo</h2>
+          <dl className="space-y-2 text-sm">
             <div className="flex justify-between text-muted-foreground">
-              <span>Subtotal</span>
-              <span>${totalPrice.toFixed(2)}</span>
+              <dt>Subtotal</dt>
+              <dd className="tabular-price">${totalPrice.toFixed(2)}</dd>
             </div>
             <div className="flex justify-between text-muted-foreground">
-              <span>Taxa de serviço</span>
-              <span>${(totalPrice * 0.05).toFixed(2)}</span>
+              <dt>Taxa de serviço</dt>
+              <dd className="tabular-price">${serviceFee.toFixed(2)}</dd>
             </div>
-            <div className="border-t border-border pt-2 flex justify-between font-heading text-lg text-foreground">
-              <span>Total</span>
-              <span className="text-primary">
-                ${(totalPrice * 1.05).toFixed(2)}
-              </span>
+            <div className="flex justify-between border-t border-border pt-2 text-base font-medium text-foreground">
+              <dt>Total</dt>
+              <dd className="tabular-price">${total.toFixed(2)}</dd>
             </div>
-          </div>
+          </dl>
           <Button asChild className="w-full" size="lg">
-            <Link to="/checkout">Finalizar Compra</Link>
+            <Link to="/checkout">Finalizar compra</Link>
           </Button>
-        </div>
+          <p className="text-xs text-muted-foreground">
+            O pagamento é confirmado só depois do retorno do PayPal.
+          </p>
+        </aside>
       </div>
     </div>
   );

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,51 +1,57 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { CreditCard, CheckCircle, ShieldCheck } from 'lucide-react';
-import { motion } from 'framer-motion';
-import { useCart } from '@/contexts/CartContext';
-import { useAuth } from '@/contexts/AuthContext';
-import { createOrder } from '@/api/orders';
-import { createPaymentLink } from '@/api/payments';
-import { Button } from '@/components/ui/button';
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useCart } from "@/contexts/CartContext";
+import { useAuth } from "@/contexts/AuthContext";
+import { createOrder } from "@/api/orders";
+import { createPaymentLink } from "@/api/payments";
+import { EmptyState } from "@/components/page-state";
+import { Button } from "@/components/ui/button";
 
 export default function Checkout() {
-  const { items, totalPrice, clearCart } = useCart();
+  const { items, totalPrice } = useCart();
   const { isAuthenticated, user } = useAuth();
   const navigate = useNavigate();
-  const [completed, setCompleted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const serviceFee = totalPrice * 0.05;
   const total = totalPrice * 1.05;
-
-  if (completed) {
-    return (
-      <div className="container py-20 text-center">
-        <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ type: 'spring' }}>
-          <CheckCircle className="h-20 w-20 text-primary mx-auto mb-6" />
-        </motion.div>
-        <h1 className="text-3xl font-heading text-foreground mb-4">Pedido Confirmado!</h1>
-        <p className="text-muted-foreground mb-8">Seu pagamento foi processado com sucesso. Você receberá os itens em breve.</p>
-        <Button asChild><Link to="/products">Continuar Comprando</Link></Button>
-      </div>
-    );
-  }
 
   if (items.length === 0) {
     return (
-      <div className="container py-20 text-center">
-        <p className="text-muted-foreground mb-4">Seu carrinho está vazio</p>
-        <Button asChild><Link to="/products">Ir ao Market</Link></Button>
+      <div className="container py-8">
+        <h1 className="sr-only">Checkout</h1>
+        <EmptyState
+          title="Carrinho vazio"
+          description="Adicione um listing ativo antes de pagar."
+          action={
+            <Button asChild>
+              <Link to="/products">Ir ao Market</Link>
+            </Button>
+          }
+        />
       </div>
     );
   }
 
-  if (!isAuthenticated || user?.role !== 'CUSTOMER') {
+  if (!isAuthenticated || user?.role !== "CUSTOMER") {
     return (
-      <div className="container py-20 text-center">
-        <p className="text-muted-foreground mb-4">Faça login como comprador para finalizar a compra.</p>
-        <Button onClick={() => navigate('/login', { state: { from: { pathname: '/checkout' } } })}>
-          Ir para Login
-        </Button>
+      <div className="container py-8">
+        <h1 className="sr-only">Checkout</h1>
+        <EmptyState
+          title="Login de comprador necessário"
+          description="Faça login como comprador para finalizar a compra."
+          action={
+            <Button
+              onClick={() =>
+                navigate("/login", {
+                  state: { from: { pathname: "/checkout" } },
+                })
+              }
+            >
+              Ir para Login
+            </Button>
+          }
+        />
       </div>
     );
   }
@@ -62,56 +68,90 @@ export default function Checkout() {
         window.location.href = payment.approvalUrl;
         return;
       }
-      setCompleted(true);
-      clearCart();
+      setError(
+        "Não foi possível obter o link do PayPal. O pagamento ainda não foi confirmado.",
+      );
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Falha ao criar pedido');
+      setError(e instanceof Error ? e.message : "Falha ao criar pedido");
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="container py-8 max-w-2xl">
-      <h1 className="text-3xl font-heading text-foreground mb-8">Checkout</h1>
+    <div className="container max-w-2xl py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Checkout</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Revise os itens e pague no PayPal. Nada é confirmado nesta tela.
+        </p>
+      </div>
 
       <div className="space-y-6">
-        <div className="p-4 rounded-lg border border-border bg-card space-y-3">
-          <h2 className="font-heading text-sm text-muted-foreground">Itens ({items.length})</h2>
-          {items.map(({ listing }) => {
-            const productName = `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
-            return (
-              <div key={listing.id} className="flex justify-between text-sm">
-                <span className="text-foreground">{productName}</span>
-                <span className="text-muted-foreground">${Number(listing.price).toFixed(2)}</span>
-              </div>
-            );
-          })}
-          <div className="border-t border-border pt-3 flex justify-between font-heading text-lg">
-            <span className="text-foreground">Total</span>
-            <span className="text-primary">${total.toFixed(2)}</span>
-          </div>
-        </div>
-
-        <div className="p-6 rounded-lg border border-border bg-card space-y-4">
-          <h2 className="font-heading text-foreground flex items-center gap-2">
-            <CreditCard className="h-5 w-5" /> Pagamento
+        <section className="space-y-3 rounded-md border border-border bg-card p-4">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Itens ({items.length})
           </h2>
-          <p className="text-sm text-muted-foreground">Pagamento via PayPal</p>
-          {error && <p className="text-sm text-destructive">{error}</p>}
+          <ul className="space-y-2">
+            {items.map(({ listing }) => {
+              const name = `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
+              return (
+                <li
+                  key={listing.id}
+                  className="flex justify-between gap-4 text-sm"
+                >
+                  <span className="min-w-0 truncate text-foreground">
+                    {name}
+                  </span>
+                  <span className="shrink-0 tabular-price text-muted-foreground">
+                    ${Number(listing.price).toFixed(2)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+          <dl className="space-y-1 border-t border-border pt-3 text-sm">
+            <div className="flex justify-between text-muted-foreground">
+              <dt>Subtotal</dt>
+              <dd className="tabular-price">${totalPrice.toFixed(2)}</dd>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <dt>Taxa de serviço</dt>
+              <dd className="tabular-price">${serviceFee.toFixed(2)}</dd>
+            </div>
+            <div className="flex justify-between pt-1 text-base font-medium text-foreground">
+              <dt>Total</dt>
+              <dd className="tabular-price">${total.toFixed(2)}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="space-y-4 rounded-md border border-border bg-card p-6">
+          <h2 className="text-sm font-semibold tracking-tight">PayPal</h2>
+          <p className="text-sm text-muted-foreground">
+            Você será redirecionado ao PayPal. O pagamento só é confirmado
+            depois que o provedor retornar o resultado — esta página não marca o
+            pedido como pago.
+          </p>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
           <Button
             className="w-full"
             size="lg"
             onClick={handlePay}
             disabled={loading}
           >
-            {loading ? 'Processando...' : `Pagar com PayPal — $${total.toFixed(2)}`}
+            {loading
+              ? "Abrindo o PayPal..."
+              : `Pagar com PayPal — $${total.toFixed(2)}`}
           </Button>
-          <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
-            <ShieldCheck className="h-3 w-3" />
-            <span>Transação segura e protegida</span>
-          </div>
-        </div>
+          <p className="text-center text-xs text-muted-foreground">
+            Sem confirmação local até o retorno do PayPal.
+          </p>
+        </section>
       </div>
     </div>
   );

--- a/src/pages/__tests__/CartPage.test.tsx
+++ b/src/pages/__tests__/CartPage.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import CartPage from "../CartPage";
+import type { Listing } from "@/types/api";
+
+const cartState = {
+  items: [] as { listing: Listing }[],
+  totalPrice: 0,
+  totalItems: 0,
+  removeItem: vi.fn(),
+};
+
+vi.mock("@/contexts/CartContext", () => ({
+  useCart: () => cartState,
+}));
+
+function listing(id: string, price: number): Listing {
+  return {
+    id,
+    productId: "prod-1",
+    sellerId: "seller-1",
+    floatValue: 0.12345678 as unknown as Listing["floatValue"],
+    price: price as unknown as Listing["price"],
+    currency: "USD",
+    status: "ACTIVE",
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      imageUrl: null,
+      isStattrak: false,
+      isSouvenir: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    seller: { id: "seller-1", storeName: "Store Alpha" },
+    pattern: 123,
+  } as Listing;
+}
+
+function renderCart() {
+  return render(
+    <MemoryRouter>
+      <CartPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("CartPage", () => {
+  beforeEach(() => {
+    cartState.items = [];
+    cartState.totalPrice = 0;
+    cartState.totalItems = 0;
+    cartState.removeItem.mockReset();
+  });
+
+  it("shows empty cart and a Market link", () => {
+    renderCart();
+    expect(screen.getByText("Carrinho vazio")).toBeTruthy();
+    expect(screen.getByText("Explorar Market")).toBeTruthy();
+    expect(screen.queryByText("Finalizar compra")).toBeNull();
+  });
+
+  it("keeps 5% service fee display math", () => {
+    cartState.items = [{ listing: listing("listing-ak", 100) }];
+    cartState.totalPrice = 100;
+    cartState.totalItems = 1;
+    renderCart();
+    expect(screen.getAllByText("$100.00").length).toBe(2);
+    expect(screen.getByText("$5.00")).toBeTruthy();
+    expect(screen.getByText("$105.00")).toBeTruthy();
+    expect(screen.getByText("Finalizar compra")).toBeTruthy();
+    expect(screen.queryByText("SKINMARKET")).toBeNull();
+  });
+});

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Checkout from "../Checkout";
+import type { Listing, User } from "@/types/api";
+
+const createOrder = vi.fn();
+const createPaymentLink = vi.fn();
+
+const cartState = {
+  items: [] as { listing: Listing }[],
+  totalPrice: 0,
+  clearCart: vi.fn(),
+};
+
+const authState = {
+  user: null as User | null,
+  isAuthenticated: false,
+};
+
+vi.mock("@/api/orders", () => ({
+  createOrder: (...args: unknown[]) => createOrder(...args),
+}));
+
+vi.mock("@/api/payments", () => ({
+  createPaymentLink: (...args: unknown[]) => createPaymentLink(...args),
+}));
+
+vi.mock("@/contexts/CartContext", () => ({
+  useCart: () => cartState,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+function listing(price = 100): Listing {
+  return {
+    id: "listing-ak",
+    productId: "prod-1",
+    sellerId: "seller-1",
+    floatValue: 0.15 as unknown as Listing["floatValue"],
+    price: price as unknown as Listing["price"],
+    currency: "USD",
+    status: "ACTIVE",
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      imageUrl: null,
+      isStattrak: false,
+      isSouvenir: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    seller: { id: "seller-1", storeName: "Store Alpha" },
+  } as Listing;
+}
+
+function renderCheckout() {
+  return render(
+    <MemoryRouter>
+      <Checkout />
+    </MemoryRouter>,
+  );
+}
+
+describe("Checkout", () => {
+  beforeEach(() => {
+    cartState.items = [];
+    cartState.totalPrice = 0;
+    cartState.clearCart.mockReset();
+    authState.user = null;
+    authState.isAuthenticated = false;
+    createOrder.mockReset();
+    createPaymentLink.mockReset();
+  });
+
+  it("keeps empty-cart gate and does not offer PayPal", () => {
+    renderCheckout();
+    expect(screen.getByText("Carrinho vazio")).toBeTruthy();
+    expect(screen.getByText("Ir ao Market")).toBeTruthy();
+    expect(screen.queryByText(/Pagar com PayPal/)).toBeNull();
+  });
+
+  it("keeps CUSTOMER-only pay gate when the cart has items", () => {
+    cartState.items = [{ listing: listing() }];
+    cartState.totalPrice = 100;
+    renderCheckout();
+    expect(screen.getByText("Login de comprador necessário")).toBeTruthy();
+    expect(screen.getByText("Ir para Login")).toBeTruthy();
+    expect(screen.queryByText(/Pagar com PayPal/)).toBeNull();
+  });
+
+  it("shows 5% fee and does not claim payment succeeded", () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    authState.isAuthenticated = true;
+    authState.user = {
+      id: "u1",
+      name: "Buyer",
+      email: "buyer@test.com",
+      role: "CUSTOMER",
+    } as User;
+
+    renderCheckout();
+
+    expect(screen.getAllByText("$100.00").length).toBe(2);
+    expect(screen.getByText("$5.00")).toBeTruthy();
+    expect(screen.getByText("$105.00")).toBeTruthy();
+    expect(screen.getByText(/Pagar com PayPal — \$105\.00/)).toBeTruthy();
+    expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();
+    expect(screen.queryByText(/processado com sucesso/i)).toBeNull();
+    expect(
+      screen.getByText(/só é confirmado depois que o provedor retornar/i),
+    ).toBeTruthy();
+  });
+
+  it("calls createOrder + createPaymentLink and errors without claiming success", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    authState.isAuthenticated = true;
+    authState.user = {
+      id: "u1",
+      name: "Buyer",
+      email: "buyer@test.com",
+      role: "CUSTOMER",
+    } as User;
+    createOrder.mockResolvedValue({ id: "order-1" });
+    createPaymentLink.mockResolvedValue({});
+
+    renderCheckout();
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    await waitFor(() => {
+      expect(createOrder).toHaveBeenCalledWith({
+        items: [{ listingId: "listing-ak" }],
+      });
+      expect(createPaymentLink).toHaveBeenCalledWith({ orderId: "order-1" });
+    });
+
+    expect(
+      screen.getByText(/pagamento ainda não foi confirmado/i),
+    ).toBeTruthy();
+    expect(cartState.clearCart).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Activity

C1 — Carrinho e checkout (UX only).

## What

Editorial Neon Arsenal cart and checkout. Removes `font-heading`, framer-motion, and the fake “Pedido Confirmado / pagamento processado com sucesso” screen.

## Preserved

- Empty cart still blocks pay and links to Market
- Checkout still requires authenticated `CUSTOMER` (redirect `from` `/checkout`)
- Same `createOrder({ items: [{ listingId }] })` + `createPaymentLink({ orderId })`
- Same 5% service-fee display math
- PayPal redirect when `approvalUrl` exists
- No `server/` or `CartContext` changes

## Honesty

If PayPal does not return `approvalUrl`, show an error and keep the cart. Copy states that payment is confirmed only after PayPal return.

## Verify

- `npm test -- src/contexts/__tests__/CartContext.test.tsx` → 12 passed
- `npm test` → 37 passed (includes new CartPage/Checkout tests)
- `npm run typecheck` → pass
- `npm run lint` → 0 errors (9 existing UI warnings)
- Browser: empty `/cart` and `/checkout` gates, no success copy. Filled-cart / CUSTOMER / PayPal-honesty paths covered by component tests (local API had no listings).

[Carrinho vazio editorial](https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fc1-cart-empty.webp)
[Checkout vazio sem PayPal](https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fc1-checkout-empty.webp)
[c1-cart-checkout-walkthrough.mp4](https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fc1-cart-checkout-walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

