### PR TITLE
fix: keep Vercel SPA routes and production API_URL from falling back to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # ─── Frontend (Vite) ──────────────────────────────────────────────────────────
 # Use API_URL (no VITE_ prefix) in Vercel/Render and mark it as Config, not Sensitive.
+# Production builds must use the public Render API, for example:
+# API_URL=https://neon-arsenal-market-api.onrender.com
 # The browser needs this origin; it is not a secret.
 API_URL=http://localhost:3001
 # Optional local alias still accepted by the client:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ When a payment is confirmed, seller transactions are generated from the order it
 
 For the common split deployment, use Vercel for the Vite frontend and Render for the Express API:
 
-- In Vercel, add `API_URL` as **Config** (not Sensitive) with the public Render API origin, for example `https://neon-arsenal-api.onrender.com`. Do not use the `VITE_` prefix.
+- In Vercel, add `API_URL` as **Config** (not Sensitive) with the public Render API origin, for example `https://neon-arsenal-market-api.onrender.com`. Do not use the `VITE_` prefix. A production frontend build fails if this still points at localhost.
 - In Render, set `FRONTEND_URL` to the public frontend origin. Use a comma-separated list when allowing both production and preview origins.
 - In Render, set `RESEND_API_KEY` and `EMAIL_FROM` so production registration can send verification codes.
 - Keep `SEED_DEMO_DATA=true` only for demo/test deployments that should expose the seeded accounts shown on the login page.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For the common split deployment, use Vercel for the Vite frontend and Render for
 - In Render, set `FRONTEND_URL` to the public frontend origin. Use a comma-separated list when allowing both production and preview origins.
 - In Render, set `RESEND_API_KEY` and `EMAIL_FROM` so production registration can send verification codes.
 - Keep `SEED_DEMO_DATA=true` only for demo/test deployments that should expose the seeded accounts shown on the login page.
-- `vercel.json` rewrites React Router paths to `index.html` so direct page refreshes do not return 404.
+- `vercel.json` rewrites React Router paths to `index.html`, and the production build also emits `dist/404.html`, so direct page refreshes do not return Vercel's NOT_FOUND page. In the Vercel project, set Framework Preset to **Vite**, not Other.
 
 The Render Blueprint also defines an optional `neon-arsenal-web` static site. If you deploy the frontend on Render instead of Vercel, set its `API_URL`; the Blueprint includes the same SPA rewrite to `index.html`.
 

--- a/src/api/__tests__/apiBaseUrl.test.ts
+++ b/src/api/__tests__/apiBaseUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveApiBaseUrl } from "../apiBaseUrl";
+import { assertProductionApiBaseUrl, resolveApiBaseUrl } from "../apiBaseUrl";
 
 describe("resolveApiBaseUrl", () => {
   it("prefers API_URL without a public framework prefix", () => {
@@ -19,5 +19,11 @@ describe("resolveApiBaseUrl", () => {
 
   it("defaults to the local API when neither variable is set", () => {
     expect(resolveApiBaseUrl({})).toBe("http://localhost:3001");
+  });
+
+  it("rejects a localhost API origin for production builds", () => {
+    expect(() => assertProductionApiBaseUrl("http://localhost:3001")).toThrow(
+      /API_URL/,
+    );
   });
 });

--- a/src/api/apiBaseUrl.ts
+++ b/src/api/apiBaseUrl.ts
@@ -21,3 +21,20 @@ export function resolveApiBaseUrl(env: ApiUrlEnv = {}): string {
     DEFAULT_API_BASE
   );
 }
+
+export function isLocalApiBaseUrl(apiUrl: string): boolean {
+  try {
+    const { hostname } = new URL(apiUrl);
+    return hostname === "localhost" || hostname === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
+export function assertProductionApiBaseUrl(apiUrl: string): void {
+  if (isLocalApiBaseUrl(apiUrl)) {
+    throw new Error(
+      "Production frontend builds must set API_URL to the public Render API origin, for example https://neon-arsenal-market-api.onrender.com",
+    );
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -63,7 +63,13 @@ async function request<T>(
     return fetch(url, { ...init, headers });
   };
 
-  let res = await doFetch(access);
+  let res: Response;
+  try {
+    res = await doFetch(access);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "Failed to fetch";
+    throw new Error(`Could not reach API at ${url}: ${reason}`);
+  }
 
   if (res.status === 401 && !skipAuth && access) {
     try {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,13 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "cleanUrls": false,
+  "trailingSlash": false,
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!assets/).*)",
       "destination": "/index.html"
     }
   ]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,25 @@
-import { defineConfig, loadEnv } from "vite";
-import react from "@vitejs/plugin-react";
+import { copyFileSync, existsSync } from "node:fs";
 import path from "path";
+import { defineConfig, loadEnv, type Plugin } from "vite";
+import react from "@vitejs/plugin-react";
 import { componentTagger } from "lovable-tagger";
 import {
   assertProductionApiBaseUrl,
   resolveApiBaseUrl,
 } from "./src/api/apiBaseUrl";
+
+function spaFallbackHtmlPlugin(): Plugin {
+  return {
+    name: "spa-fallback-html",
+    closeBundle() {
+      const indexHtml = path.resolve(__dirname, "dist/index.html");
+      const fallbackHtml = path.resolve(__dirname, "dist/404.html");
+      if (existsSync(indexHtml)) {
+        copyFileSync(indexHtml, fallbackHtml);
+      }
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -30,7 +44,11 @@ export default defineConfig(({ mode }) => {
         overlay: false,
       },
     },
-    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    plugins: [
+      react(),
+      spaFallbackHtmlPlugin(),
+      mode === "development" && componentTagger(),
+    ].filter(Boolean),
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,10 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
-import { resolveApiBaseUrl } from "./src/api/apiBaseUrl";
+import {
+  assertProductionApiBaseUrl,
+  resolveApiBaseUrl,
+} from "./src/api/apiBaseUrl";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -11,6 +14,9 @@ export default defineConfig(({ mode }) => {
     API_URL: process.env.API_URL || env.API_URL,
     VITE_API_URL: process.env.VITE_API_URL || env.VITE_API_URL,
   });
+  if (mode === "production") {
+    assertProductionApiBaseUrl(apiUrl);
+  }
 
   return {
     // Bake API_URL at build time so Vercel can store it as Config without a VITE_ prefix.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fail production frontend builds that still embed `http://localhost:3001`
- pin the Vercel Framework Preset to Vite and emit `dist/404.html` so React Router routes survive refresh
- surface the API origin in client fetch errors

These commits landed after PR #25 was merged and are the remaining production-routing fixes.

## Verification
- `npm test -- --run src/api/__tests__/apiBaseUrl.test.ts` passed
- `API_URL=https://neon-arsenal-market-api.onrender.com npm run build` passed and wrote `dist/404.html`
- production build without a public `API_URL` fails closed

## Render note
Email sending still needs `RESEND_API_KEY` and `EMAIL_FROM` on `neon-arsenal-market-api`. Those values cannot be invented from the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

