### PR TITLE
[P-front] S1 — Home Neon Arsenal

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,34 +1,77 @@
-import { motion } from "framer-motion";
-import { ProductCard } from "@/components/ProductCard";
+import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { ListingCard } from "@/components/ProductCard";
+import { EmptyState, ErrorState } from "@/components/page-state";
 import { listListings } from "@/api/listings";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function IndexPage() {
-  const { data: listingsData } = useQuery({
-    queryKey: ["listings"],
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["listings", { status: "ACTIVE", limit: 8 }],
     queryFn: () => listListings({ status: "ACTIVE", limit: 8 }),
   });
-  const listings = listingsData?.items ?? [];
+  const listings = data?.items ?? [];
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-      className="min-h-screen bg-gradient-to-br from-gray-900 to-black"
-    >
-      <div className="container mx-auto px-4 py-16">
-        <h1 className="text-4xl font-bold text-white mb-2">
-          CS2 Skin Marketplace
-        </h1>
-        <p className="text-gray-400 mb-12">Browse premium weapon skins</p>
+    <div className="container py-10">
+      <div className="mb-10 max-w-xl">
+        <h1 className="text-3xl font-semibold tracking-tight">Neon Arsenal</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Listings ativos · item único. Oito em destaque.
+        </p>
+        <Button asChild className="mt-6">
+          <Link to="/products">Ver Market</Link>
+        </Button>
+      </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          {listings.map((p) => (
-            <ProductCard key={p.id} listing={p} />
+      {isLoading ? (
+        <div
+          className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+          role="status"
+          aria-label="Carregando"
+        >
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-64 w-full" />
           ))}
         </div>
-      </div>
-    </motion.div>
+      ) : null}
+
+      {isError ? (
+        <ErrorState
+          title="Erro ao carregar listings"
+          description={
+            error instanceof Error
+              ? error.message
+              : "Tente novamente em instantes."
+          }
+          action={
+            <Button type="button" variant="outline" onClick={() => refetch()}>
+              Tentar novamente
+            </Button>
+          }
+        />
+      ) : null}
+
+      {!isLoading && !isError && listings.length === 0 ? (
+        <EmptyState
+          title="Nenhum listing ativo"
+          description="Quando houver itens, eles aparecem aqui."
+          action={
+            <Button asChild>
+              <Link to="/products">Ver Market</Link>
+            </Button>
+          }
+        />
+      ) : null}
+
+      {!isLoading && !isError && listings.length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {listings.map((listing) => (
+            <ListingCard key={listing.id} listing={listing} />
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Activity

S1 — Home Neon Arsenal.

## What

Editorial home: Neon Arsenal hero, CTA to `/products`, and the first eight `ACTIVE` listings via `ListingCard`.

## Preserved

- `listListings({ status: "ACTIVE", limit: 8 })`
- No new routes or sections
- `ListingCard` consumed only; card file not edited
- No `server/` edits

## States

- Loading: 8 skeletons
- Empty: `EmptyState`
- Error: `ErrorState` + retry

## Verify

- `npm run typecheck` → pass
- `npm run lint` → 0 errors (9 existing UI warnings)
- `npm test` → 41 passed
- Browser: hero Neon Arsenal, `Ver Market` → `/products`, retry shows 8 skeletons, error URL is `/listings?limit=8&status=ACTIVE`. Happy-path cards not shown live (API local down).

[Home editorial com erro de listings](https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fs1-home-error.webp)
[Home com 8 skeletons de loading](https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fs1-home-loading.webp)
[s1-home-walkthrough.mp4](https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fs1-home-walkthrough.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60490ec8-2adc-4ecd-a571-b7e886e3ef90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

