### PR TITLE
[P-front] D1 — Dashboard seller

### DIFF
--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -1,155 +1,185 @@
-import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { motion } from 'framer-motion';
-import { BarChart3, TrendingUp, Package, DollarSign } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { listOrders } from '@/api/orders';
-import { getSellerListings } from '@/api/listings';
-import type { Listing, Order } from '@/types/api';
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Package, ShoppingBag, DollarSign } from "lucide-react";
+import { listOrders } from "@/api/orders";
+import { getSellerListings } from "@/api/listings";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Order } from "@/types/api";
+
+function orderTotal(order: Order): number {
+  if (order.totalAmount != null && Number(order.totalAmount) > 0) {
+    return Number(order.totalAmount);
+  }
+  return (
+    order.items?.reduce(
+      (sum, item) => sum + Number(item.priceSnapshot || 0),
+      0,
+    ) ?? 0
+  );
+}
+
+function orderSummary(order: Order): string {
+  const names =
+    order.items
+      ?.slice(0, 2)
+      .map((item) =>
+        item.listing?.product
+          ? `${item.listing.product.weapon} | ${item.listing.product.skinName}`
+          : "Item",
+      )
+      .join(", ") ?? "—";
+  const extra = order.items && order.items.length > 2 ? "…" : "";
+  return `${names}${extra}`;
+}
 
 export default function SellerDashboard() {
-  const [listings, setListings] = useState<Listing[]>([]);
-
-  const { data: orders = [] } = useQuery({
-    queryKey: ['orders'],
+  const listingsQuery = useQuery({
+    queryKey: ["sellerListings"],
+    queryFn: () => getSellerListings(),
+  });
+  const ordersQuery = useQuery({
+    queryKey: ["orders"],
     queryFn: () => listOrders(),
   });
 
-  const { data: sellerListings = [] } = useQuery({
-    queryKey: ['sellerListings'],
-    queryFn: () => getSellerListings(),
-  });
+  const listings = listingsQuery.data?.items ?? [];
+  const orders = ordersQuery.data ?? [];
+  const isLoading = listingsQuery.isLoading || ordersQuery.isLoading;
+  const isError = listingsQuery.isError || ordersQuery.isError;
+  const error = listingsQuery.error ?? ordersQuery.error;
 
-  useEffect(() => {
-    if (sellerListings && 'items' in sellerListings) {
-      setListings((sellerListings as { items: Listing[]; total: number }).items);
-    } else if (Array.isArray(sellerListings)) {
-      setListings(sellerListings);
-    }
-  }, [sellerListings]);
+  const activeListings = listings.filter(
+    (listing) => listing.status === "ACTIVE",
+  ).length;
+  const totalRevenue = orders.reduce(
+    (sum, order) => sum + orderTotal(order),
+    0,
+  );
 
-  // Calculate metrics
-  const totalRevenue = orders.reduce((sum, order) => {
-    const orderSum = order.items?.reduce((itemSum, i) => itemSum + Number(i.priceSnapshot || 0), 0) || 0;
-    return sum + orderSum;
-  }, 0);
+  if (isLoading) {
+    return (
+      <div className="space-y-6" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      </div>
+    );
+  }
 
-  const activeListings = listings.filter((l) => l.status === 'ACTIVE').length;
-
-  const firstItem = orders[0]?.items?.[0];
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar o painel"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              void listingsQuery.refetch();
+              void ordersQuery.refetch();
+            }}
+          >
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
 
   const stats = [
+    { label: "Listings ativos", value: String(activeListings), icon: Package },
     {
-      label: 'Active Listings',
-      value: activeListings,
-      icon: Package,
-      color: 'text-blue-500',
-    },
-    {
-      label: 'Total Revenue',
+      label: "Receita",
       value: `$${totalRevenue.toFixed(2)}`,
       icon: DollarSign,
-      color: 'text-green-500',
     },
-    {
-      label: 'Orders',
-      value: orders.length,
-      icon: TrendingUp,
-      color: 'text-purple-500',
-    },
+    { label: "Pedidos", value: String(orders.length), icon: ShoppingBag },
   ];
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-      className="min-h-screen bg-gradient-to-br from-gray-900 to-black p-6"
-    >
-      <div className="container mx-auto max-w-7xl">
-        <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ duration: 0.3 }}>
-          <h1 className="text-4xl font-bold text-white mb-2">Seller Dashboard</h1>
-          <p className="text-gray-400 mb-8">Manage your CS2 skin marketplace inventory</p>
-        </motion.div>
-
-        {/* Stats Grid */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3, delay: 0.1 }}
-          className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8"
-        >
-          {stats.map((stat, index) => (
-            <motion.div
-              key={stat.label}
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.3, delay: 0.1 + index * 0.1 }}
-            >
-              <Card className="bg-gray-800 border-gray-700">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm font-medium text-gray-400">{stat.label}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex items-center justify-between">
-                    <div className="text-3xl font-bold text-white">{stat.value}</div>
-                    <stat.icon className={`w-8 h-8 ${stat.color}`} />
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          ))}
-        </motion.div>
-
-        {/* Recent Orders */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3, delay: 0.2 }}
-        >
-          <Card className="bg-gray-800 border-gray-700">
-            <CardHeader>
-              <CardTitle className="text-white">Recent Orders</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {orders.length === 0 ? (
-                <p className="text-gray-400">No orders yet</p>
-              ) : (
-                <div className="space-y-4">
-                  {orders.slice(0, 5).map((order) => {
-                    const itemsSummary = order.items
-                      ?.slice(0, 2)
-                      .map((i) => i.listing?.product ? `${i.listing.product.weapon} | ${i.listing.product.skinName}` : 'Item')
-                      .join(', ') ?? '—';
-                    const hasMore = order.items && order.items.length > 2 ? '…' : '';
-
-                    return (
-                      <div key={order.id} className="flex items-center justify-between p-4 bg-gray-700 rounded-lg">
-                        <div>
-                          <p className="text-white font-semibold">{firstItem?.listing?.product?.weapon ?? 'Item'}</p>
-                          <p className="text-gray-400 text-sm">{itemsSummary}{hasMore}</p>
-                        </div>
-                        <div className="text-right">
-                          <p className="text-white font-semibold">
-                            $
-                            {order.items
-                              ?.reduce((sum, i) => sum + Number(i.priceSnapshot || 0), 0)
-                              .toFixed(2) || '0.00'}
-                          </p>
-                          <Badge variant={order.status === 'COMPLETED' ? 'default' : 'secondary'}>
-                            {order.status}
-                          </Badge>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </motion.div>
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Visão geral</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Listings únicos, pedidos e receita da loja.
+        </p>
       </div>
-    </motion.div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-md border border-border bg-card p-4"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs text-muted-foreground">{stat.label}</p>
+              <stat.icon className="h-4 w-4 text-muted-foreground" />
+            </div>
+            <p className="mt-2 tabular-nums text-2xl font-semibold tracking-tight">
+              {stat.value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <section>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold tracking-tight">
+            Pedidos recentes
+          </h2>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/seller/orders">Ver pedidos</Link>
+          </Button>
+        </div>
+        {orders.length === 0 ? (
+          <EmptyState
+            title="Nenhum pedido"
+            description="Quando houver vendas, elas aparecem aqui."
+            action={
+              <Button asChild>
+                <Link to="/seller/listings">Ver listings</Link>
+              </Button>
+            }
+          />
+        ) : (
+          <ul className="space-y-2">
+            {orders.slice(0, 5).map((order) => (
+              <li
+                key={order.id}
+                className="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-4"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {orderSummary(order)}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Pedido {order.id}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="tabular-nums text-sm font-semibold">
+                    ${orderTotal(order).toFixed(2)}
+                  </p>
+                  <Badge variant="secondary" className="mt-1">
+                    {order.status}
+                  </Badge>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
   );
 }

--- a/src/pages/__tests__/SellerDashboard.test.tsx
+++ b/src/pages/__tests__/SellerDashboard.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SellerDashboard from "../SellerDashboard";
+import type { Listing, Order } from "@/types/api";
+
+const getSellerListings = vi.fn();
+const listOrders = vi.fn();
+
+vi.mock("@/api/listings", () => ({
+  getSellerListings: (...args: unknown[]) => getSellerListings(...args),
+}));
+
+vi.mock("@/api/orders", () => ({
+  listOrders: (...args: unknown[]) => listOrders(...args),
+}));
+
+function listing(status: Listing["status"] = "ACTIVE"): Listing {
+  return {
+    id: `listing-${status}`,
+    productId: "prod-1",
+    sellerId: "seller-1",
+    floatValue: 0.1,
+    price: 10,
+    currency: "USD",
+    status,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+  };
+}
+
+function order(id: string, amount: number): Order {
+  return {
+    id,
+    totalAmount: amount,
+    status: "CONFIRMED",
+    paymentStatus: "PAID",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    items: [
+      {
+        id: `item-${id}`,
+        listingId: "listing-1",
+        sellerId: "seller-1",
+        priceSnapshot: amount,
+        listing: {
+          id: "listing-1",
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+      },
+    ],
+  };
+}
+
+function renderDashboard() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <SellerDashboard />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SellerDashboard", () => {
+  beforeEach(() => {
+    getSellerListings.mockReset();
+    listOrders.mockReset();
+  });
+
+  it("shows listing, revenue and order stats without leftover marketplace chrome", async () => {
+    getSellerListings.mockResolvedValue({
+      items: [listing("ACTIVE"), listing("SOLD")],
+      total: 2,
+    });
+    listOrders.mockResolvedValue([order("ord-1", 42)]);
+
+    renderDashboard();
+
+    expect(await screen.findByText("Visão geral")).toBeTruthy();
+    expect(screen.getByText("Listings ativos")).toBeTruthy();
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$42.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("AK-47 | Redline")).toBeTruthy();
+    expect(screen.queryByText(/SKINMARKET/i)).toBeNull();
+    expect(screen.queryByText(/CS2 Skin Marketplace/i)).toBeNull();
+  });
+});

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -4,7 +4,6 @@ import {
   Pencil,
   Trash2,
   EyeOff,
-  Eye,
   Loader2,
   DollarSign,
 } from "lucide-react";
@@ -275,24 +274,35 @@ export default function SellerListings() {
   if (error && !seller) {
     return (
       <div className="space-y-4">
-        <h1 className="text-2xl font-heading text-foreground">Meus Listings</h1>
-        <p className="text-destructive">{error}</p>
+        <h1 className="text-2xl font-semibold tracking-tight">Meus listings</h1>
+        <p className="text-sm text-destructive">{error}</p>
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-heading text-foreground">Meus Listings</h1>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Meus listings
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            CRUD de itens únicos. O catálogo de produtos é somente leitura.
+          </p>
+        </div>
         <Button onClick={openCreate} disabled={!seller}>
-          <Package className="h-4 w-4 mr-2" />
+          <Package className="mr-2 h-4 w-4" />
           Novo Listing
         </Button>
       </div>
 
       {loading ? (
-        <div className="flex items-center justify-center py-12">
+        <div
+          className="flex items-center justify-center py-12"
+          role="status"
+          aria-label="Carregando"
+        >
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
       ) : (
@@ -328,7 +338,7 @@ export default function SellerListings() {
                       <TableCell className="hidden md:table-cell text-muted-foreground">
                         {Number(l.floatValue).toFixed(8)}
                       </TableCell>
-                      <TableCell className="text-primary font-heading">
+                      <TableCell className="tabular-nums font-medium">
                         ${Number(l.price).toFixed(2)}
                       </TableCell>
                       <TableCell>

--- a/src/pages/seller/SellerOrders.tsx
+++ b/src/pages/seller/SellerOrders.tsx
@@ -1,108 +1,125 @@
-import { useQuery } from '@tanstack/react-query';
-import { motion } from 'framer-motion';
-import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { listOrders } from '@/api/orders';
-import { AlertCircle, Loader2 } from 'lucide-react';
-import type { Order } from '@/types/api';
+import { useQuery } from "@tanstack/react-query";
+import { listOrders } from "@/api/orders";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Order } from "@/types/api";
+
+function orderTotal(order: Order): number {
+  if (order.totalAmount != null && Number(order.totalAmount) > 0) {
+    return Number(order.totalAmount);
+  }
+  return (
+    order.items?.reduce(
+      (sum, item) => sum + Number(item.priceSnapshot || 0),
+      0,
+    ) ?? 0
+  );
+}
 
 export default function SellerOrdersPage() {
-  const { data: orders = [], isLoading, error } = useQuery({
-    queryKey: ['sellerOrders'],
+  const {
+    data: orders = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["sellerOrders"],
     queryFn: () => listOrders(),
   });
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-black flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-blue-500 animate-spin" />
+      <div className="space-y-3" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
       </div>
     );
   }
 
-  if (error) {
+  if (isError) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-black flex items-center justify-center">
-        <div className="text-center">
-          <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-          <p className="text-white text-lg">Failed to load orders</p>
-        </div>
-      </div>
+      <ErrorState
+        title="Erro ao carregar pedidos"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button type="button" variant="outline" onClick={() => refetch()}>
+            Tentar novamente
+          </Button>
+        }
+      />
     );
   }
 
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-      className="min-h-screen bg-gradient-to-br from-gray-900 to-black p-6"
-    >
-      <div className="container mx-auto max-w-7xl">
-        <motion.div initial={{ y: 20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ duration: 0.3 }}>
-          <h1 className="text-4xl font-bold text-white mb-2">Orders</h1>
-          <p className="text-gray-400 mb-8">Manage your CS2 skin marketplace orders</p>
-        </motion.div>
-
-        {orders.length === 0 ? (
-          <Card className="bg-gray-800 border-gray-700">
-            <CardContent className="p-12 text-center">
-              <p className="text-gray-400">No orders yet</p>
-            </CardContent>
-          </Card>
-        ) : (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, delay: 0.1 }}
-            className="space-y-4"
-          >
-            {orders.map((order) => (
-              <OrderCard key={order.id} order={order} />
-            ))}
-          </motion.div>
-        )}
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Pedidos</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Pedidos que incluem um listing da sua loja.
+        </p>
       </div>
-    </motion.div>
-  );
-}
 
-function OrderCard({ order }: { order: Order }) {
-  const itemsSummary = order.items
-    ?.slice(0, 2)
-    .map((i) => i.listing?.product ? `${i.listing.product.weapon} | ${i.listing.product.skinName}` : 'Item')
-    .join(', ') ?? '—';
-  const hasMore = order.items && order.items.length > 2 ? '…' : '';
+      {orders.length === 0 ? (
+        <EmptyState
+          title="Nenhum pedido"
+          description="Quando um listing for vendido, o pedido aparece aqui."
+        />
+      ) : (
+        <ul className="space-y-2">
+          {orders.map((order) => {
+            const summary =
+              order.items
+                ?.slice(0, 2)
+                .map((item) =>
+                  item.listing?.product
+                    ? `${item.listing.product.weapon} | ${item.listing.product.skinName}`
+                    : "Item",
+                )
+                .join(", ") ?? "—";
+            const extra = order.items && order.items.length > 2 ? "…" : "";
 
-  const total = order.items?.reduce((sum, i) => sum + Number(i.priceSnapshot || 0), 0) || 0;
-
-  return (
-    <Card className="bg-gray-800 border-gray-700 hover:border-gray-600 transition-colors">
-      <CardContent className="p-6">
-        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-          <div className="flex-1">
-            <h3 className="text-white font-semibold mb-1">Order #{order.id}</h3>
-            <p className="text-gray-400 text-sm mb-3">
-              {itemsSummary}
-              {hasMore}
-            </p>
-            <div className="flex items-center gap-4">
-              <Badge variant={order.status === 'COMPLETED' ? 'default' : 'secondary'}>
-                {order.status}
-              </Badge>
-              {order.createdAt && (
-                <p className="text-gray-400 text-sm">
-                  {new Date(order.createdAt).toLocaleDateString()}
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="text-right">
-            <p className="text-white text-2xl font-bold">${total.toFixed(2)}</p>
-            <p className="text-gray-400 text-sm">{order.items?.length ?? 0} items</p>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+            return (
+              <li
+                key={order.id}
+                className="flex flex-col justify-between gap-3 rounded-md border border-border bg-card p-4 sm:flex-row sm:items-center"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">Pedido {order.id}</p>
+                  <p className="mt-1 truncate text-sm text-muted-foreground">
+                    {summary}
+                    {extra}
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary">{order.status}</Badge>
+                    {order.createdAt ? (
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(order.createdAt).toLocaleDateString()}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+                <div className="text-left sm:text-right">
+                  <p className="tabular-nums text-lg font-semibold">
+                    ${orderTotal(order).toFixed(2)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {order.items?.length ?? 0}{" "}
+                    {(order.items?.length ?? 0) === 1 ? "item" : "itens"}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/src/pages/seller/SellerProducts.tsx
+++ b/src/pages/seller/SellerProducts.tsx
@@ -1,415 +1,136 @@
-import { useEffect, useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { motion } from "framer-motion";
-import { Trash2, Edit2, Loader2, AlertCircle } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { listProducts } from "@/api/products";
+import { EmptyState, ErrorState } from "@/components/page-state";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
-  getSellerListings,
-  createListing,
-  updateListing,
-  cancelListing,
-} from "@/api/listings";
-import type { Listing } from "@/types/api";
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const PAGE_SIZE = 20;
 
 export default function SellerProductsPage() {
-  const queryClient = useQueryClient();
-  const [listings, setListings] = useState<Listing[]>([]);
-  const [showForm, setShowForm] = useState(false);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [formData, setFormData] = useState({
-    productId: "",
-    floatValue: "",
-    price: "",
-    pattern: "",
+  const [page, setPage] = useState(1);
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["products", { page, limit: PAGE_SIZE }],
+    queryFn: () => listProducts({ page, limit: PAGE_SIZE }),
   });
 
-  const { data: sellerListings, isLoading } = useQuery({
-    queryKey: ["sellerListings"],
-    queryFn: () => getSellerListings(),
-  });
-
-  useEffect(() => {
-    if (sellerListings && "items" in sellerListings) {
-      setListings(
-        (sellerListings as { items: Listing[]; total: number }).items,
-      );
-    } else if (Array.isArray(sellerListings)) {
-      setListings(sellerListings);
-    }
-  }, [sellerListings]);
-
-  const createMutation = useMutation({
-    mutationFn: (input: {
-      productId: string;
-      floatValue: number;
-      price: number;
-      pattern?: number;
-    }) => createListing(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sellerListings"] });
-      setFormData({ productId: "", floatValue: "", price: "", pattern: "" });
-      setShowForm(false);
-    },
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({
-      id,
-      input,
-    }: {
-      id: string;
-      input: Partial<{
-        price: number;
-        status: "ACTIVE" | "SOLD" | "RESERVED" | "CANCELED";
-        tradeLockUntil: string | null;
-      }>;
-    }) => updateListing(id, input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sellerListings"] });
-      setEditingId(null);
-      setFormData({ productId: "", floatValue: "", price: "", pattern: "" });
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => cancelListing(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["sellerListings"] });
-    },
-  });
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const floatValue = parseFloat(formData.floatValue);
-    const price = parseFloat(formData.price);
-
-    if (!formData.productId || isNaN(floatValue) || isNaN(price)) {
-      alert("Please fill in all required fields");
-      return;
-    }
-
-    if (editingId) {
-      updateMutation.mutate({
-        id: editingId,
-        input: {
-          price,
-          status: "ACTIVE",
-        },
-      });
-    } else {
-      createMutation.mutate({
-        productId: formData.productId,
-        floatValue,
-        price,
-        pattern: formData.pattern ? parseInt(formData.pattern) : undefined,
-      });
-    }
-  };
-
-  const handleEdit = (listing: Listing) => {
-    setEditingId(listing.id);
-    setFormData({
-      productId: listing.productId,
-      floatValue: listing.floatValue.toString(),
-      price: listing.price.toString(),
-      pattern: listing.pattern?.toString() || "",
-    });
-    setShowForm(true);
-  };
-
-  const handleCancel = (id: string) => {
-    if (window.confirm("Are you sure you want to cancel this listing?")) {
-      deleteMutation.mutate(id);
-    }
-  };
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-black flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-blue-500 animate-spin" />
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-48 w-full" />
       </div>
     );
   }
 
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar o catálogo"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button type="button" variant="outline" onClick={() => refetch()}>
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
+
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.5 }}
-      className="min-h-screen bg-gradient-to-br from-gray-900 to-black p-6"
-    >
-      <div className="container mx-auto max-w-7xl">
-        <motion.div
-          initial={{ y: 20, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          transition={{ duration: 0.3 }}
-        >
-          <div className="flex items-center justify-between mb-8">
-            <div>
-              <h1 className="text-4xl font-bold text-white mb-2">
-                My Listings
-              </h1>
-              <p className="text-gray-400">
-                Manage your CS2 skin marketplace listings
-              </p>
-            </div>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Produtos</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Catálogo somente leitura. Para anunciar um item único, use Listings.
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link to="/seller/listings">Ir para listings</Link>
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <EmptyState
+          title="Nenhum produto no catálogo"
+          description="O catálogo é gerenciado pelo admin."
+        />
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Skin</TableHead>
+                <TableHead>Raridade</TableHead>
+                <TableHead className="hidden md:table-cell">Exterior</TableHead>
+                <TableHead className="hidden md:table-cell">Coleção</TableHead>
+                <TableHead>StatTrak™</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((product) => (
+                <TableRow key={product.id}>
+                  <TableCell className="font-medium">
+                    {product.weapon} | {product.skinName}
+                  </TableCell>
+                  <TableCell>{product.rarity}</TableCell>
+                  <TableCell className="hidden text-muted-foreground md:table-cell">
+                    {product.exterior}
+                  </TableCell>
+                  <TableCell className="hidden text-muted-foreground md:table-cell">
+                    {product.collection || "N/A"}
+                  </TableCell>
+                  <TableCell>{product.isStattrak ? "Sim" : "Não"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {total > PAGE_SIZE ? (
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span className="tabular-nums">{total} produtos</span>
+          <div className="flex gap-2">
             <Button
-              onClick={() => {
-                setEditingId(null);
-                setFormData({
-                  productId: "",
-                  floatValue: "",
-                  price: "",
-                  pattern: "",
-                });
-                setShowForm(!showForm);
-              }}
-              className="bg-blue-600 hover:bg-blue-700"
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
             >
-              {showForm ? "Cancel" : "Create Listing"}
+              Anterior
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={page >= pageCount}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Próxima
             </Button>
           </div>
-        </motion.div>
-
-        {/* Form */}
-        {showForm && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            className="mb-8"
-          >
-            <Card className="bg-gray-800 border-gray-700">
-              <CardHeader>
-                <CardTitle className="text-white">
-                  {editingId ? "Edit Listing" : "Create New Listing"}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-gray-300 text-sm font-medium mb-2">
-                        Product ID*
-                      </label>
-                      <Input
-                        type="text"
-                        placeholder="e.g., 1, 2, 3..."
-                        value={formData.productId}
-                        onChange={(e) =>
-                          setFormData({
-                            ...formData,
-                            productId: e.target.value,
-                          })
-                        }
-                        disabled={!!editingId}
-                        className="bg-gray-700 border-gray-600 text-white"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-gray-300 text-sm font-medium mb-2">
-                        Float Value (0-1)*
-                      </label>
-                      <Input
-                        type="number"
-                        placeholder="0.15"
-                        step="0.01"
-                        min="0"
-                        max="1"
-                        value={formData.floatValue}
-                        onChange={(e) =>
-                          setFormData({
-                            ...formData,
-                            floatValue: e.target.value,
-                          })
-                        }
-                        disabled={!!editingId}
-                        className="bg-gray-700 border-gray-600 text-white"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-gray-300 text-sm font-medium mb-2">
-                        Price (USD)*
-                      </label>
-                      <Input
-                        type="number"
-                        placeholder="9.99"
-                        step="0.01"
-                        min="0"
-                        value={formData.price}
-                        onChange={(e) =>
-                          setFormData({ ...formData, price: e.target.value })
-                        }
-                        className="bg-gray-700 border-gray-600 text-white"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-gray-300 text-sm font-medium mb-2">
-                        Pattern (optional)
-                      </label>
-                      <Input
-                        type="number"
-                        placeholder="1000"
-                        value={formData.pattern}
-                        onChange={(e) =>
-                          setFormData({ ...formData, pattern: e.target.value })
-                        }
-                        disabled={!!editingId}
-                        className="bg-gray-700 border-gray-600 text-white"
-                      />
-                    </div>
-                  </div>
-                  <div className="flex gap-2 pt-4">
-                    <Button
-                      type="submit"
-                      disabled={
-                        createMutation.isPending || updateMutation.isPending
-                      }
-                      className="bg-blue-600 hover:bg-blue-700"
-                    >
-                      {createMutation.isPending || updateMutation.isPending ? (
-                        <>
-                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                          {editingId ? "Updating..." : "Creating..."}
-                        </>
-                      ) : editingId ? (
-                        "Update Listing"
-                      ) : (
-                        "Create Listing"
-                      )}
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={() => {
-                        setShowForm(false);
-                        setEditingId(null);
-                      }}
-                      variant="outline"
-                      className="border-gray-600 text-gray-300 hover:bg-gray-700"
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
-          </motion.div>
-        )}
-
-        {/* Listings Table */}
-        {listings.length === 0 ? (
-          <Card className="bg-gray-800 border-gray-700">
-            <CardContent className="p-12 text-center">
-              <AlertCircle className="w-12 h-12 text-gray-500 mx-auto mb-4" />
-              <p className="text-gray-400">
-                No listings yet. Create your first listing!
-              </p>
-            </CardContent>
-          </Card>
-        ) : (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.3, delay: 0.1 }}
-            className="overflow-x-auto"
-          >
-            <Card className="bg-gray-800 border-gray-700">
-              <CardContent className="p-0">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-gray-700">
-                      <th className="px-6 py-3 text-left text-gray-300 font-semibold">
-                        Skin
-                      </th>
-                      <th className="px-6 py-3 text-left text-gray-300 font-semibold">
-                        Float
-                      </th>
-                      <th className="px-6 py-3 text-left text-gray-300 font-semibold">
-                        Price
-                      </th>
-                      <th className="px-6 py-3 text-left text-gray-300 font-semibold">
-                        Status
-                      </th>
-                      <th className="px-6 py-3 text-left text-gray-300 font-semibold">
-                        Actions
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {listings.map((listing) => (
-                      <motion.tr
-                        key={listing.id}
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        className="border-b border-gray-700 hover:bg-gray-700 transition-colors"
-                      >
-                        <td className="px-6 py-4">
-                          <div className="text-white font-medium">
-                            {listing.product?.weapon} |{" "}
-                            {listing.product?.skinName}
-                          </div>
-                          <div className="text-gray-400 text-sm">
-                            {listing.product?.exterior}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 text-gray-300">
-                          {Number(listing.floatValue).toFixed(4)}
-                        </td>
-                        <td className="px-6 py-4 text-white font-semibold">
-                          ${Number(listing.price).toFixed(2)}
-                        </td>
-                        <td className="px-6 py-4">
-                          <Badge
-                            variant={
-                              listing.status === "ACTIVE"
-                                ? "default"
-                                : "secondary"
-                            }
-                          >
-                            {listing.status}
-                          </Badge>
-                        </td>
-                        <td className="px-6 py-4">
-                          <div className="flex gap-2">
-                            {listing.status === "ACTIVE" && (
-                              <Button
-                                size="sm"
-                                onClick={() => handleEdit(listing)}
-                                disabled={
-                                  updateMutation.isPending ||
-                                  editingId === listing.id
-                                }
-                                className="bg-blue-600 hover:bg-blue-700"
-                              >
-                                <Edit2 className="w-4 h-4" />
-                              </Button>
-                            )}
-                            <Button
-                              size="sm"
-                              onClick={() => handleCancel(listing.id)}
-                              disabled={
-                                deleteMutation.isPending ||
-                                listing.status !== "ACTIVE"
-                              }
-                              variant="destructive"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                            </Button>
-                          </div>
-                        </td>
-                      </motion.tr>
-                    ))}
-                  </tbody>
-                </table>
-              </CardContent>
-            </Card>
-          </motion.div>
-        )}
-      </div>
-    </motion.div>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import SellerListings from "../SellerListings";
+import type { Listing, Seller } from "@/types/api";
+
+const getSellerMe = vi.fn();
+const getSellerListings = vi.fn();
+const listProducts = vi.fn();
+
+vi.mock("@/api", () => ({
+  getSellerMe: (...args: unknown[]) => getSellerMe(...args),
+  getSellerListings: (...args: unknown[]) => getSellerListings(...args),
+  createListing: vi.fn(),
+  updateListing: vi.fn(),
+  updateListingPrice: vi.fn(),
+  cancelListing: vi.fn(),
+}));
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function seller(): Seller {
+  return {
+    id: "seller-1",
+    userId: "user-1",
+    storeName: "NeonTrader Store",
+    balance: 0,
+    rating: 0,
+    isApproved: true,
+  };
+}
+
+function listing(): Listing {
+  return {
+    id: "listing-1",
+    productId: "ak-redline-ft",
+    sellerId: "seller-1",
+    floatValue: 0.25,
+    pattern: 123,
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: {
+      id: "ak-redline-ft",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+  };
+}
+
+describe("SellerListings", () => {
+  beforeEach(() => {
+    getSellerMe.mockReset();
+    getSellerListings.mockReset();
+    listProducts.mockReset();
+    getSellerMe.mockResolvedValue(seller());
+    getSellerListings.mockResolvedValue({ items: [listing()], total: 1 });
+    listProducts.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 100,
+    });
+  });
+
+  it("keeps unique-item listing CRUD on /seller/listings", async () => {
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Novo Listing" }),
+    ).toBeTruthy();
+    expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    expect(screen.getByTitle("Editar")).toBeTruthy();
+    expect(screen.getByTitle("Atualizar preço")).toBeTruthy();
+    expect(screen.getByTitle("Cancelar listing")).toBeTruthy();
+  });
+});

--- a/src/pages/seller/__tests__/SellerProducts.test.tsx
+++ b/src/pages/seller/__tests__/SellerProducts.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SellerProductsPage from "../SellerProducts";
+import type { Product } from "@/types/api";
+
+const listProducts = vi.fn();
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+function product(): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    collection: "The Huntsman Collection",
+    imageUrl: null,
+    isStattrak: false,
+    isSouvenir: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function renderProducts() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <SellerProductsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SellerProducts", () => {
+  beforeEach(() => {
+    listProducts.mockReset();
+  });
+
+  it("renders a read-only product catalog from listProducts", async () => {
+    listProducts.mockResolvedValue({
+      items: [product()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderProducts();
+
+    expect(await screen.findByText("Produtos")).toBeTruthy();
+    expect(screen.getByText("AK-47 | Redline")).toBeTruthy();
+    expect(screen.getByText("Classified")).toBeTruthy();
+    expect(screen.getByText("The Huntsman Collection")).toBeTruthy();
+    expect(
+      screen.getByText("Ir para listings").closest("a")?.getAttribute("href"),
+    ).toBe("/seller/listings");
+    expect(listProducts).toHaveBeenCalled();
+  });
+
+  it("does not expose listing or product mutations", async () => {
+    listProducts.mockResolvedValue({
+      items: [product()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderProducts();
+    await screen.findByText("AK-47 | Redline");
+
+    expect(screen.queryByText("Novo Listing")).toBeNull();
+    expect(screen.queryByText("Create Listing")).toBeNull();
+    expect(screen.queryByText("Editar")).toBeNull();
+    expect(screen.queryByText("Excluir")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /criar|salvar|excluir/i }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebuild do painel do seller no visual dark editorial.

## Escopo
- `src/pages/SellerDashboard.tsx`
- `src/pages/seller/SellerListings.tsx`
- `src/pages/seller/SellerProducts.tsx`
- `src/pages/seller/SellerOrders.tsx`

Sem `server/`, sem Header/DashboardLayout, sem nova rota.

## Aceite
- `/seller/listings` e `/seller/products` continuam existindo
- Listings permanece CRUD de item único
- Products vira catálogo somente leitura via `listProducts` (não é mais um segundo CRUD de listings)

## Verificação
- `npm run typecheck`
- `npm run lint` (0 errors)
- `npm test` — 50 passed
- UI: visão geral, listings com Novo Listing, products só leitura, pedidos

[Visão geral do seller](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller_overview.webp)
[Listings CRUD](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller_listings_crud.webp)
[Catálogo de produtos somente leitura](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller_products_readonly.webp)
[Pedidos do seller](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller_orders_empty.webp)
[seller_dashboard_listings_products_orders.mp4](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller_dashboard_listings_products_orders.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

