### PR TITLE
P1.3: External-call resilience and graceful shutdown

### DIFF
--- a/docs/adr/0005-external-retry-and-graceful-shutdown.md
+++ b/docs/adr/0005-external-retry-and-graceful-shutdown.md
@@ -1,0 +1,31 @@
+# ADR 0005 — External retry policy and graceful shutdown
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #8 / roadmap P1.3 needs explicit timeouts, bounded retries, retry classification, and a process lifecycle that can drain HTTP work without adding a queue, worker fleet, or circuit breaker. PayPal `OrdersCreate` already has a timeout and must not be retried. PayPal lookups already retried 5xx/429 with linear delay. The HTTP server did not stop jobs or disconnect PostgreSQL on SIGTERM.
+
+A circuit breaker is not justified: the failure mode is provider blips and process replacement, not a measured retry storm.
+
+## Decision
+
+1. Keep PostgreSQL as the source of truth. External retries never create a second local order, reservation, payment confirmation, or seller transaction.
+2. Classify provider failures once:
+   - retryable: timeout/abort, network, HTTP 429, HTTP 5xx;
+   - not retryable: other HTTP 4xx and untagged business `AppError`s.
+3. Retry only idempotent (or acceptably duplicate) calls, with max 3 attempts and exponential backoff `baseDelayMs * 2^(attempt-1)` (200ms base):
+   - PayPal `OrdersGet`, OAuth token, certificate download;
+   - Resend verification email (same code; a timeout after accept can send a duplicate email).
+4. Do not retry `OrdersCreate` or `OrdersCapture`. A hung create is recovered by the buyer retrying with the same `Idempotency-Key` (new PayPal order is a new local payment attempt). A hung capture is recovered by the webhook or the GET reconciliation sweep.
+5. On SIGTERM/SIGINT: mark the process shutting down (`GET /ready` → 503 `shutting_down`), stop in-process job timers, `server.close()` with a 10s drain then `closeAllConnections()`, disconnect Prisma, then shut down telemetry. Liveness `GET /health` stays 200 until the process exits.
+
+Rejected alternatives: retrying every HTTP client by default; Redis/SQS for retries; a circuit breaker without evidence of retry amplification.
+
+## Consequences
+
+- Render/Railway can drain an instance via `/ready` while `/health` remains a liveness probe.
+- Multiple replicas may still run expiry and reconciliation sweeps; those remain safe because of conditional PostgreSQL updates.
+- Verification email is the only retried call with a user-visible duplicate side effect, and only of the same short-lived code.

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -32,7 +32,7 @@ Express API --> PayPal
 Express API --> Resend
 ```
 
-The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling.
+The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts` and `startApiProcess`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling. `startApiProcess` binds `0.0.0.0:$PORT`, starts the in-process reservation-expiry and PayPal-reconciliation jobs, and registers SIGTERM/SIGINT graceful shutdown (drain HTTP, stop jobs, disconnect Prisma, shut down telemetry). `GET /ready` returns 503 `shutting_down` after shutdown begins.
 
 Observability is optional. `OTEL_ENABLED` defaults to off so `npm run dev` does not need a collector. See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
 
@@ -76,7 +76,7 @@ Expired reservations are released by an in-process sweep that calls `listingsSer
 
 ### Payment confirmation
 
-Payment creation calls PayPal outside the database transaction, with an explicit timeout (`PAYPAL_API_TIMEOUT_MS`, default 10s). `OrdersCreate` is not retried. The PayPal order ID is stored on the local order.
+Payment creation calls PayPal outside the database transaction, with an explicit timeout (`PAYPAL_API_TIMEOUT_MS`, default 10s). `OrdersCreate` and `OrdersCapture` are not retried. Idempotent PayPal reads (order GET, OAuth token, webhook certificate) retry HTTP 5xx/429, timeouts and network errors up to 3 times with exponential backoff. The PayPal order ID is stored on the local order.
 
 Webhook handling:
 

--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -48,7 +48,7 @@ Rules:
 6. A crash must not permanently leave the system unable to reconcile external payment state with local state.
 7. Each PayPal webhook event id is persisted (`PaymentWebhookEvent`) with a unique constraint on `(provider, externalEventId)`.
 8. Only `PAYMENT.CAPTURE.COMPLETED` confirms local payment. `CHECKOUT.ORDER.APPROVED` is intermediate and must not sell listings or create seller transactions.
-9. External PayPal calls have an explicit timeout. Creating a PayPal order is not retried. Looking up PayPal order status may retry HTTP 5xx/429.
+9. External PayPal calls have an explicit timeout. Creating or capturing a PayPal order is not retried. Looking up PayPal order status, fetching an OAuth token, or downloading a webhook certificate may retry HTTP 5xx/429, timeouts and network errors (max 3 attempts, exponential backoff).
 
 ## Seller finances
 

--- a/docs/architecture/failure-modes.md
+++ b/docs/architecture/failure-modes.md
@@ -1,0 +1,48 @@
+# Failure Modes
+
+This is the operational map of how Neon Arsenal fails and recovers. PostgreSQL remains authoritative for business state. PayPal and Resend are unreliable from the application's point of view.
+
+## External HTTP
+
+| Call | Timeout | Retry | Duplicate risk | Recovery if the process dies after a remote success |
+|---|---|---|---|---|
+| PayPal `OrdersCreate` | `PAYPAL_API_TIMEOUT_MS` (10s) | None | A retry would open a second PayPal order | Buyer retries `POST /payments` or `POST /orders` with the same idempotency key. Orphan PayPal orders are not captured locally. |
+| PayPal `OrdersCapture` | same | None | Capture can move funds | Webhook `PAYMENT.CAPTURE.COMPLETED` or GET reconciliation. |
+| PayPal `OrdersGet` | same | 3 attempts, 5xx/429/timeout/network, exponential backoff | Read-only | Next reconciliation sweep. |
+| PayPal OAuth token | same | same as GET | Read-only token | Next call fetches a new token. |
+| PayPal webhook cert download | same | same as GET | Read-only | Next webhook retries; PayPal retries the delivery. |
+| Resend verification email | `EMAIL_API_TIMEOUT_MS` (10s) | 3 attempts, 5xx/429/timeout/network | Same code may be emailed twice if Resend accepted after our timeout | User uses the code from either email. 4xx is not retried. |
+
+Classification lives in `server/src/shared/resilience/retry.ts`. Circuit breakers are not used.
+
+## Payments and webhooks
+
+- Duplicate PayPal events: unique `(provider, externalEventId)` plus `confirmPayment` claim. See `docs/adr/0002-paypal-webhook-reliability.md`.
+- Out-of-order `CHECKOUT.ORDER.APPROVED` then capture: approved events are stored as `IGNORED`; only `PAYMENT.CAPTURE.COMPLETED` sells listings.
+- Capture after reservation expiry: local confirm rolls back; webhook returns HTTP 200 so PayPal stops; money captured then needs an operational refund.
+- Capture that cannot resolve a local order yet: HTTP 503 so PayPal retries.
+- Process crash after PayPal capture and before local commit: webhook retry or in-process GET reconciliation (60s, min age 2 minutes, batch 20).
+
+## Reservations and orders
+
+- Two buyers, one listing: one `ACTIVE → RESERVED` conditional update wins. See `docs/architecture/domain-invariants.md`.
+- Expiry vs payment: expiry cannot overwrite `SOLD`; payment cannot sell an expired or re-reserved listing. See `docs/adr/0001-in-process-reservation-expiry.md`.
+- Duplicate `POST /orders`: customer `Idempotency-Key` in the same transaction as the reservation. See `docs/adr/0003-order-creation-idempotency.md`.
+
+## Process lifecycle
+
+On SIGTERM/SIGINT the API:
+
+1. Marks itself shutting down (`GET /ready` returns 503 `shutting_down`).
+2. Stops reservation-expiry and PayPal-reconciliation timers (in-flight sweeps may finish).
+3. Stops accepting new HTTP connections and drains in-flight requests for up to 10s, then closes remaining connections.
+4. Disconnects Prisma.
+5. Shuts down OpenTelemetry exporters.
+
+`GET /health` remains 200 until exit so liveness probes do not kill a draining instance early. New work is refused by `server.close()` and by `/ready`.
+
+A crash during shutdown is the same as any other crash: PostgreSQL constraints plus webhook/reconciliation recover payment; the next process starts new job timers.
+
+## What this document does not add
+
+No Redis, Kafka, SQS, or extra worker service. Those would only be justified by a measured bottleneck (for example expiry delayed by a frozen event loop on every replica).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,15 +69,16 @@ See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
 
 ### P1.3 Resilience
 
-Add explicit:
+Implemented:
 
-- external request timeouts;
-- bounded retries with backoff;
-- retry classification;
-- graceful shutdown;
-- reconciliation jobs where needed.
+- shared retry classification (timeout/network/429/5xx vs other 4xx) with max 3 attempts and exponential backoff;
+- PayPal `OrdersCreate` / `OrdersCapture` still not retried;
+- PayPal `OrdersGet`, OAuth token and webhook certificate download retry retryable failures;
+- Resend verification email retries retryable failures; 4xx is not retried;
+- SIGTERM/SIGINT drains HTTP (10s), stops in-process jobs, disconnects Prisma, shuts down telemetry;
+- `GET /ready` returns 503 `shutting_down` during drain.
 
-Use circuit breakers only when a concrete failure mode justifies them.
+See `docs/adr/0005-external-retry-and-graceful-shutdown.md` and `docs/architecture/failure-modes.md`.
 
 ### P1.4 Performance evidence
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,11 +3,7 @@ import { startTelemetry } from "./shared/observability/sdk.js";
 await startTelemetry();
 
 const { app } = await import("./app.js");
-const { startReservationExpiryJob } = await import("./shared/jobs/reservationExpiryJob.js");
-const { startPaypalReconciliationJob } = await import("./shared/jobs/paypalReconciliationJob.js");
-
-const PORT = Number(process.env.PORT ?? 3001);
-const HOST = "0.0.0.0";
+const { startApiProcess } = await import("./shared/lifecycle/startApi.js");
 
 if (process.env.SEED_DEMO_DATA === "true") {
   const { seedDemoData } = await import("./scripts/seedDemoData.js");
@@ -19,8 +15,4 @@ if (process.env.SEED_DEMO_DATA === "true") {
   }
 }
 
-app.listen(PORT, HOST, () => {
-  console.log(`Server running on http://${HOST}:${PORT}`);
-  startReservationExpiryJob();
-  startPaypalReconciliationJob();
-});
+startApiProcess(app);

--- a/server/src/shared/config/paypal.ts
+++ b/server/src/shared/config/paypal.ts
@@ -29,3 +29,9 @@ export function getPayPalApiBaseUrl(): string {
     ? "https://api-m.paypal.com"
     : "https://api-m.sandbox.paypal.com";
 }
+
+/** Lookup/token/cert fetches may retry; mutating PayPal calls must not. */
+export const PAYPAL_IDEMPOTENT_RETRY = {
+  maxAttempts: 3,
+  baseDelayMs: 200,
+} as const;

--- a/server/src/shared/database/index.ts
+++ b/server/src/shared/database/index.ts
@@ -1,1 +1,1 @@
-export { prisma } from "./prisma.js";
+export { prisma, disconnectPrisma } from "./prisma.js";

--- a/server/src/shared/database/prisma.ts
+++ b/server/src/shared/database/prisma.ts
@@ -14,3 +14,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 export const prisma = withPrismaObservability(baseClient);
+
+export async function disconnectPrisma(): Promise<void> {
+  await baseClient.$disconnect();
+}

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -114,6 +114,19 @@ export const openApiSpec = {
         },
       },
     },
+    "/ready": {
+      get: {
+        tags: ["Health"],
+        summary: "Readiness check",
+        description:
+          "Returns 200 when PostgreSQL is reachable. Returns 503 `unavailable` when the database check fails, or 503 `shutting_down` after SIGTERM/SIGINT so load balancers can drain the instance.",
+        security: [],
+        responses: {
+          200: { description: "Process can serve traffic", content: { "application/json": { schema: { type: "object", properties: { status: { type: "string", example: "ready" } } } } } },
+          503: { description: "Database unreachable or process shutting down" },
+        },
+      },
+    },
     "/auth/register": {
       post: {
         tags: ["Auth"],

--- a/server/src/shared/lifecycle/__tests__/shutdown.test.ts
+++ b/server/src/shared/lifecycle/__tests__/shutdown.test.ts
@@ -1,0 +1,97 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetLifecycleForTests } from "../state.js";
+import { resetShutdownForTests, runGracefulShutdown } from "../shutdown.js";
+
+vi.mock("../../database/prisma.js", () => ({
+  disconnectPrisma: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../observability/sdk.js", () => ({
+  shutdownTelemetry: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return `http://127.0.0.1:${port}`;
+}
+
+describe("graceful shutdown", () => {
+  afterEach(() => {
+    resetShutdownForTests();
+    resetLifecycleForTests();
+    vi.clearAllMocks();
+  });
+
+  it("stops jobs, refuses new HTTP work, and releases database and telemetry", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" }).end("ok");
+    });
+    const baseUrl = await listen(server);
+    const stopJobs = vi.fn();
+    const disconnectDb = vi.fn().mockResolvedValue(undefined);
+    const shutdownTelemetryFn = vi.fn().mockResolvedValue(undefined);
+    const exit = vi.fn();
+
+    await expect(fetch(baseUrl)).resolves.toMatchObject({ status: 200 });
+
+    const first = runGracefulShutdown({
+      server,
+      stopJobs,
+      disconnectDb,
+      shutdownTelemetryFn,
+      drainMs: 50,
+      exit,
+    });
+    const second = runGracefulShutdown({
+      server,
+      stopJobs,
+      disconnectDb,
+      shutdownTelemetryFn,
+      drainMs: 50,
+      exit,
+    });
+    await Promise.all([first, second]);
+
+    expect(stopJobs).toHaveBeenCalledOnce();
+    expect(disconnectDb).toHaveBeenCalledOnce();
+    expect(shutdownTelemetryFn).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(0);
+    await expect(fetch(baseUrl)).rejects.toThrow();
+  });
+
+  it("still releases later resources when HTTP close fails", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200).end("ok");
+    });
+    await listen(server);
+    vi.spyOn(server, "close").mockImplementation((cb) => {
+      cb?.(new Error("close failed"));
+      return server;
+    });
+    const disconnectDb = vi.fn().mockResolvedValue(undefined);
+    const shutdownTelemetryFn = vi.fn().mockResolvedValue(undefined);
+    const exit = vi.fn();
+
+    await runGracefulShutdown({
+      server,
+      stopJobs: vi.fn(),
+      disconnectDb,
+      shutdownTelemetryFn,
+      drainMs: 20,
+      exit,
+    });
+
+    expect(disconnectDb).toHaveBeenCalledOnce();
+    expect(shutdownTelemetryFn).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(1);
+    vi.mocked(server.close).mockRestore();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});

--- a/server/src/shared/lifecycle/shutdown.ts
+++ b/server/src/shared/lifecycle/shutdown.ts
@@ -1,0 +1,109 @@
+import type { Server } from "node:http";
+import { logger } from "../logger.js";
+import { disconnectPrisma } from "../database/prisma.js";
+import { shutdownTelemetry } from "../observability/sdk.js";
+import { beginShutdown, isProcessShuttingDown } from "./state.js";
+
+/** Bound wait for in-flight HTTP requests before connections are forced closed. */
+export const SHUTDOWN_DRAIN_MS = 10_000;
+
+export type GracefulShutdownParams = {
+  server: Server;
+  stopJobs: () => void;
+  disconnectDb?: () => Promise<void>;
+  shutdownTelemetryFn?: () => Promise<void>;
+  drainMs?: number;
+  exit?: (code: number) => void;
+};
+
+let inFlight: Promise<void> | undefined;
+
+export async function runGracefulShutdown(params: GracefulShutdownParams): Promise<void> {
+  if (!inFlight) {
+    inFlight = performShutdown(params);
+  }
+  await inFlight;
+}
+
+export function resetShutdownForTests(): void {
+  inFlight = undefined;
+}
+
+export function installProcessShutdownHandlers(
+  params: GracefulShutdownParams,
+  signals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"]
+): () => Promise<void> {
+  const shutdown = () =>
+    runGracefulShutdown({
+      ...params,
+      exit: params.exit ?? ((code) => process.exit(code)),
+    });
+
+  for (const signal of signals) {
+    process.once(signal, () => {
+      logger.info({ signal }, "shutdown signal received");
+      void shutdown();
+    });
+  }
+
+  return shutdown;
+}
+
+async function performShutdown(params: GracefulShutdownParams): Promise<void> {
+  const drainMs = params.drainMs ?? SHUTDOWN_DRAIN_MS;
+  const disconnectDb = params.disconnectDb ?? disconnectPrisma;
+  const shutdownTelemetryFn = params.shutdownTelemetryFn ?? shutdownTelemetry;
+  let exitCode = 0;
+
+  beginShutdown();
+  logger.info("graceful shutdown started");
+  params.stopJobs();
+
+  try {
+    await closeHttpServer(params.server, drainMs);
+  } catch (err) {
+    exitCode = 1;
+    logger.error({ err }, "http server close failed");
+  }
+
+  try {
+    await disconnectDb();
+  } catch (err) {
+    exitCode = 1;
+    logger.error({ err }, "database disconnect failed");
+  }
+
+  try {
+    await shutdownTelemetryFn();
+  } catch (err) {
+    exitCode = 1;
+    logger.error({ err }, "telemetry shutdown failed");
+  }
+
+  logger.info({ exitCode, shuttingDown: isProcessShuttingDown() }, "graceful shutdown finished");
+  params.exit?.(exitCode);
+}
+
+async function closeHttpServer(server: Server, drainMs: number): Promise<void> {
+  if (typeof server.closeIdleConnections === "function") {
+    server.closeIdleConnections();
+  }
+
+  let forceTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+      forceTimer = setTimeout(() => {
+        if (typeof server.closeAllConnections === "function") {
+          server.closeAllConnections();
+        }
+      }, drainMs);
+      forceTimer.unref();
+    });
+  } finally {
+    if (forceTimer) clearTimeout(forceTimer);
+  }
+}

--- a/server/src/shared/lifecycle/startApi.ts
+++ b/server/src/shared/lifecycle/startApi.ts
@@ -1,0 +1,34 @@
+import type { Express } from "express";
+import type { Server } from "node:http";
+import { logger } from "../logger.js";
+import { startPaypalReconciliationJob } from "../jobs/paypalReconciliationJob.js";
+import { startReservationExpiryJob } from "../jobs/reservationExpiryJob.js";
+import { installProcessShutdownHandlers } from "./shutdown.js";
+
+export function startApiProcess(
+  app: Express,
+  options?: { port?: number; host?: string; installSignals?: boolean }
+): Server {
+  const port = options?.port ?? Number(process.env.PORT ?? 3001);
+  const host = options?.host ?? "0.0.0.0";
+  const jobs: NodeJS.Timeout[] = [];
+
+  const server = app.listen(port, host, () => {
+    logger.info({ host, port }, "http server listening");
+    console.log(`Server running on http://${host}:${port}`);
+    jobs.push(startReservationExpiryJob(), startPaypalReconciliationJob());
+  });
+
+  const stopJobs = () => {
+    for (const job of jobs) {
+      clearInterval(job);
+    }
+    jobs.length = 0;
+  };
+
+  if (options?.installSignals !== false) {
+    installProcessShutdownHandlers({ server, stopJobs });
+  }
+
+  return server;
+}

--- a/server/src/shared/lifecycle/state.ts
+++ b/server/src/shared/lifecycle/state.ts
@@ -1,0 +1,13 @@
+let shuttingDown = false;
+
+export function isProcessShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+export function beginShutdown(): void {
+  shuttingDown = true;
+}
+
+export function resetLifecycleForTests(): void {
+  shuttingDown = false;
+}

--- a/server/src/shared/resilience/__tests__/retry.test.ts
+++ b/server/src/shared/resilience/__tests__/retry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "../../errors/AppError.js";
+import {
+  classifyExternalFailure,
+  classifyHttpStatus,
+  withRetry,
+} from "../retry.js";
+
+describe("retry classification", () => {
+  it("retries HTTP 429 and 5xx and refuses other 4xx", () => {
+    expect(classifyHttpStatus(429)).toEqual({ retryable: true, reason: "http_429" });
+    expect(classifyHttpStatus(503)).toEqual({ retryable: true, reason: "http_5xx" });
+    expect(classifyHttpStatus(400)).toEqual({ retryable: false, reason: "http_4xx" });
+    expect(classifyHttpStatus(404)).toEqual({ retryable: false, reason: "http_4xx" });
+  });
+
+  it("retries timeouts and tagged network failures", () => {
+    const timeout = new Error("Aborted");
+    timeout.name = "TimeoutError";
+    expect(classifyExternalFailure(timeout)).toEqual({ retryable: true, reason: "timeout" });
+    expect(classifyExternalFailure(new AppError(504, "PayPal OrdersGet timed out"))).toEqual({
+      retryable: true,
+      reason: "timeout",
+    });
+    expect(classifyExternalFailure(new TypeError("fetch failed"))).toEqual({
+      retryable: true,
+      reason: "network",
+    });
+  });
+
+  it("does not retry ordinary 4xx AppErrors", () => {
+    expect(classifyExternalFailure(new AppError(400, "bad request"))).toEqual({
+      retryable: false,
+      reason: "non_retryable",
+    });
+  });
+});
+
+describe("withRetry", () => {
+  it("retries retryable failures with exponential backoff then succeeds", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    let attempts = 0;
+    const result = await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw Object.assign(new Error("upstream"), classifyHttpStatus(503));
+        }
+        return "ok";
+      },
+      { maxAttempts: 3, baseDelayMs: 200, sleep }
+    );
+    expect(result).toBe("ok");
+    expect(attempts).toBe(3);
+    expect(sleep.mock.calls.map((call) => call[0])).toEqual([200, 400]);
+  });
+
+  it("does not retry non-retryable failures", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const operation = vi.fn(async () => {
+      throw Object.assign(new AppError(502, "PayPal OrdersGet failed: 404"), classifyHttpStatus(404));
+    });
+    await expect(withRetry(operation, { maxAttempts: 3, baseDelayMs: 200, sleep })).rejects.toMatchObject({
+      statusCode: 502,
+    });
+    expect(operation).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("stops after maxAttempts for retryable failures", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const operation = vi.fn(async () => {
+      throw Object.assign(new Error("upstream"), classifyHttpStatus(503));
+    });
+    await expect(withRetry(operation, { maxAttempts: 3, baseDelayMs: 50, sleep })).rejects.toMatchObject({
+      message: "upstream",
+    });
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/shared/resilience/retry.ts
+++ b/server/src/shared/resilience/retry.ts
@@ -1,0 +1,118 @@
+import { AppError } from "../errors/AppError.js";
+
+export const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+export const DEFAULT_RETRY_BASE_DELAY_MS = 200;
+
+export type RetryReason =
+  | "timeout"
+  | "network"
+  | "http_429"
+  | "http_5xx"
+  | "http_4xx"
+  | "non_retryable"
+  | "unknown";
+
+export type RetryClassification = {
+  retryable: boolean;
+  reason: RetryReason;
+};
+
+export type RetryOptions = {
+  maxAttempts: number;
+  baseDelayMs: number;
+  classify?: (err: unknown) => RetryClassification;
+  sleep?: (ms: number) => Promise<void>;
+  onRetry?: (info: {
+    attempt: number;
+    maxAttempts: number;
+    delayMs: number;
+    reason: RetryReason;
+    error: unknown;
+  }) => void;
+};
+
+export function isTimeoutError(err: unknown): boolean {
+  return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+}
+
+export function classifyHttpStatus(status: number): RetryClassification {
+  if (status === 429) return { retryable: true, reason: "http_429" };
+  if (status >= 500) return { retryable: true, reason: "http_5xx" };
+  if (status >= 400) return { retryable: false, reason: "http_4xx" };
+  return { retryable: false, reason: "unknown" };
+}
+
+export function classifyExternalFailure(err: unknown): RetryClassification {
+  const tagged = readTaggedClassification(err);
+  if (tagged) return tagged;
+  if (isTimeoutError(err)) return { retryable: true, reason: "timeout" };
+  if (err instanceof AppError) {
+    if (err.statusCode === 504) return { retryable: true, reason: "timeout" };
+    if (err.statusCode >= 500) return { retryable: false, reason: "non_retryable" };
+    return { retryable: false, reason: "non_retryable" };
+  }
+  if (isNetworkError(err)) return { retryable: true, reason: "network" };
+  return { retryable: false, reason: "unknown" };
+}
+
+export async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function withRetry<T>(operation: () => Promise<T>, options: RetryOptions): Promise<T> {
+  const maxAttempts = Math.max(1, options.maxAttempts);
+  const classify = options.classify ?? classifyExternalFailure;
+  const sleepFn = options.sleep ?? sleep;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (err) {
+      lastError = err;
+      const decision = classify(err);
+      if (!decision.retryable || attempt >= maxAttempts) {
+        throw err;
+      }
+      const delayMs = options.baseDelayMs * 2 ** (attempt - 1);
+      options.onRetry?.({
+        attempt,
+        maxAttempts,
+        delayMs,
+        reason: decision.reason,
+        error: err,
+      });
+      await sleepFn(delayMs);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Retry exhausted");
+}
+
+function readTaggedClassification(err: unknown): RetryClassification | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  if (!("retryable" in err) || !("reason" in err)) return undefined;
+  const retryable = Boolean((err as { retryable: unknown }).retryable);
+  const reason = (err as { reason: unknown }).reason;
+  if (
+    reason !== "timeout" &&
+    reason !== "network" &&
+    reason !== "http_429" &&
+    reason !== "http_5xx" &&
+    reason !== "http_4xx" &&
+    reason !== "non_retryable" &&
+    reason !== "unknown"
+  ) {
+    return undefined;
+  }
+  return { retryable, reason };
+}
+
+function isNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "TypeError") return true;
+  return /ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|EPIPE|fetch failed/i.test(err.message);
+}

--- a/server/src/shared/routes/__tests__/health.test.ts
+++ b/server/src/shared/routes/__tests__/health.test.ts
@@ -47,8 +47,20 @@ describe("Health routes", () => {
   });
 
   describe("GET /ready", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       vi.clearAllMocks();
+      const { resetLifecycleForTests } = await import("../../lifecycle/state.js");
+      resetLifecycleForTests();
+    });
+
+    it("returns 503 when the process is shutting down", async () => {
+      const { beginShutdown } = await import("../../lifecycle/state.js");
+      const { prisma } = await import("../../database/index.js");
+      beginShutdown();
+      const res = await fetch(`${baseUrl}/ready`);
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ status: "shutting_down" });
+      expect(prisma.$queryRaw).not.toHaveBeenCalled();
     });
 
     it("returns 200 when DB is reachable", async () => {

--- a/server/src/shared/routes/health.routes.ts
+++ b/server/src/shared/routes/health.routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import { prisma } from "../database/index.js";
+import { isProcessShuttingDown } from "../lifecycle/state.js";
 import { logger } from "../logger.js";
 
 const router = Router();
@@ -11,6 +12,10 @@ router.get("/health", (_req: Request, res: Response) => {
 
 /** Readiness: app can serve traffic (e.g. DB reachable) */
 router.get("/ready", async (_req: Request, res: Response) => {
+  if (isProcessShuttingDown()) {
+    res.status(503).json({ status: "shutting_down" });
+    return;
+  }
   try {
     await prisma.$queryRaw`SELECT 1`;
     res.status(200).json({ status: "ready" });

--- a/server/src/shared/utils/__tests__/paypal.http.test.ts
+++ b/server/src/shared/utils/__tests__/paypal.http.test.ts
@@ -59,7 +59,7 @@ describe("PayPal HTTP policy", () => {
     expect(orderCalls).toBe(3);
   });
 
-  it("times out a hung PayPal OrdersGet", async () => {
+  it("times out a hung PayPal OrdersGet after bounded retries", async () => {
     const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/v1/oauth2/token")) {
@@ -77,6 +77,25 @@ describe("PayPal HTTP policy", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { getPayPalOrder } = await import("../paypal.js");
-    await expect(getPayPalOrder("paypal-1")).rejects.toBeInstanceOf(Error);
+    await expect(getPayPalOrder("paypal-1")).rejects.toMatchObject({ statusCode: 504 });
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).includes("/v2/checkout/orders"))).toHaveLength(3);
+  });
+
+  it("retries PayPal OAuth on HTTP 5xx then succeeds", async () => {
+    let tokenCalls = 0;
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes("/v1/oauth2/token")) {
+        tokenCalls += 1;
+        if (tokenCalls < 2) return new Response("upstream", { status: 503 });
+        return new Response(JSON.stringify({ access_token: "token", expires_in: 300 }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ id: "paypal-1", status: "COMPLETED" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getPayPalOrder } = await import("../paypal.js");
+    await expect(getPayPalOrder("paypal-1")).resolves.toEqual({ id: "paypal-1", status: "COMPLETED" });
+    expect(tokenCalls).toBe(2);
   });
 });

--- a/server/src/shared/utils/__tests__/paypal.policy.test.ts
+++ b/server/src/shared/utils/__tests__/paypal.policy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { PAYPAL_HTTP_POLICY } from "../paypal.js";
+
+describe("PayPal HTTP retry policy", () => {
+  it("never retries mutating PayPal operations", () => {
+    expect(PAYPAL_HTTP_POLICY.orders_create.retry).toBe(false);
+    expect(PAYPAL_HTTP_POLICY.orders_capture.retry).toBe(false);
+  });
+
+  it("retries idempotent lookups with a bounded attempt count", () => {
+    expect(PAYPAL_HTTP_POLICY.orders_get).toMatchObject({ retry: true, maxAttempts: 3 });
+    expect(PAYPAL_HTTP_POLICY.oauth_token).toMatchObject({ retry: true, maxAttempts: 3 });
+    expect(PAYPAL_HTTP_POLICY.cert_download).toMatchObject({ retry: true, maxAttempts: 3 });
+  });
+});

--- a/server/src/shared/utils/__tests__/paypalWebhook.test.ts
+++ b/server/src/shared/utils/__tests__/paypalWebhook.test.ts
@@ -1,7 +1,8 @@
 import { createSign, generateKeyPairSync } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   computePaypalCrc32,
+  downloadPayPalCertificate,
   parsePayPalWebhookEvent,
   verifyPayPalWebhookSignature,
 } from "../paypalWebhook.js";
@@ -211,5 +212,35 @@ describe("parsePayPalWebhookEvent", () => {
       paypalOrderId: "PAYPAL-ORDER-2",
       referenceOrderId: "local-order",
     });
+  });
+});
+
+describe("downloadPayPalCertificate", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not retry HTTP 4xx", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("missing", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      downloadPayPalCertificate("https://api.sandbox.paypal.com/v1/notifications/certs/CERT-404")
+    ).rejects.toThrow(/failed: 404/);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("retries HTTP 5xx then succeeds", async () => {
+    const pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("upstream", { status: 503 }))
+      .mockResolvedValueOnce(new Response(pem, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      downloadPayPalCertificate("https://api.sandbox.paypal.com/v1/notifications/certs/CERT-503")
+    ).resolves.toBe(pem);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/server/src/shared/utils/__tests__/sendVerificationCode.test.ts
+++ b/server/src/shared/utils/__tests__/sendVerificationCode.test.ts
@@ -80,7 +80,8 @@ describe("sendVerificationCode", () => {
   it("maps provider failures to an operational error", async () => {
     process.env.RESEND_API_KEY = "resend-key";
     process.env.EMAIL_FROM = "SkinMarket <noreply@example.com>";
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("bad request", { status: 400 })));
+    const fetchMock = vi.fn().mockResolvedValue(new Response("bad request", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
 
     const { sendVerificationCode } = await import("../sendVerificationCode.js");
 
@@ -88,5 +89,20 @@ describe("sendVerificationCode", () => {
       statusCode: 502,
       message: "Failed to send verification email",
     });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("retries Resend HTTP 5xx then succeeds", async () => {
+    process.env.RESEND_API_KEY = "resend-key";
+    process.env.EMAIL_FROM = "SkinMarket <noreply@example.com>";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("upstream", { status: 503 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { sendVerificationCode } = await import("../sendVerificationCode.js");
+    await sendVerificationCode("new@test.com", "123456");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/server/src/shared/utils/paypal.ts
+++ b/server/src/shared/utils/paypal.ts
@@ -1,8 +1,9 @@
 import paypal from "@paypal/checkout-server-sdk";
 import { AppError } from "../errors/AppError.js";
 import { logger } from "../logger.js";
-import { getPayPalApiBaseUrl, getPayPalApiTimeoutMs } from "../config/paypal.js";
+import { getPayPalApiBaseUrl, getPayPalApiTimeoutMs, PAYPAL_IDEMPOTENT_RETRY } from "../config/paypal.js";
 import { withPaypalOperation } from "../observability/paypal.js";
+import { classifyHttpStatus, isTimeoutError, withRetry } from "../resilience/retry.js";
 
 function environment() {
   const clientId = process.env.PAYPAL_CLIENT_ID ?? "";
@@ -18,6 +19,15 @@ const client = new paypal.core.PayPalHttpClient(environment());
 
 type TokenCache = { token: string; expiresAt: number };
 let tokenCache: TokenCache | null = null;
+
+/** Mutating PayPal calls are not retried; lookups and token/cert fetches may retry. */
+export const PAYPAL_HTTP_POLICY = {
+  orders_create: { retry: false, reason: "OrdersCreate can open a second PayPal order" },
+  orders_capture: { retry: false, reason: "OrdersCapture can capture funds more than once" },
+  orders_get: { retry: true, ...PAYPAL_IDEMPOTENT_RETRY },
+  oauth_token: { retry: true, ...PAYPAL_IDEMPOTENT_RETRY },
+  cert_download: { retry: true, ...PAYPAL_IDEMPOTENT_RETRY },
+} as const;
 
 async function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   const ms = getPayPalApiTimeoutMs();
@@ -67,32 +77,33 @@ export async function getPayPalOrder(paypalOrderId: string): Promise<{ id?: stri
   return withPaypalOperation("orders_get", async () => {
     const token = await getPayPalAccessToken();
     const url = `${getPayPalApiBaseUrl()}/v2/checkout/orders/${encodeURIComponent(paypalOrderId)}`;
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
-      try {
-        const response = await fetch(url, {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
-        });
-        if (response.status >= 500 || response.status === 429) {
-          lastError = new AppError(502, `PayPal OrdersGet failed: ${response.status}`);
-          if (attempt < 3) await delay(200 * attempt);
-          continue;
+    try {
+      return await withRetry(
+        async () => {
+          const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
+          });
+          if (!response.ok) {
+            throw Object.assign(
+              new AppError(502, `PayPal OrdersGet failed: ${response.status}`),
+              classifyHttpStatus(response.status)
+            );
+          }
+          return (await response.json()) as { id?: string; status?: string };
+        },
+        {
+          maxAttempts: PAYPAL_HTTP_POLICY.orders_get.maxAttempts,
+          baseDelayMs: PAYPAL_HTTP_POLICY.orders_get.baseDelayMs,
+          onRetry: ({ attempt, reason }) => {
+            logger.warn({ attempt, reason }, "PayPal OrdersGet retrying");
+          },
         }
-        if (!response.ok) {
-          throw new AppError(502, `PayPal OrdersGet failed: ${response.status}`);
-        }
-        return (await response.json()) as { id?: string; status?: string };
-      } catch (err) {
-        if (err instanceof AppError && !isRetryablePayPalLookupError(err)) {
-          throw err;
-        }
-        lastError = err;
-        if (attempt < 3) await delay(200 * attempt);
-      }
+      );
+    } catch (err) {
+      if (isTimeoutError(err)) throw new AppError(504, "PayPal OrdersGet timed out");
+      throw err;
     }
-    logger.warn({ err: lastError }, "PayPal OrdersGet exhausted retries");
-    throw lastError instanceof Error ? lastError : new AppError(502, "PayPal OrdersGet failed");
   });
 }
 
@@ -104,25 +115,44 @@ export async function getPayPalAccessToken(): Promise<string> {
     const clientId = process.env.PAYPAL_CLIENT_ID ?? "";
     const secret = process.env.PAYPAL_SECRET ?? "";
     const credentials = Buffer.from(`${clientId}:${secret}`).toString("base64");
-    const response = await fetch(`${getPayPalApiBaseUrl()}/v1/oauth2/token`, {
-      method: "POST",
-      headers: {
-        Authorization: `Basic ${credentials}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: "grant_type=client_credentials",
-      signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
-    });
-    if (!response.ok) {
-      throw new AppError(502, "PayPal OAuth token request failed");
+    try {
+      const body = await withRetry(
+        async () => {
+          const response = await fetch(`${getPayPalApiBaseUrl()}/v1/oauth2/token`, {
+            method: "POST",
+            headers: {
+              Authorization: `Basic ${credentials}`,
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: "grant_type=client_credentials",
+            signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
+          });
+          if (!response.ok) {
+            throw Object.assign(
+              new AppError(502, "PayPal OAuth token request failed"),
+              classifyHttpStatus(response.status)
+            );
+          }
+          return (await response.json()) as { access_token?: string; expires_in?: number };
+        },
+        {
+          maxAttempts: PAYPAL_HTTP_POLICY.oauth_token.maxAttempts,
+          baseDelayMs: PAYPAL_HTTP_POLICY.oauth_token.baseDelayMs,
+          onRetry: ({ attempt, reason }) => {
+            logger.warn({ attempt, reason }, "PayPal OAuth token retrying");
+          },
+        }
+      );
+      if (!body.access_token) {
+        throw new AppError(502, "PayPal OAuth token missing");
+      }
+      const ttlMs = Math.max(30_000, ((body.expires_in ?? 300) - 30) * 1000);
+      tokenCache = { token: body.access_token, expiresAt: Date.now() + ttlMs };
+      return tokenCache.token;
+    } catch (err) {
+      if (isTimeoutError(err)) throw new AppError(504, "PayPal OAuth token request timed out");
+      throw err;
     }
-    const body = (await response.json()) as { access_token?: string; expires_in?: number };
-    if (!body.access_token) {
-      throw new AppError(502, "PayPal OAuth token missing");
-    }
-    const ttlMs = Math.max(30_000, ((body.expires_in ?? 300) - 30) * 1000);
-    tokenCache = { token: body.access_token, expiresAt: Date.now() + ttlMs };
-    return body.access_token;
   });
 }
 
@@ -133,16 +163,4 @@ export function getPayPalOrderIdFromResult(result: { id?: string }): string | un
 export function getPayPalApprovalLink(result: { links?: Array<{ href?: string; rel?: string }> }): string | undefined {
   const link = result.links?.find((l) => l.rel === "approve");
   return link?.href;
-}
-
-function isRetryablePayPalLookupError(err: AppError): boolean {
-  if (err.statusCode === 504) return true;
-  const statusMatch = err.message.match(/PayPal OrdersGet failed: (\d+)/);
-  if (!statusMatch) return false;
-  const status = Number(statusMatch[1]);
-  return status >= 500 || status === 429;
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/server/src/shared/utils/paypalWebhook.ts
+++ b/server/src/shared/utils/paypalWebhook.ts
@@ -1,7 +1,8 @@
 import { createVerify } from "node:crypto";
 import { crc32 as zlibCrc32 } from "node:zlib";
 import { logger } from "../logger.js";
-import { getPayPalApiTimeoutMs, PAYPAL_WEBHOOK_MAX_SKEW_MS } from "../config/paypal.js";
+import { getPayPalApiTimeoutMs, PAYPAL_IDEMPOTENT_RETRY, PAYPAL_WEBHOOK_MAX_SKEW_MS } from "../config/paypal.js";
+import { classifyHttpStatus, isTimeoutError, withRetry } from "../resilience/retry.js";
 
 const PAYPAL_CERT_HOSTS = new Set([
   "api.paypal.com",
@@ -195,11 +196,36 @@ export async function downloadPayPalCertificate(url: string): Promise<string> {
     throw new Error("PayPal certificate URL host is not allowlisted");
   }
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(getPayPalApiTimeoutMs()) });
-  if (!response.ok) {
-    throw new Error(`PayPal certificate download failed: ${response.status}`);
-  }
-  const pem = await response.text();
+  const pem = await withRetry(
+    async () => {
+      let response: Response;
+      try {
+        response = await fetch(url, { signal: AbortSignal.timeout(getPayPalApiTimeoutMs()) });
+      } catch (err) {
+        if (isTimeoutError(err)) {
+          throw Object.assign(new Error("PayPal certificate download timed out"), {
+            retryable: true,
+            reason: "timeout" as const,
+          });
+        }
+        throw err;
+      }
+      if (!response.ok) {
+        throw Object.assign(
+          new Error(`PayPal certificate download failed: ${response.status}`),
+          classifyHttpStatus(response.status)
+        );
+      }
+      return response.text();
+    },
+    {
+      maxAttempts: PAYPAL_IDEMPOTENT_RETRY.maxAttempts,
+      baseDelayMs: PAYPAL_IDEMPOTENT_RETRY.baseDelayMs,
+      onRetry: ({ attempt, reason }) => {
+        logger.warn({ attempt, reason }, "PayPal certificate download retrying");
+      },
+    }
+  );
   certCache.set(url, { pem, cachedAt: Date.now() });
   return pem;
 }

--- a/server/src/shared/utils/sendVerificationCode.ts
+++ b/server/src/shared/utils/sendVerificationCode.ts
@@ -6,6 +6,22 @@ import {
   getResendApiKey,
   isVerificationEmailConfigured,
 } from "../config/email.js";
+import {
+  classifyHttpStatus,
+  DEFAULT_RETRY_BASE_DELAY_MS,
+  DEFAULT_RETRY_MAX_ATTEMPTS,
+  isTimeoutError,
+  withRetry,
+} from "../resilience/retry.js";
+
+export const EMAIL_HTTP_POLICY = {
+  verification_send: {
+    retry: true,
+    maxAttempts: DEFAULT_RETRY_MAX_ATTEMPTS,
+    baseDelayMs: DEFAULT_RETRY_BASE_DELAY_MS,
+    reason: "Resend 5xx/429/timeout may be retried; 4xx is not. A timeout after accept can duplicate the same code.",
+  },
+} as const;
 
 /**
  * Sends the verification code to the user (e.g. by email).
@@ -19,33 +35,55 @@ export async function sendVerificationCode(email: string, code: string): Promise
 
   assertVerificationEmailDeliveryConfigured();
 
-  let response: Response;
   try {
-    response = await fetch("https://api.resend.com/emails", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${getResendApiKey()}`,
-        "Content-Type": "application/json",
+    await withRetry(
+      async () => {
+        let response: Response;
+        try {
+          response = await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${getResendApiKey()}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              from: getEmailFrom(),
+              to: [email],
+              subject: "Seu código de verificação - SkinMarket",
+              text: `Seu código de verificação é ${code}. Ele expira em 10 minutos.`,
+            }),
+            signal: AbortSignal.timeout(getEmailApiTimeoutMs()),
+          });
+        } catch (err) {
+          if (isTimeoutError(err)) {
+            throw new AppError(504, "Verification email request timed out");
+          }
+          logger.warn({ err }, "verification email request failed");
+          throw Object.assign(new AppError(502, "Failed to send verification email"), {
+            retryable: true,
+            reason: "network" as const,
+          });
+        }
+
+        if (!response.ok) {
+          const classified = classifyHttpStatus(response.status);
+          logger.warn({ statusCode: response.status }, "verification email provider rejected request");
+          throw Object.assign(new AppError(502, "Failed to send verification email"), classified);
+        }
       },
-      body: JSON.stringify({
-        from: getEmailFrom(),
-        to: [email],
-        subject: "Seu código de verificação - SkinMarket",
-        text: `Seu código de verificação é ${code}. Ele expira em 10 minutos.`,
-      }),
-      signal: AbortSignal.timeout(getEmailApiTimeoutMs()),
-    });
+      {
+        maxAttempts: EMAIL_HTTP_POLICY.verification_send.maxAttempts,
+        baseDelayMs: EMAIL_HTTP_POLICY.verification_send.baseDelayMs,
+        onRetry: ({ attempt, reason }) => {
+          logger.warn({ attempt, reason }, "verification email retrying");
+        },
+      }
+    );
   } catch (err) {
-    if (err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")) {
+    if (isTimeoutError(err)) {
       throw new AppError(504, "Verification email request timed out");
     }
-    logger.warn({ err }, "verification email request failed");
-    throw new AppError(502, "Failed to send verification email");
-  }
-
-  if (!response.ok) {
-    logger.warn({ statusCode: response.status }, "verification email provider rejected request");
-    throw new AppError(502, "Failed to send verification email");
+    throw err;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements roadmap **P1.3** / GitHub issue #8 (closed as `not_planned` without the work) in parallel with the P-front track.

This PR stays out of `src/`. Frontend agents keep owning the Vite client.

## Objective
Make PayPal/Resend calls and process lifecycle resilient without adding queues, Redis, or circuit breakers.

## Changes
- Shared retry classification: timeout/network/429/5xx retry; other 4xx do not.
- Bounded retries (max 3, exponential backoff) for PayPal `OrdersGet`, OAuth token, webhook certificate download, and Resend verification email.
- `OrdersCreate` and `OrdersCapture` are still not retried (duplicate side effects).
- SIGTERM/SIGINT: stop in-process jobs, drain HTTP (10s), disconnect Prisma, shut down telemetry.
- `GET /ready` returns `503 shutting_down` during drain; `GET /health` stays a liveness probe.
- Docs: ADR 0005, `docs/architecture/failure-modes.md`, roadmap/current-state/invariants/OpenAPI.

## Invariants
- Retries cannot create a second local order, reservation, payment confirmation, or seller transaction.
- Reservation/payment confirmation semantics are unchanged.

## Verification
- `cd server && npm run test:unit -- src/shared/resilience src/shared/lifecycle src/shared/utils/__tests__/paypal.http.test.ts src/shared/utils/__tests__/paypal.policy.test.ts src/shared/utils/__tests__/paypalWebhook.test.ts src/shared/utils/__tests__/sendVerificationCode.test.ts src/shared/routes/__tests__/health.test.ts` → 7 files, 36 tests passed
- `cd server && npm run test:unit` → 24 files, 139 tests passed
- Pre-commit `tsc --noEmit` for client and server → passed
- Integration tests not run: no `TEST_DATABASE_URL`, and this change does not alter PostgreSQL invariants

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

