### PR TITLE
[P-front] D2 — Dashboard admin

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,314 +1,325 @@
-import {
-  BarChart3,
-  Users,
-  ShoppingBag,
-  DollarSign,
-  CheckCircle,
-  XCircle,
-  Clock,
-  Loader2,
-} from "lucide-react";
-import { motion } from "framer-motion";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { listAdminOrders, adminApproveSeller } from "@/api/admin";
-import { listSellers } from "@/api/sellers";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { adminApproveSeller, listAdminOrders } from "@/api/admin";
 import { listProducts } from "@/api/products";
+import { listSellers } from "@/api/sellers";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import type { Order, Seller } from "@/types/api";
+
+function formatMoney(value: string | number): string {
+  return `$${Number(value).toFixed(2)}`;
+}
+
+function formatCommission(rate: Seller["commissionRate"]): string {
+  return `${(Number(rate ?? 0.1) * 100).toFixed(0)}%`;
+}
 
 export default function AdminDashboard() {
   const queryClient = useQueryClient();
+  const { toast } = useToast();
 
-  const { data: orders = [] } = useQuery({
+  const ordersQuery = useQuery({
     queryKey: ["admin-orders"],
     queryFn: listAdminOrders,
   });
-  const { data: sellers = [] } = useQuery({
+  const sellersQuery = useQuery({
     queryKey: ["admin-sellers"],
     queryFn: listSellers,
   });
-  const { data: productsData } = useQuery({
+  const productsQuery = useQuery({
     queryKey: ["admin-products"],
     queryFn: () => listProducts({ limit: 1 }),
   });
 
-  const totalRevenue = orders.reduce((s, o) => s + Number(o.totalAmount), 0);
-  const pendingSellers = sellers.filter((s) => !s.isApproved);
+  const orders = ordersQuery.data ?? [];
+  const sellers = sellersQuery.data ?? [];
+  const pendingSellers = sellers.filter((seller) => !seller.isApproved);
+  const recentOrders = orders.slice(0, 10);
+  const totalRevenue = orders.reduce(
+    (sum, order) => sum + Number(order.totalAmount),
+    0,
+  );
 
-  const approveMutation = useMutation({
+  const approveSeller = useMutation({
     mutationFn: ({ id, isApproved }: { id: string; isApproved: boolean }) =>
       adminApproveSeller(id, isApproved),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["admin-sellers"] }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["admin-sellers"] });
+      toast({
+        title: variables.isApproved
+          ? "Vendedor aprovado"
+          : "Vendedor rejeitado",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Não foi possível atualizar o vendedor",
+        variant: "destructive",
+      });
+    },
   });
 
-  const globalStats = [
-    {
-      icon: DollarSign,
-      label: "Receita Total",
-      value: `$${totalRevenue.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
-      color: "text-primary",
-    },
-    {
-      icon: ShoppingBag,
-      label: "Produtos",
-      value: String(productsData?.total ?? "—"),
-      color: "text-secondary",
-    },
-    {
-      icon: Users,
-      label: "Vendedores",
-      value: String(sellers.length),
-      color: "text-primary",
-    },
-    {
-      icon: BarChart3,
-      label: "Pedidos",
-      value: String(orders.length),
-      color: "text-secondary",
-    },
+  const isLoading =
+    ordersQuery.isLoading || sellersQuery.isLoading || productsQuery.isLoading;
+  const isError =
+    ordersQuery.isError || sellersQuery.isError || productsQuery.isError;
+  const error = ordersQuery.error ?? sellersQuery.error ?? productsQuery.error;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar o painel"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              void ordersQuery.refetch();
+              void sellersQuery.refetch();
+              void productsQuery.refetch();
+            }}
+          >
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
+
+  const stats = [
+    { label: "Receita", value: formatMoney(totalRevenue) },
+    { label: "Produtos", value: String(productsQuery.data?.total ?? 0) },
+    { label: "Vendedores", value: String(sellers.length) },
+    { label: "Pedidos", value: String(orders.length) },
   ];
 
   return (
     <div className="space-y-8">
-      <h1 className="text-3xl font-heading text-foreground">Admin Panel</h1>
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Painel admin</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Catálogo, vendedores e pedidos da plataforma.
+        </p>
+      </div>
 
-      {/* Global Stats */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        {globalStats.map((s, i) => (
-          <motion.div
-            key={s.label}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: i * 0.05 }}
-            className="p-4 rounded-lg border border-border bg-card"
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-md border border-border bg-card p-4"
           >
-            <div className="flex items-center gap-2 mb-2">
-              <s.icon className={`h-4 w-4 ${s.color}`} />
-              <span className="text-xs text-muted-foreground font-heading">
-                {s.label}
-              </span>
-            </div>
-            <span className={`font-heading text-2xl ${s.color}`}>
-              {s.value}
-            </span>
-          </motion.div>
+            <p className="text-xs text-muted-foreground">{stat.label}</p>
+            <p className="mt-2 tabular-nums text-2xl font-semibold tracking-tight">
+              {stat.value}
+            </p>
+          </div>
         ))}
       </div>
 
-      {/* Pending Sellers */}
-      <div>
-        <h2 className="text-xl font-heading text-foreground mb-4">
-          Aprovação de Vendedores
-          {pendingSellers.length > 0 && (
-            <span className="ml-2 text-sm bg-secondary/10 text-secondary px-2 py-0.5 rounded">
-              {pendingSellers.length} pendente(s)
-            </span>
-          )}
-        </h2>
-        {pendingSellers.length === 0 ? (
-          <p className="text-muted-foreground text-sm p-4 rounded-lg border border-border bg-card">
-            Nenhum vendedor pendente de aprovação
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold tracking-tight">
+            Vendedores pendentes
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Aprove ou rejeite cadastros aguardando revisão.
           </p>
+        </div>
+        {pendingSellers.length === 0 ? (
+          <EmptyState
+            title="Nenhum vendedor pendente de aprovação"
+            description="Todos os cadastros já foram revisados."
+          />
         ) : (
-          <div className="space-y-3">
-            {pendingSellers.map((s) => (
-              <div
-                key={s.id}
-                className="flex items-center justify-between p-4 rounded-lg border border-border bg-card"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center">
-                    <Users className="h-5 w-5 text-muted-foreground" />
-                  </div>
-                  <div>
-                    <span className="text-sm font-medium text-foreground block">
-                      {s.storeName}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      {s.user?.name ?? s.userId}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex gap-2">
+          <PendingSellersTable
+            sellers={pendingSellers}
+            busy={approveSeller.isPending}
+            onApprove={(id) => approveSeller.mutate({ id, isApproved: true })}
+            onReject={(id) => approveSeller.mutate({ id, isApproved: false })}
+          />
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold tracking-tight">
+          Todos os vendedores
+        </h2>
+        {sellers.length === 0 ? (
+          <EmptyState title="Nenhum vendedor cadastrado" />
+        ) : (
+          <SellersOverviewTable sellers={sellers} />
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold tracking-tight">
+          Pedidos recentes
+        </h2>
+        {recentOrders.length === 0 ? (
+          <EmptyState title="Nenhum pedido encontrado" />
+        ) : (
+          <RecentOrdersTable orders={recentOrders} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PendingSellersTable({
+  sellers,
+  busy,
+  onApprove,
+  onReject,
+}: {
+  sellers: Seller[];
+  busy: boolean;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Loja</TableHead>
+            <TableHead>Usuário</TableHead>
+            <TableHead className="text-right">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sellers.map((seller) => (
+            <TableRow key={seller.id}>
+              <TableCell className="font-medium">{seller.storeName}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {seller.user?.name ?? "—"}
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-2">
                   <Button
+                    type="button"
                     size="sm"
-                    disabled={approveMutation.isPending}
-                    onClick={() =>
-                      approveMutation.mutate({ id: s.id, isApproved: true })
-                    }
+                    disabled={busy}
+                    onClick={() => onApprove(seller.id)}
                   >
-                    {approveMutation.isPending ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <CheckCircle className="h-4 w-4 mr-1" />
-                    )}
                     Aprovar
                   </Button>
                   <Button
-                    variant="outline"
+                    type="button"
                     size="sm"
-                    disabled={approveMutation.isPending}
-                    onClick={() =>
-                      approveMutation.mutate({ id: s.id, isApproved: false })
-                    }
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() => onReject(seller.id)}
                   >
-                    <XCircle className="h-4 w-4 mr-1" />
                     Rejeitar
                   </Button>
                 </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
 
-      {/* All Sellers */}
-      <div>
-        <h2 className="text-xl font-heading text-foreground mb-4">
-          Todos os Vendedores
-        </h2>
-        <div className="rounded-lg border border-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Loja
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden sm:table-cell">
-                  Usuário
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Comissão
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Rating
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {sellers.map((s) => (
-                <tr
-                  key={s.id}
-                  className="border-t border-border hover:bg-muted/50 transition-colors"
-                >
-                  <td className="p-3 text-foreground font-medium">
-                    {s.storeName}
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden sm:table-cell">
-                    {s.user?.name ?? "—"}
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden md:table-cell">
-                    {(Number(s.commissionRate ?? 0.1) * 100).toFixed(0)}%
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden md:table-cell">
-                    ★ {Number(s.rating).toFixed(1)}
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`text-xs font-heading px-2 py-1 rounded ${s.isApproved ? "bg-primary/10 text-primary" : "bg-secondary/10 text-secondary"}`}
-                    >
-                      {s.isApproved ? "Aprovado" : "Pendente"}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
+function SellersOverviewTable({ sellers }: { sellers: Seller[] }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Loja</TableHead>
+            <TableHead>Usuário</TableHead>
+            <TableHead>Comissão</TableHead>
+            <TableHead>Avaliação</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sellers.map((seller) => (
+            <TableRow key={seller.id}>
+              <TableCell className="font-medium">{seller.storeName}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {seller.user?.name ?? "—"}
+              </TableCell>
+              <TableCell>{formatCommission(seller.commissionRate)}</TableCell>
+              <TableCell>{Number(seller.rating).toFixed(1)}</TableCell>
+              <TableCell>
+                <Badge variant={seller.isApproved ? "default" : "secondary"}>
+                  {seller.isApproved ? "Aprovado" : "Pendente"}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
 
-      {/* Recent Orders */}
-      <div>
-        <h2 className="text-xl font-heading text-foreground mb-4">
-          Pedidos Recentes
-        </h2>
-        <div className="rounded-lg border border-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  ID
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden sm:table-cell">
-                  Total
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Data
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Pagamento
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {orders.slice(0, 10).map((o) => (
-                <tr
-                  key={o.id}
-                  className="border-t border-border hover:bg-muted/50 transition-colors"
-                >
-                  <td className="p-3 text-muted-foreground font-mono text-xs">
-                    #{o.id.slice(0, 8)}
-                  </td>
-                  <td className="p-3 text-primary font-heading hidden sm:table-cell">
-                    ${Number(o.totalAmount).toFixed(2)}
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden md:table-cell">
-                    {new Date(o.createdAt).toLocaleDateString("pt-BR")}
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`text-xs font-heading px-2 py-1 rounded ${
-                        o.paymentStatus === "PAID"
-                          ? "bg-primary/10 text-primary"
-                          : o.paymentStatus === "REFUNDED"
-                            ? "bg-destructive/10 text-destructive"
-                            : "bg-muted text-muted-foreground"
-                      }`}
-                    >
-                      {o.paymentStatus}
-                    </span>
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`inline-flex items-center gap-1 text-xs font-heading px-2 py-1 rounded ${
-                        o.status === "DELIVERED"
-                          ? "bg-primary/10 text-primary"
-                          : o.status === "SHIPPED"
-                            ? "bg-secondary/10 text-secondary"
-                            : o.status === "CANCELLED"
-                              ? "bg-destructive/10 text-destructive"
-                              : "bg-muted text-muted-foreground"
-                      }`}
-                    >
-                      {o.status === "PENDING" && <Clock className="h-3 w-3" />}
-                      {o.status === "DELIVERED" && (
-                        <CheckCircle className="h-3 w-3" />
-                      )}
-                      {o.status}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-              {orders.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={5}
-                    className="p-6 text-center text-muted-foreground"
-                  >
-                    Nenhum pedido encontrado
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
+function RecentOrdersTable({ orders }: { orders: Order[] }) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>ID</TableHead>
+            <TableHead>Total</TableHead>
+            <TableHead>Data</TableHead>
+            <TableHead>Pagamento</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map((order) => (
+            <TableRow key={order.id}>
+              <TableCell className="font-mono text-xs">
+                #{order.id.slice(0, 8)}
+              </TableCell>
+              <TableCell>{formatMoney(order.totalAmount)}</TableCell>
+              <TableCell>
+                {new Date(order.createdAt).toLocaleDateString("pt-BR")}
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline">{order.paymentStatus}</Badge>
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary">{order.status}</Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/src/pages/__tests__/AdminDashboard.test.tsx
+++ b/src/pages/__tests__/AdminDashboard.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AdminDashboard from "../AdminDashboard";
+import type { Order, Seller } from "@/types/api";
+
+const listAdminOrders = vi.fn();
+const adminApproveSeller = vi.fn();
+const listSellers = vi.fn();
+const listProducts = vi.fn();
+
+vi.mock("@/api/admin", () => ({
+  listAdminOrders: (...args: unknown[]) => listAdminOrders(...args),
+  adminApproveSeller: (...args: unknown[]) => adminApproveSeller(...args),
+}));
+
+vi.mock("@/api/sellers", () => ({
+  listSellers: (...args: unknown[]) => listSellers(...args),
+}));
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function seller(overrides: Partial<Seller> = {}): Seller {
+  return {
+    id: "seller-pending",
+    userId: "user-pending",
+    storeName: "Loja Pendente",
+    commissionRate: 0.1,
+    balance: 0,
+    rating: 4.5,
+    isApproved: false,
+    user: {
+      id: "user-pending",
+      name: "Pending Seller",
+      email: "pending@test.com",
+    },
+    ...overrides,
+  };
+}
+
+function order(): Order {
+  return {
+    id: "order-abcdef12",
+    totalAmount: 42,
+    status: "CONFIRMED",
+    paymentStatus: "PAID",
+    createdAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+    updatedAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+  };
+}
+
+function renderDashboard() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminDashboard />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminDashboard", () => {
+  beforeEach(() => {
+    listAdminOrders.mockReset();
+    adminApproveSeller.mockReset();
+    listSellers.mockReset();
+    listProducts.mockReset();
+    adminApproveSeller.mockResolvedValue(seller({ isApproved: true }));
+  });
+
+  it("uses current admin lists and approve contract without leftover marketplace chrome", async () => {
+    listSellers.mockResolvedValue([
+      seller(),
+      seller({
+        id: "seller-ok",
+        storeName: "Loja Aprovada",
+        isApproved: true,
+        user: { id: "user-ok", name: "Approved Seller", email: "ok@test.com" },
+      }),
+    ]);
+    listAdminOrders.mockResolvedValue([order()]);
+    listProducts.mockResolvedValue({ items: [], total: 12, page: 1, limit: 1 });
+
+    renderDashboard();
+
+    expect(await screen.findByText("Painel admin")).toBeTruthy();
+    expect(screen.getByText("Receita")).toBeTruthy();
+    expect(screen.getAllByText("$42.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("12")).toBeTruthy();
+    expect(screen.getAllByText("Loja Pendente").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("10%").length).toBeGreaterThan(0);
+    expect(listSellers).toHaveBeenCalled();
+    expect(listAdminOrders).toHaveBeenCalled();
+    expect(listProducts).toHaveBeenCalledWith({ limit: 1 });
+    expect(screen.queryByText(/SKINMARKET/i)).toBeNull();
+    expect(screen.queryByText(/CS2 Skin Marketplace/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Aprovar" }));
+    await waitFor(() => {
+      expect(adminApproveSeller).toHaveBeenCalledWith("seller-pending", true);
+    });
+  });
+});

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -1,105 +1,108 @@
-import { Clock, CheckCircle, Truck } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { listAdminOrders } from "@/api/admin";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+function formatMoney(value: number): string {
+  return `$${Number(value).toFixed(2)}`;
+}
 
 export default function AdminOrders() {
-  const { data: orders = [], isLoading } = useQuery({
+  const {
+    data: orders = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ["admin-orders"],
     queryFn: listAdminOrders,
   });
 
+  if (isLoading) {
+    return (
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar os pedidos"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void refetch()}
+          >
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-heading text-foreground">Pedidos</h1>
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Pedidos</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Pedidos da plataforma, com status de pagamento e cumprimento.
+        </p>
+      </div>
 
-      {isLoading && (
-        <p className="text-muted-foreground">Carregando pedidos...</p>
-      )}
-
-      {!isLoading && (
-        <div className="rounded-lg border border-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  ID
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden sm:table-cell">
-                  Total
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Data
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Pagamento
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {orders.map((o) => (
-                <tr
-                  key={o.id}
-                  className="border-t border-border hover:bg-muted/50 transition-colors"
-                >
-                  <td className="p-3 text-muted-foreground font-mono text-xs">
-                    #{o.id.slice(0, 8)}
-                  </td>
-                  <td className="p-3 text-primary font-heading hidden sm:table-cell">
-                    ${Number(o.totalAmount).toFixed(2)}
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden md:table-cell">
-                    {new Date(o.createdAt).toLocaleDateString("pt-BR")}
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`text-xs font-heading px-2 py-1 rounded ${
-                        o.paymentStatus === "PAID"
-                          ? "bg-primary/10 text-primary"
-                          : o.paymentStatus === "REFUNDED"
-                            ? "bg-destructive/10 text-destructive"
-                            : "bg-muted text-muted-foreground"
-                      }`}
-                    >
-                      {o.paymentStatus}
-                    </span>
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`inline-flex items-center gap-1 text-xs font-heading px-2 py-1 rounded ${
-                        o.status === "DELIVERED"
-                          ? "bg-primary/10 text-primary"
-                          : o.status === "SHIPPED"
-                            ? "bg-secondary/10 text-secondary"
-                            : o.status === "CANCELLED"
-                              ? "bg-destructive/10 text-destructive"
-                              : "bg-muted text-muted-foreground"
-                      }`}
-                    >
-                      {o.status === "PENDING" && <Clock className="h-3 w-3" />}
-                      {o.status === "SHIPPED" && <Truck className="h-3 w-3" />}
-                      {o.status === "DELIVERED" && (
-                        <CheckCircle className="h-3 w-3" />
-                      )}
-                      {o.status}
-                    </span>
-                  </td>
-                </tr>
+      {orders.length === 0 ? (
+        <EmptyState title="Nenhum pedido encontrado" />
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Total</TableHead>
+                <TableHead>Data</TableHead>
+                <TableHead>Pagamento</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {orders.map((order) => (
+                <TableRow key={order.id}>
+                  <TableCell className="font-mono text-xs">
+                    #{order.id.slice(0, 8)}
+                  </TableCell>
+                  <TableCell>{formatMoney(order.totalAmount)}</TableCell>
+                  <TableCell>
+                    {new Date(order.createdAt).toLocaleDateString("pt-BR")}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">{order.paymentStatus}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">{order.status}</Badge>
+                  </TableCell>
+                </TableRow>
               ))}
-              {orders.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={5}
-                    className="p-6 text-center text-muted-foreground"
-                  >
-                    Nenhum pedido encontrado
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       )}
     </div>

--- a/src/pages/admin/AdminSellers.tsx
+++ b/src/pages/admin/AdminSellers.tsx
@@ -1,141 +1,171 @@
-import { CheckCircle, XCircle, Users, Loader2 } from "lucide-react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { listSellers } from "@/api/sellers";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { adminApproveSeller } from "@/api/admin";
+import { listSellers } from "@/api/sellers";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import type { Seller } from "@/types/api";
+
+function formatMoney(value: number): string {
+  return `$${Number(value).toFixed(2)}`;
+}
+
+function formatCommission(rate: Seller["commissionRate"]): string {
+  return `${(Number(rate ?? 0.1) * 100).toFixed(0)}%`;
+}
 
 export default function AdminSellers() {
   const queryClient = useQueryClient();
-  const { data: sellers = [], isLoading } = useQuery({
+  const { toast } = useToast();
+  const {
+    data: sellers = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ["admin-sellers"],
     queryFn: listSellers,
   });
 
-  const approveMutation = useMutation({
+  const approveSeller = useMutation({
     mutationFn: ({ id, isApproved }: { id: string; isApproved: boolean }) =>
       adminApproveSeller(id, isApproved),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["admin-sellers"] }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["admin-sellers"] });
+      toast({
+        title: variables.isApproved ? "Vendedor aprovado" : "Vendedor suspenso",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Não foi possível atualizar o vendedor",
+        variant: "destructive",
+      });
+    },
   });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar os vendedores"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void refetch()}
+          >
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-heading text-foreground">Vendedores</h1>
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Vendedores</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Aprove cadastros pendentes ou suspenda lojas já ativas.
+        </p>
+      </div>
 
-      {isLoading && (
-        <p className="text-muted-foreground">Carregando vendedores...</p>
-      )}
-
-      {!isLoading && (
-        <div className="rounded-lg border border-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Loja
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden sm:table-cell">
-                  Usuário
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Comissão
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Saldo
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Status
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Ações
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {sellers.map((s) => (
-                <tr
-                  key={s.id}
-                  className="border-t border-border hover:bg-muted/50 transition-colors"
-                >
-                  <td className="p-3">
-                    <div className="flex items-center gap-2">
-                      <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center">
-                        <Users className="h-4 w-4 text-muted-foreground" />
-                      </div>
-                      <span className="font-medium text-foreground">
-                        {s.storeName}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden sm:table-cell">
-                    {s.user?.name ?? "—"}
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden md:table-cell">
-                    {(Number(s.commissionRate ?? 0.1) * 100).toFixed(0)}%
-                  </td>
-                  <td className="p-3 text-primary font-heading hidden md:table-cell">
-                    ${Number(s.balance).toFixed(2)}
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`text-xs font-heading px-2 py-1 rounded ${s.isApproved ? "bg-primary/10 text-primary" : "bg-secondary/10 text-secondary"}`}
+      {sellers.length === 0 ? (
+        <EmptyState title="Nenhum vendedor cadastrado" />
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Loja</TableHead>
+                <TableHead>Usuário</TableHead>
+                <TableHead>Comissão</TableHead>
+                <TableHead>Saldo</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sellers.map((seller) => (
+                <TableRow key={seller.id}>
+                  <TableCell className="font-medium">
+                    {seller.storeName}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {seller.user?.name ?? "—"}
+                  </TableCell>
+                  <TableCell>
+                    {formatCommission(seller.commissionRate)}
+                  </TableCell>
+                  <TableCell>{formatMoney(seller.balance)}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={seller.isApproved ? "default" : "secondary"}
                     >
-                      {s.isApproved ? "Aprovado" : "Pendente"}
-                    </span>
-                  </td>
-                  <td className="p-3">
-                    <div className="flex gap-1">
-                      {!s.isApproved ? (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          disabled={approveMutation.isPending}
-                          onClick={() =>
-                            approveMutation.mutate({
-                              id: s.id,
-                              isApproved: true,
-                            })
-                          }
-                        >
-                          {approveMutation.isPending ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                          ) : (
-                            <CheckCircle className="h-3 w-3 mr-1 text-primary" />
-                          )}
-                          Aprovar
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          disabled={approveMutation.isPending}
-                          onClick={() =>
-                            approveMutation.mutate({
-                              id: s.id,
-                              isApproved: false,
-                            })
-                          }
-                        >
-                          <XCircle className="h-3 w-3 mr-1 text-destructive" />
-                          Suspender
-                        </Button>
-                      )}
-                    </div>
-                  </td>
-                </tr>
+                      {seller.isApproved ? "Aprovado" : "Pendente"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {seller.isApproved ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        disabled={approveSeller.isPending}
+                        onClick={() =>
+                          approveSeller.mutate({
+                            id: seller.id,
+                            isApproved: false,
+                          })
+                        }
+                      >
+                        Suspender
+                      </Button>
+                    ) : (
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={approveSeller.isPending}
+                        onClick={() =>
+                          approveSeller.mutate({
+                            id: seller.id,
+                            isApproved: true,
+                          })
+                        }
+                      >
+                        Aprovar
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
               ))}
-              {sellers.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={6}
-                    className="p-6 text-center text-muted-foreground"
-                  >
-                    Nenhum vendedor cadastrado
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       )}
     </div>

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,95 +1,102 @@
-import { Shield, User } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { listAdminUsers } from "@/api/admin";
-
-const ROLE_STYLE: Record<string, string> = {
-  ADMIN: "bg-destructive/10 text-destructive",
-  SELLER: "bg-secondary/10 text-secondary",
-  CUSTOMER: "bg-muted text-muted-foreground",
-};
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 
 export default function AdminUsers() {
-  const { data: users = [], isLoading } = useQuery({
+  const {
+    data: users = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
     queryKey: ["admin-users"],
     queryFn: listAdminUsers,
   });
 
+  if (isLoading) {
+    return (
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar os usuários"
+        description={
+          error instanceof Error
+            ? error.message
+            : "Tente novamente em instantes."
+        }
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void refetch()}
+          >
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-heading text-foreground">Usuários</h1>
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Usuários</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Contas cadastradas na plataforma. Esta página é apenas leitura.
+        </p>
+      </div>
 
-      {isLoading && (
-        <p className="text-muted-foreground">Carregando usuários...</p>
-      )}
-
-      {!isLoading && (
-        <div className="rounded-lg border border-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted">
-              <tr>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Nome
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden sm:table-cell">
-                  E-mail
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs">
-                  Papel
-                </th>
-                <th className="text-left p-3 font-heading text-muted-foreground text-xs hidden md:table-cell">
-                  Cadastro
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {users.map((u) => (
-                <tr
-                  key={u.id}
-                  className="border-t border-border hover:bg-muted/50 transition-colors"
-                >
-                  <td className="p-3">
-                    <div className="flex items-center gap-2">
-                      <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center">
-                        {u.role === "ADMIN" ? (
-                          <Shield className="h-4 w-4 text-destructive" />
-                        ) : (
-                          <User className="h-4 w-4 text-muted-foreground" />
-                        )}
-                      </div>
-                      <span className="font-medium text-foreground">
-                        {u.name}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden sm:table-cell">
-                    {u.email}
-                  </td>
-                  <td className="p-3">
-                    <span
-                      className={`text-xs font-heading px-2 py-1 rounded ${ROLE_STYLE[u.role] ?? "bg-muted text-muted-foreground"}`}
-                    >
-                      {u.role}
-                    </span>
-                  </td>
-                  <td className="p-3 text-muted-foreground hidden md:table-cell">
-                    {u.createdAt
-                      ? new Date(u.createdAt).toLocaleDateString("pt-BR")
+      {users.length === 0 ? (
+        <EmptyState title="Nenhum usuário encontrado" />
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>E-mail</TableHead>
+                <TableHead>Papel</TableHead>
+                <TableHead>Cadastro</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell className="font-medium">{user.name}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {user.email}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">{user.role}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    {user.createdAt
+                      ? new Date(user.createdAt).toLocaleDateString("pt-BR")
                       : "—"}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ))}
-              {users.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={4}
-                    className="p-6 text-center text-muted-foreground"
-                  >
-                    Nenhum usuário encontrado
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       )}
     </div>

--- a/src/pages/admin/__tests__/AdminOrders.test.tsx
+++ b/src/pages/admin/__tests__/AdminOrders.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AdminOrders from "../AdminOrders";
+import type { Order } from "@/types/api";
+
+const listAdminOrders = vi.fn();
+
+vi.mock("@/api/admin", () => ({
+  listAdminOrders: (...args: unknown[]) => listAdminOrders(...args),
+}));
+
+function order(): Order {
+  return {
+    id: "order-abcdef12",
+    totalAmount: 18.5,
+    status: "CONFIRMED",
+    paymentStatus: "PAID",
+    createdAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+    updatedAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+  };
+}
+
+function renderOrders() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminOrders />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminOrders", () => {
+  beforeEach(() => {
+    listAdminOrders.mockReset();
+  });
+
+  it("lists admin orders without extra actions", async () => {
+    listAdminOrders.mockResolvedValue([order()]);
+
+    renderOrders();
+
+    expect(await screen.findByText("Pedidos")).toBeTruthy();
+    expect(screen.getByText("#order-ab")).toBeTruthy();
+    expect(screen.getByText("$18.50")).toBeTruthy();
+    expect(screen.getByText("PAID")).toBeTruthy();
+    expect(listAdminOrders).toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Aprovar" })).toBeNull();
+  });
+});

--- a/src/pages/admin/__tests__/AdminSellers.test.tsx
+++ b/src/pages/admin/__tests__/AdminSellers.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AdminSellers from "../AdminSellers";
+import type { Seller } from "@/types/api";
+
+const listSellers = vi.fn();
+const adminApproveSeller = vi.fn();
+
+vi.mock("@/api/sellers", () => ({
+  listSellers: (...args: unknown[]) => listSellers(...args),
+}));
+
+vi.mock("@/api/admin", () => ({
+  adminApproveSeller: (...args: unknown[]) => adminApproveSeller(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function seller(overrides: Partial<Seller> = {}): Seller {
+  return {
+    id: "seller-pending",
+    userId: "user-pending",
+    storeName: "Loja Pendente",
+    commissionRate: 0.1,
+    balance: 25,
+    rating: 0,
+    isApproved: false,
+    user: {
+      id: "user-pending",
+      name: "Pending Seller",
+      email: "pending@test.com",
+    },
+    ...overrides,
+  };
+}
+
+function renderSellers() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminSellers />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminSellers", () => {
+  beforeEach(() => {
+    listSellers.mockReset();
+    adminApproveSeller.mockReset();
+    adminApproveSeller.mockResolvedValue(seller({ isApproved: true }));
+  });
+
+  it("lists sellers and approves with adminApproveSeller(id, true)", async () => {
+    listSellers.mockResolvedValue([
+      seller(),
+      seller({
+        id: "seller-ok",
+        storeName: "Loja Aprovada",
+        isApproved: true,
+        user: { id: "user-ok", name: "Approved Seller", email: "ok@test.com" },
+      }),
+    ]);
+
+    renderSellers();
+
+    expect(await screen.findByText("Vendedores")).toBeTruthy();
+    expect(screen.getByText("Loja Pendente")).toBeTruthy();
+    expect(screen.getByText("Loja Aprovada")).toBeTruthy();
+    expect(listSellers).toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Aprovar" }));
+    await waitFor(() => {
+      expect(adminApproveSeller).toHaveBeenCalledWith("seller-pending", true);
+    });
+  });
+
+  it("suspends an approved seller with adminApproveSeller(id, false)", async () => {
+    listSellers.mockResolvedValue([
+      seller({
+        id: "seller-ok",
+        storeName: "Loja Aprovada",
+        isApproved: true,
+      }),
+    ]);
+
+    renderSellers();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Suspender" }));
+    await waitFor(() => {
+      expect(adminApproveSeller).toHaveBeenCalledWith("seller-ok", false);
+    });
+  });
+});

--- a/src/pages/admin/__tests__/AdminUsers.test.tsx
+++ b/src/pages/admin/__tests__/AdminUsers.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AdminUsers from "../AdminUsers";
+import type { User } from "@/types/api";
+
+const listAdminUsers = vi.fn();
+
+vi.mock("@/api/admin", () => ({
+  listAdminUsers: (...args: unknown[]) => listAdminUsers(...args),
+}));
+
+function user(): User {
+  return {
+    id: "user-1",
+    name: "Admin User",
+    email: "admin@skinmarket.gg",
+    role: "ADMIN",
+    createdAt: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+  };
+}
+
+function renderUsers() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminUsers />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminUsers", () => {
+  beforeEach(() => {
+    listAdminUsers.mockReset();
+  });
+
+  it("lists users as read-only", async () => {
+    listAdminUsers.mockResolvedValue([user()]);
+
+    renderUsers();
+
+    expect(await screen.findByText("Usuários")).toBeTruthy();
+    expect(screen.getByText("Admin User")).toBeTruthy();
+    expect(screen.getByText("admin@skinmarket.gg")).toBeTruthy();
+    expect(screen.getByText("ADMIN")).toBeTruthy();
+    expect(listAdminUsers).toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Aprovar" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Suspender" })).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restyle the admin surfaces to the same dark editorial shell as D1, without adding admin actions or changing API contracts.

## Scope
- `src/pages/AdminDashboard.tsx`
- `src/pages/admin/AdminSellers.tsx`
- `src/pages/admin/AdminOrders.tsx`
- `src/pages/admin/AdminUsers.tsx`

Header, DashboardLayout, and `server/` are untouched.

## Preserved contract
- Lists still use `listSellers`, `listAdminOrders`, `listAdminUsers`, and `listProducts({ limit: 1 })` for the product count.
- Seller approval still goes through `adminApproveSeller(id, isApproved)` only.
- Dashboard pending sellers: Aprovar / Rejeitar.
- Sellers page: Aprovar (pending) / Suspender (approved).
- Orders and users remain read-only tables.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test` (55 passing)
- Browser walkthrough as `admin@skinmarket.gg`: `/admin`, `/admin/sellers`, `/admin/orders`, `/admin/users`

[admin-four-pages-walkthrough.mp4](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-four-pages-walkthrough.mp4)
[Painel admin](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-overview-final.png)
[Vendedores](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-sellers-final2.png)
[Pedidos](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-orders-final2.png)
[Usuários](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin-users-final2.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

