### PR TITLE
P1.4: Performance evidence and hot-path indexes

### DIFF
--- a/docs/adr/0006-hot-path-indexes.md
+++ b/docs/adr/0006-hot-path-indexes.md
@@ -1,0 +1,25 @@
+# ADR 0006 — Hot-path indexes from measured query plans
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #9 / roadmap P1.4 requires index decisions backed by `EXPLAIN ANALYZE`, not by adding caches. The public market calls `GET /listings?status=ACTIVE` and the API orders by `createdAt DESC` (the client re-sorts the current page by price/float). PayPal reconciliation lists stale `PENDING` orders by `updatedAt`.
+
+Existing single-column `Listing(status)` and `Order(paymentStatus)` indexes do not cover those `ORDER BY` clauses.
+
+## Decision
+
+1. Replace `Listing_status_idx` with `Listing(status, createdAt)`. Left-prefix still serves status-only filters; the extra column avoids a sort for market pagination.
+2. Replace `Order_paymentStatus_idx` with `Order(paymentStatus, status, updatedAt)` for the reconciliation batch (`PENDING`/`PENDING`, `paypalOrderId IS NOT NULL`, oldest first).
+3. Keep `Listing(status, reservationExpiresAt)` and unique keys for idempotency and webhook events. Do not add `(status, price)` until the API sorts by price.
+4. Do not introduce Redis, a cache, or a queue. At 2.5k listings the page query is ~0.02ms; `COUNT(*)` is the slower sibling (~0.4ms) and remains acceptable.
+
+## Consequences
+
+- Market `LIMIT 20` uses `Listing_status_createdAt_idx` (measured).
+- Reconciliation uses `Order_paymentStatus_status_updatedAt_idx` (measured).
+- `COUNT(*)` for `total` may still seq-scan. That is the documented scaling trigger for cursor pagination, not a cache.
+- Expiry `OR reservationExpiresAt IS NULL` may not pick the reservation-expiry index; reserved cardinality is small. Split that predicate only if expiry scans become a measured problem.

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -102,6 +102,10 @@ Concurrency, rollback, unique constraints and reservation/payment races are prov
 
 See `docs/testing.md`.
 
+## Performance
+
+Market browse (`status = ACTIVE ORDER BY createdAt DESC`) and PayPal reconciliation have composite indexes chosen from `EXPLAIN ANALYZE`. `COUNT(*)` for listing pagination is the slower sibling of the page query and is still cheap at a few thousand rows. Scaling triggers: `docs/architecture/scaling-path.md`. Measurements: `docs/performance.md`.
+
 ## Runtime configuration
 
 The backend package provides scripts for development, build, type checking, unit tests, PostgreSQL integration tests and Prisma migrations.

--- a/docs/architecture/scaling-path.md
+++ b/docs/architecture/scaling-path.md
@@ -1,0 +1,36 @@
+# Scaling path
+
+Neon Arsenal stays a modular monolith on PostgreSQL until a **measured** trigger says otherwise. See `docs/performance.md` for the current numbers.
+
+## Current shape
+
+```text
+Client  →  Express API (one or more replicas)
+              →  PostgreSQL (source of truth)
+              →  PayPal / Resend (timeouts, classified retries)
+```
+
+Replicas do not shard business state. Reservation, idempotency and payment confirmation are conditional writes and unique constraints. Extra API processes only add more in-process sweeps, which are already idempotent.
+
+## What is fast enough today
+
+At ~2.5k `ACTIVE` listings, market page index scans are ~0.02 ms; `listingsService.list` (joins + `COUNT(*)`) p95 is ~4 ms. Checkout and payment confirmation are PK/conditional updates. PayPal HTTP, not SQL, dominates payment-link latency.
+
+## Triggers (act only when one of these is true)
+
+| Signal | First mitigation | Still not justified |
+|---|---|---|
+| `GET /listings` p95 > ~50 ms and EXPLAIN shows `COUNT(*)` or deep `OFFSET` | Drop or cache `total`, or cursor pagination | Redis for the whole listing payload |
+| Market must sort by price/float in SQL, not in the browser | `ORDER BY` in the API + matching `(status, price)` index | Elasticsearch |
+| Expiry sweep time grows with `RESERVED` rows and the `OR expires IS NULL` plan ignores `reservationExpiresAt` | Two predicates (range vs null) | Dedicated worker queue |
+| PayPal GET reconciliation lags captured orders | Tune batch/interval; keep GET retries | Kafka/SQS |
+| Checkout lock waits dominate under many buyers on **different** listings | More API replicas + connection pool | Listing sharding |
+| CPU/RAM of one API instance saturates on JSON/auth, DB is idle | Horizontal API replicas behind a load balancer | Microservices |
+
+## Explicit non-goals until a trigger fires
+
+- Redis, Kafka, RabbitMQ, SQS
+- Read replicas (writes are the correctness path)
+- Splitting payments or listings into their own deployable
+
+When a trigger fires, record the measurement, the EXPLAIN, and the mitigation in `docs/performance.md` and a new ADR.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,65 @@
+# Performance evidence
+
+Measured on PostgreSQL 16, local Cloud Agent VM, 2 500 `ACTIVE` listings, 80 `RESERVED`, 80 `SOLD`, 120 stale pending PayPal orders. Command: `cd server && npm run perf:evidence` (after `prisma migrate deploy`). CI re-checks index use in `performance.evidence.integration.test.ts`.
+
+This is not a production load test. Absolute milliseconds will move with hardware. The **shape** of the plans and the chosen mitigations are the durable result.
+
+## Hot paths
+
+| Path | What actually runs | Dominant cost today |
+|---|---|---|
+| `GET /listings?status=ACTIVE` | `Listing` page `ORDER BY createdAt DESC LIMIT 20` plus `COUNT(*)` and joins to Product/Seller/User | `COUNT(*)` + joins, not the page index scan |
+| `GET /listings/:id` | PK lookup + joins | Primary key |
+| `POST /orders` | Transaction: unique idempotency insert, per-listing conditional `UPDATE` by PK, order items | Row lock on the listing, not a scan |
+| `confirmPayment` | Conditional order claim by PK, conditional listing sell, seller transactions | Same: PK/conditional updates |
+| Reservation expiry sweep | `UPDATE Listing WHERE status = 'RESERVED' AND (expires <= now OR expires IS NULL)` then unpaid-order `EXISTS` | Tiny `RESERVED` set |
+| PayPal reconciliation | `PENDING` orders with `paypalOrderId`, oldest first, batch 20 | Composite index + PayPal GET |
+
+PayPal HTTP (`PAYPAL_API_TIMEOUT_MS` = 10s) dominates `POST /payments` latency. Database work on that path is a PK update of `paypalOrderId`.
+
+The market UI sorts price/float **in the browser on the current page**. SQL still orders by `createdAt`. A `(status, price)` index would be unused until the API accepts a sort field.
+
+## EXPLAIN ANALYZE (representative)
+
+| Query | Plan | Execution |
+|---|---|---|
+| Market page (`status = ACTIVE ORDER BY createdAt DESC LIMIT 20`) | Index Scan `Listing_status_createdAt_idx` | 0.017 ms |
+| Market `COUNT(*)` where `status = ACTIVE` | Seq Scan | 0.425 ms |
+| Market page plus price range | Index Scan `Listing_status_createdAt_idx` (filter on price) | 0.018 ms |
+| Expiry predicate including `OR expires IS NULL` | Index Scan `Listing_status_createdAt_idx` (status prefix) | 0.030 ms |
+| Expiry predicate `status = RESERVED AND expires <= now()` | `Listing_status_reservationExpiresAt_idx` | proven in CI |
+| Reconciliation pending PayPal orders | Index Scan `Order_paymentStatus_status_updatedAt_idx` | 0.034 ms |
+| Unpaid orders that no longer hold listings | Nested loop on `OrderItem` / `Listing_pkey` | 0.023 ms |
+
+`listingsService.list` (page + count + joins), 10 samples: p50 **2.59 ms**, p95 **4.27 ms**.
+
+Index-only/unique lookups for `OrderIdempotencyKey(customerId, key)` and `PaymentWebhookEvent(provider, externalEventId)` are constraints first. At one row the planner may seq-scan; uniqueness still serializes concurrent retries.
+
+## Index review
+
+| Index | Decision | Why |
+|---|---|---|
+| `Listing(status, createdAt)` | **Added** (replaces `Listing(status)`) | Real market SQL |
+| `Order(paymentStatus, status, updatedAt)` | **Added** (replaces `Order(paymentStatus)`) | Reconciliation SQL |
+| `Listing(status, reservationExpiresAt)` | Keep | Expiry without the NULL branch |
+| `Listing(productId, status)`, `sellerId`, `price`, `floatValue` | Keep | Filters / FKs |
+| `Listing(status, price)` | **Not added** | API does not `ORDER BY price` |
+| Unique `(customerId, key)`, `(provider, externalEventId)`, `paypalOrderId` | Keep | Correctness, not speed |
+
+## Bottleneck and mitigation
+
+**Chosen now:** composite indexes above. No Redis, no query cache, no queue.
+
+**Measured bottleneck on the read path:** `COUNT(*)` for pagination `total`, not the `LIMIT 20` index scan. At 2.5k rows it is still sub-millisecond. Do not cache it yet.
+
+**Not a database problem:** PayPal round-trips; checkout correctness under contention (conditional `UPDATE`).
+
+## Capacity assumptions
+
+- One modular-monolith API process + one PostgreSQL. In-process expiry/reconciliation timers. Horizontal API replicas are safe because invariants live in PostgreSQL.
+- Current catalog size (demo seed / a few thousand listings) is well inside the plans above.
+- OFFSET pagination is used (`page * limit`). Deep offsets are not a current product need (`limit` max 100).
+
+## Scaling triggers
+
+See `docs/architecture/scaling-path.md`. Repeat measurements with `npm run perf:evidence` after the catalog grows by an order of magnitude, or if `GET /listings` p95 exceeds ~50 ms in a production-like environment.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,13 +82,14 @@ See `docs/adr/0005-external-retry-and-graceful-shutdown.md` and `docs/architectu
 
 ### P1.4 Performance evidence
 
-Produce:
+Implemented:
 
-- benchmark for important endpoints/workflows;
-- `EXPLAIN ANALYZE` evidence for important queries;
-- index review;
-- hot-path and capacity notes;
-- identified bottleneck and chosen mitigation.
+- Repeatable `EXPLAIN ANALYZE` + workflow timings (`npm run perf:evidence`, CI in `performance.evidence.integration.test.ts`);
+- Market page uses `Listing(status, createdAt)`; reconciliation uses `Order(paymentStatus, status, updatedAt)`;
+- `COUNT(*)` identified as the listing-list cost, not a reason to add Redis;
+- Capacity assumptions and scaling triggers documented.
+
+See `docs/performance.md`, `docs/architecture/scaling-path.md` and `docs/adr/0006-hot-path-indexes.md`.
 
 ## P2 — Cloud and operational maturity
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,6 +15,7 @@ From `server/`:
 | `npm run test:integration` | PostgreSQL integration tests. Fails if the database is missing. |
 | `npm run test:all` | Unit tests, then integration tests. |
 | `npm run test:db:prepare` | `prisma migrate deploy` against `DATABASE_URL`. |
+| `npm run perf:evidence` | Seed a disposable catalog, print `EXPLAIN ANALYZE` + `listingsService.list` timings. |
 
 Frontend unit tests remain `npm test` at the repository root.
 
@@ -103,5 +104,8 @@ Integration tests are not skipped when PostgreSQL is down. A missing or unreacha
 | `reservation.lifecycle.integration.test.ts` | Reservation timestamps, concurrent buyers, expiration vs payment, no duplicate seller transactions. |
 | `paypal.webhook.integration.test.ts` | Duplicate/out-of-order events, expired capture, stale-order capture, payment rollback. PayPal remains isolated. |
 | `observability.integration.test.ts` | Order/reservation/payment/webhook spans and counters against real PostgreSQL. No secrets or high-cardinality labels. |
+| `performance.evidence.integration.test.ts` | `EXPLAIN ANALYZE` on market/expiry/reconciliation SQL uses the hot-path indexes; listing/order/payment timings stay bounded. |
 
 OpenTelemetry is disabled for normal development. Telemetry tests start an in-memory exporter with `startTestTelemetry()` and do not require a collector. Unit tests also cover request-ID correlation, HTTP route cardinality, business-vs-operational span status, redaction and the disabled/OTLP-down paths. See `docs/observability.md`.
+
+`cd server && npm run perf:evidence` reprints EXPLAIN and `listingsService.list` timings against the current database. Use a disposable catalog (the integration database), not production.

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:all": "npm run test:unit && npm run test:integration",
     "test:watch": "vitest",
+    "perf:evidence": "tsx src/scripts/perfEvidence.ts",
     "test:db:prepare": "prisma migrate deploy",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",

--- a/server/prisma/migrations/20260905020000_hot_path_indexes/migration.sql
+++ b/server/prisma/migrations/20260905020000_hot_path_indexes/migration.sql
@@ -1,0 +1,10 @@
+-- Market browse: WHERE status = 'ACTIVE' ORDER BY "createdAt" DESC LIMIT n
+-- The single-column status index is redundant with this left-prefix.
+DROP INDEX IF EXISTS "Listing_status_idx";
+CREATE INDEX "Listing_status_createdAt_idx" ON "Listing"("status", "createdAt");
+
+-- PayPal reconciliation: pending paid-but-unconfirmed orders ordered by age.
+-- Replaces the standalone paymentStatus index (left-prefix of this composite).
+DROP INDEX IF EXISTS "Order_paymentStatus_idx";
+CREATE INDEX "Order_paymentStatus_status_updatedAt_idx"
+ON "Order"("paymentStatus", "status", "updatedAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -96,7 +96,7 @@ model Order {
 
   @@index([customerId])
   @@index([status])
-  @@index([paymentStatus])
+  @@index([paymentStatus, status, updatedAt])
 }
 
 model OrderIdempotencyKey {
@@ -158,9 +158,9 @@ model Listing {
   @@index([productId])
   @@index([price])
   @@index([floatValue])
-  @@index([status])
   @@index([sellerId])
   @@index([productId, status])
+  @@index([status, createdAt])
   @@index([status, reservationExpiresAt])
   @@index([reservedByOrderId])
 }

--- a/server/src/__tests__/performance.evidence.integration.test.ts
+++ b/server/src/__tests__/performance.evidence.integration.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { prisma } from "../shared/database/index.js";
+import { listingsService } from "../modules/listings/listings.service.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import { createOrder, createUser, orderKey } from "./helpers/index.js";
+import { explainAnalyze } from "../shared/perf/explain.js";
+import { timeAsync } from "../shared/perf/measure.js";
+import { indexNames, usesIndexAccess } from "../shared/perf/plan.js";
+import { PERF_QUERIES } from "../shared/perf/queries.js";
+import { seedPerformanceCatalog } from "../shared/perf/seed.js";
+
+describe("P1.4 performance evidence", () => {
+  it("uses hot-path indexes and records order/listing/payment timings", async () => {
+    const seeded = await seedPerformanceCatalog();
+    const active = await prisma.listing.findMany({
+      where: { status: "ACTIVE" },
+      take: 6,
+      select: { id: true },
+    });
+    expect(active.length).toBeGreaterThanOrEqual(6);
+
+    const market = await explainAnalyze(PERF_QUERIES.marketActiveCreatedAt);
+    expect(usesIndexAccess(market.Plan, "Listing"), indexNames(market.Plan).join(",")).toBe(true);
+    expect(indexNames(market.Plan).some((name) => name.includes("status_createdAt"))).toBe(true);
+
+    // COUNT(*) of ACTIVE listings is the pagination-total cost. At a few thousand
+    // rows PostgreSQL may still seq-scan; the evidence is the execution time, not
+    // a forced index-only scan.
+    const countPlan = await explainAnalyze(PERF_QUERIES.marketActiveCount);
+    expect(countPlan.Plan).toBeDefined();
+
+    const expireExact = await explainAnalyze(`
+      SELECT l.id
+      FROM "Listing" l
+      WHERE l.status = 'RESERVED' AND l."reservationExpiresAt" <= NOW()
+    `);
+    expect(
+      indexNames(expireExact.Plan).some((name) => name.includes("reservationExpiresAt")),
+      indexNames(expireExact.Plan).join(",")
+    ).toBe(true);
+
+    const expireWithNulls = await explainAnalyze(PERF_QUERIES.expireReserved);
+    expect(expireWithNulls.Plan).toBeDefined();
+
+    const reconcile = await explainAnalyze(PERF_QUERIES.reconcilePendingPaypal);
+    expect(usesIndexAccess(reconcile.Plan, "Order"), indexNames(reconcile.Plan).join(",")).toBe(true);
+    expect(indexNames(reconcile.Plan).some((name) => name.includes("paymentStatus"))).toBe(true);
+
+    const tableIndexes = await prisma.$queryRaw<Array<{ tablename: string; indexname: string }>>`
+      SELECT tablename, indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename IN ('Listing', 'Order', 'OrderIdempotencyKey', 'PaymentWebhookEvent')
+    `;
+    const names = tableIndexes.map((row) => row.indexname);
+    expect(names).toContain("Listing_status_createdAt_idx");
+    expect(names).toContain("Listing_status_reservationExpiresAt_idx");
+    expect(names).toContain("Order_paymentStatus_status_updatedAt_idx");
+    expect(names).toContain("OrderIdempotencyKey_customerId_key_key");
+    expect(names).toContain("PaymentWebhookEvent_provider_externalEventId_key");
+    expect(names).not.toContain("Listing_status_idx");
+    expect(names).not.toContain("Order_paymentStatus_idx");
+
+    await prisma.orderIdempotencyKey.create({
+      data: {
+        customerId: seeded.customer.id,
+        key: "perf-lookup",
+        requestHash: "hash",
+        status: "COMPLETED",
+      },
+    });
+    await prisma.paymentWebhookEvent.create({
+      data: {
+        provider: "PAYPAL",
+        externalEventId: "WH-PERF-1",
+        eventType: "PAYMENT.CAPTURE.COMPLETED",
+        status: "PROCESSED",
+      },
+    });
+
+    const buyer = await createUser({ name: "Perf Checkout Buyer", role: "CUSTOMER" });
+    const listTiming = await timeAsync(
+      () => listingsService.list({ status: "ACTIVE", page: 1, limit: 20 }),
+      8
+    );
+    const getTiming = await timeAsync(() => listingsService.getById(active[0].id), 8);
+
+    const createDurations = [];
+    const confirmDurations = [];
+    for (let index = 0; index < 3; index += 1) {
+      const listingId = active[index + 1].id;
+      const created = await timeAsync(
+        () => createOrder(buyer.id, [listingId], orderKey(`perf-${index}`)),
+        1
+      );
+      createDurations.push(created);
+      const order = await prisma.order.findFirstOrThrow({
+        where: { customerId: buyer.id, items: { some: { listingId } } },
+        select: { id: true },
+      });
+      const confirmed = await timeAsync(() => paymentsService.confirmPayment(order.id), 1);
+      confirmDurations.push(confirmed);
+    }
+
+    expect(listTiming.p95Ms).toBeGreaterThan(0);
+    expect(listTiming.p95Ms).toBeLessThan(2_000);
+    expect(getTiming.p95Ms).toBeLessThan(1_000);
+    expect(createDurations[0].p95Ms).toBeLessThan(2_000);
+    expect(confirmDurations[0].p95Ms).toBeLessThan(2_000);
+
+    expect(market["Execution Time"]).toBeGreaterThan(0);
+    expect(countPlan["Execution Time"]).toBeGreaterThan(0);
+  });
+});

--- a/server/src/scripts/perfEvidence.ts
+++ b/server/src/scripts/perfEvidence.ts
@@ -1,0 +1,46 @@
+import { prisma } from "../shared/database/index.js";
+import { explainAnalyze } from "../shared/perf/explain.js";
+import { indexNames, usesIndexAccess } from "../shared/perf/plan.js";
+import { PERF_QUERIES } from "../shared/perf/queries.js";
+import { seedPerformanceCatalog } from "../shared/perf/seed.js";
+import { listingsService } from "../modules/listings/listings.service.js";
+import { timeAsync } from "../shared/perf/measure.js";
+
+function summarize(name: string, sql: string, plan: Awaited<ReturnType<typeof explainAnalyze>>) {
+  return {
+    name,
+    sql: sql.replace(/\s+/g, " ").trim(),
+    executionMs: plan["Execution Time"] ?? null,
+    planningMs: plan["Planning Time"] ?? null,
+    indexAccess: usesIndexAccess(plan.Plan, "Listing") || usesIndexAccess(plan.Plan, "Order") || usesIndexAccess(plan.Plan, "OrderIdempotencyKey") || usesIndexAccess(plan.Plan, "PaymentWebhookEvent"),
+    indexes: indexNames(plan.Plan),
+  };
+}
+
+async function main() {
+  await seedPerformanceCatalog();
+  const queries = [
+    ["marketActiveCreatedAt", PERF_QUERIES.marketActiveCreatedAt],
+    ["marketActiveCount", PERF_QUERIES.marketActiveCount],
+    ["marketActivePriceRange", PERF_QUERIES.marketActivePriceRange],
+    ["expireReserved", PERF_QUERIES.expireReserved],
+    ["reconcilePendingPaypal", PERF_QUERIES.reconcilePendingPaypal],
+    ["cancelUnpaidWithoutHold", PERF_QUERIES.cancelUnpaidWithoutHold],
+  ] as const;
+
+  const explains = [];
+  for (const [name, sql] of queries) {
+    explains.push(summarize(name, sql, await explainAnalyze(sql)));
+  }
+
+  const list = await timeAsync(() => listingsService.list({ status: "ACTIVE", page: 1, limit: 20 }), 10);
+  const report = { explains, list };
+  console.log(JSON.stringify(report, null, 2));
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/server/src/shared/perf/__tests__/plan.test.ts
+++ b/server/src/shared/perf/__tests__/plan.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { flattenPlans, usesIndexAccess, usesSeqScan, type ExplainNode } from "../plan.js";
+
+function node(partial: ExplainNode): ExplainNode {
+  return partial;
+}
+
+describe("EXPLAIN plan helpers", () => {
+  it("detects index access on a nested plan", () => {
+    const plan = node({
+      "Node Type": "Limit",
+      Plans: [
+        {
+          "Node Type": "Index Scan",
+          "Relation Name": "Listing",
+          "Index Name": "Listing_status_createdAt_idx",
+        },
+      ],
+    });
+    expect(flattenPlans(plan)).toHaveLength(2);
+    expect(usesIndexAccess(plan, "Listing")).toBe(true);
+    expect(usesSeqScan(plan, "Listing")).toBe(false);
+  });
+
+  it("detects sequential scans on the named relation only", () => {
+    const plan = node({
+      "Node Type": "Nested Loop",
+      Plans: [
+        { "Node Type": "Seq Scan", "Relation Name": "Listing" },
+        { "Node Type": "Index Scan", "Relation Name": "Product", "Index Name": "Product_pkey" },
+      ],
+    });
+    expect(usesSeqScan(plan, "Listing")).toBe(true);
+    expect(usesIndexAccess(plan, "Product")).toBe(true);
+    expect(usesSeqScan(plan, "Product")).toBe(false);
+  });
+});

--- a/server/src/shared/perf/explain.ts
+++ b/server/src/shared/perf/explain.ts
@@ -1,0 +1,13 @@
+import { prisma } from "../database/index.js";
+import type { ExplainResult } from "./plan.js";
+
+export async function explainAnalyze(sql: string): Promise<ExplainResult> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ "QUERY PLAN": ExplainResult[] }>>(
+    `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${sql}`
+  );
+  const plan = rows[0]?.["QUERY PLAN"]?.[0];
+  if (!plan?.Plan) {
+    throw new Error("EXPLAIN ANALYZE returned no plan");
+  }
+  return plan;
+}

--- a/server/src/shared/perf/measure.ts
+++ b/server/src/shared/perf/measure.ts
@@ -1,0 +1,34 @@
+export type TimingSummary = {
+  samples: number;
+  minMs: number;
+  maxMs: number;
+  p50Ms: number;
+  p95Ms: number;
+};
+
+export async function timeAsync(operation: () => Promise<unknown>, samples: number): Promise<TimingSummary> {
+  const durations: number[] = [];
+  for (let index = 0; index < samples; index += 1) {
+    const started = performance.now();
+    await operation();
+    durations.push(performance.now() - started);
+  }
+  durations.sort((a, b) => a - b);
+  return {
+    samples,
+    minMs: roundMs(durations[0]),
+    maxMs: roundMs(durations[durations.length - 1]),
+    p50Ms: roundMs(percentile(durations, 0.5)),
+    p95Ms: roundMs(percentile(durations, 0.95)),
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.ceil(p * sorted.length) - 1);
+  return sorted[Math.max(0, index)];
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/server/src/shared/perf/plan.ts
+++ b/server/src/shared/perf/plan.ts
@@ -1,0 +1,41 @@
+export type ExplainNode = {
+  "Node Type"?: string;
+  "Relation Name"?: string;
+  "Index Name"?: string;
+  "Actual Total Time"?: number;
+  "Plan Rows"?: number;
+  Plans?: ExplainNode[];
+};
+
+export type ExplainResult = {
+  Plan?: ExplainNode;
+  "Execution Time"?: number;
+  "Planning Time"?: number;
+};
+
+export function flattenPlans(node: ExplainNode | undefined): ExplainNode[] {
+  if (!node) return [];
+  return [node, ...(node.Plans ?? []).flatMap((child) => flattenPlans(child))];
+}
+
+export function indexNames(node: ExplainNode | undefined): string[] {
+  return flattenPlans(node)
+    .map((plan) => plan["Index Name"])
+    .filter((name): name is string => Boolean(name));
+}
+
+export function nodeTypesOnRelation(node: ExplainNode | undefined, relation: string): string[] {
+  return flattenPlans(node)
+    .filter((plan) => plan["Relation Name"] === relation)
+    .map((plan) => plan["Node Type"] ?? "Unknown");
+}
+
+export function usesIndexAccess(node: ExplainNode | undefined, relation: string): boolean {
+  return nodeTypesOnRelation(node, relation).some((type) =>
+    /Index Scan|Index Only Scan|Bitmap Index Scan|Bitmap Heap Scan/.test(type)
+  );
+}
+
+export function usesSeqScan(node: ExplainNode | undefined, relation: string): boolean {
+  return nodeTypesOnRelation(node, relation).includes("Seq Scan");
+}

--- a/server/src/shared/perf/queries.ts
+++ b/server/src/shared/perf/queries.ts
@@ -1,0 +1,77 @@
+/**
+ * SQL that matches the hot Prisma/raw queries in listings, orders and payments.
+ * Used for EXPLAIN ANALYZE so index decisions are tied to executable plans,
+ * not guessed from schema comments.
+ */
+export const PERF_QUERIES = {
+  marketActiveCreatedAt: `
+    SELECT l.id
+    FROM "Listing" l
+    WHERE l.status = 'ACTIVE'
+    ORDER BY l."createdAt" DESC
+    LIMIT 20
+  `,
+  marketActiveCount: `
+    SELECT COUNT(*)::int AS count
+    FROM "Listing"
+    WHERE status = 'ACTIVE'
+  `,
+  marketActivePriceRange: `
+    SELECT l.id
+    FROM "Listing" l
+    WHERE l.status = 'ACTIVE'
+      AND l.price >= 50
+      AND l.price <= 500
+    ORDER BY l."createdAt" DESC
+    LIMIT 20
+  `,
+  expireReserved: `
+    SELECT l.id
+    FROM "Listing" l
+    WHERE l.status = 'RESERVED'
+      AND (l."reservationExpiresAt" <= NOW() OR l."reservationExpiresAt" IS NULL)
+  `,
+  sellHeldListing: `
+    SELECT l.id
+    FROM "Listing" l
+    WHERE l.status = 'RESERVED'
+      AND l."reservedByOrderId" IS NOT NULL
+      AND l."reservationExpiresAt" > NOW()
+    LIMIT 20
+  `,
+  reconcilePendingPaypal: `
+    SELECT o.id
+    FROM "Order" o
+    WHERE o."paymentStatus" = 'PENDING'
+      AND o.status = 'PENDING'
+      AND o."paypalOrderId" IS NOT NULL
+      AND o."updatedAt" <= NOW() - INTERVAL '2 minutes'
+    ORDER BY o."updatedAt" ASC
+    LIMIT 20
+  `,
+  idempotencyLookup: `
+    SELECT k.id
+    FROM "OrderIdempotencyKey" k
+    WHERE k."customerId" = $1 AND k.key = $2
+  `,
+  webhookEventLookup: `
+    SELECT e.id
+    FROM "PaymentWebhookEvent" e
+    WHERE e.provider = 'PAYPAL' AND e."externalEventId" = $1
+  `,
+  cancelUnpaidWithoutHold: `
+    SELECT o.id
+    FROM "Order" o
+    WHERE o."paymentStatus" = 'PENDING'
+      AND o.status = 'PENDING'
+      AND EXISTS (
+        SELECT 1
+        FROM "OrderItem" i
+        INNER JOIN "Listing" l ON l.id = i."listingId"
+        WHERE i."orderId" = o.id
+          AND (l.status <> 'RESERVED' OR l."reservedByOrderId" IS DISTINCT FROM o.id)
+      )
+  `,
+} as const;
+
+export type PerfQueryName = keyof typeof PERF_QUERIES;

--- a/server/src/shared/perf/seed.ts
+++ b/server/src/shared/perf/seed.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "node:crypto";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../database/index.js";
+
+export const PERF_SEED = {
+  activeListings: 2_500,
+  reservedListings: 80,
+  soldListings: 80,
+  pendingPaypalOrders: 120,
+  products: 40,
+} as const;
+
+/**
+ * Catalog sized so the planner prefers indexes over seq scans for Listing/Order
+ * hot paths. Keep this out of the demo seed: integration tests truncate after.
+ */
+export async function seedPerformanceCatalog() {
+  const suffix = randomUUID();
+  const customer = await prisma.user.create({
+    data: {
+      name: "Perf Buyer",
+      email: `perf-buyer-${suffix}@test.local`,
+      password: "hash",
+      role: "CUSTOMER",
+    },
+  });
+  const sellerUser = await prisma.user.create({
+    data: {
+      name: "Perf Seller",
+      email: `perf-seller-${suffix}@test.local`,
+      password: "hash",
+      role: "SELLER",
+    },
+  });
+  const seller = await prisma.seller.create({
+    data: {
+      userId: sellerUser.id,
+      storeName: `Perf Store ${suffix}`,
+      isApproved: true,
+      commissionRate: new Prisma.Decimal("0.1"),
+    },
+  });
+
+  await prisma.product.createMany({
+    data: Array.from({ length: PERF_SEED.products }, (_, index) => ({
+      game: "CS2",
+      weapon: index % 2 === 0 ? "AK-47" : "AWP",
+      skinName: `Perf Skin ${index}-${suffix}`,
+      rarity: "Classified",
+      exterior: index % 3 === 0 ? "Factory New" : "Field-Tested",
+      isStattrak: index % 5 === 0,
+    })),
+  });
+  const products = await prisma.product.findMany({ select: { id: true } });
+
+  const listingRows: Prisma.ListingCreateManyInput[] = [
+    ...Array.from({ length: PERF_SEED.activeListings }, (_, index) => ({
+      productId: products[index % products.length].id,
+      sellerId: seller.id,
+      floatValue: new Prisma.Decimal(((index % 90) + 1) / 100),
+      price: new Prisma.Decimal(50 + (index % 400)),
+      status: "ACTIVE",
+    })),
+    ...Array.from({ length: PERF_SEED.reservedListings }, (_, index) => ({
+      productId: products[index % products.length].id,
+      sellerId: seller.id,
+      floatValue: new Prisma.Decimal("0.12"),
+      price: new Prisma.Decimal("120.00"),
+      status: "RESERVED",
+      reservedAt: new Date(Date.now() - 20 * 60 * 1000),
+      reservationExpiresAt: new Date(Date.now() - 5 * 60 * 1000),
+    })),
+    ...Array.from({ length: PERF_SEED.soldListings }, (_, index) => ({
+      productId: products[index % products.length].id,
+      sellerId: seller.id,
+      floatValue: new Prisma.Decimal("0.08"),
+      price: new Prisma.Decimal("200.00"),
+      status: "SOLD",
+      soldAt: new Date(),
+    })),
+  ];
+
+  const chunkSize = 500;
+  for (let offset = 0; offset < listingRows.length; offset += chunkSize) {
+    await prisma.listing.createMany({ data: listingRows.slice(offset, offset + chunkSize) });
+  }
+
+  const stale = new Date(Date.now() - 10 * 60 * 1000);
+  await prisma.order.createMany({
+    data: Array.from({ length: PERF_SEED.pendingPaypalOrders }, (_, index) => ({
+      customerId: customer.id,
+      totalAmount: new Prisma.Decimal("100.00"),
+      status: "PENDING",
+      paymentStatus: "PENDING",
+      paypalOrderId: `PAYPAL-PERF-${suffix}-${index}`,
+      updatedAt: stale,
+    })),
+  });
+
+  await prisma.$executeRaw`ANALYZE "Listing"`;
+  await prisma.$executeRaw`ANALYZE "Order"`;
+  await prisma.$executeRaw`ANALYZE "OrderItem"`;
+  await prisma.$executeRaw`ANALYZE "OrderIdempotencyKey"`;
+  await prisma.$executeRaw`ANALYZE "PaymentWebhookEvent"`;
+
+  return { customer, seller, products };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements roadmap **P1.4** / issue #9: turn performance claims into measured evidence. Stays out of `src/` (P-front).

## Evidence
At 2 500 `ACTIVE` listings on PostgreSQL 16:

- Market `ORDER BY createdAt DESC LIMIT 20` → Index Scan `Listing_status_createdAt_idx` (0.017 ms)
- `COUNT(*)` for pagination `total` → Seq Scan (0.425 ms) — this is the listing-list cost
- Reconciliation pending PayPal orders → Index Scan `Order_paymentStatus_status_updatedAt_idx` (0.034 ms)
- `listingsService.list` p50 2.59 ms / p95 4.27 ms

## Changes
- Replace `Listing(status)` with `Listing(status, createdAt)`
- Replace `Order(paymentStatus)` with `Order(paymentStatus, status, updatedAt)`
- Repeatable harness: `cd server && npm run perf:evidence`
- CI: `performance.evidence.integration.test.ts`
- Docs: `docs/performance.md`, `docs/architecture/scaling-path.md`, ADR 0006

## Not done (on purpose)
No Redis, cache, or queue. Price sort still happens in the browser on the current page; `(status, price)` is not added until the API sorts by price.

## Verification
- `npm run test:unit` → 141 passed
- `npm run test:integration` against isolated `neon_arsenal_test` → 42 passed
- server + client `tsc --noEmit` → passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

