### PR TITLE
[P-front] Q1 — Estados vazios e acessibilidade

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
-import { Component, type ErrorInfo, type ReactNode } from 'react';
-import { Button } from '@/components/ui/button';
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { ErrorState } from "@/components/page-state";
+import { Button } from "@/components/ui/button";
 
 interface Props {
   children: ReactNode;
@@ -19,23 +20,26 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught:', error, errorInfo);
+    console.error("ErrorBoundary caught:", error, errorInfo);
   }
 
   render() {
     if (this.state.hasError && this.state.error) {
       if (this.props.fallback) return this.props.fallback;
       return (
-        <div className="container py-20 text-center">
-          <h1 className="text-2xl font-heading text-foreground mb-2">Algo deu errado</h1>
-          <p className="text-muted-foreground mb-6 max-w-md mx-auto">
-            {this.state.error.message}
-          </p>
-          <Button
-            onClick={() => this.setState({ hasError: false, error: null })}
-          >
-            Tentar novamente
-          </Button>
+        <div className="container py-20">
+          <ErrorState
+            title="Algo deu errado"
+            description={this.state.error.message}
+            action={
+              <Button
+                type="button"
+                onClick={() => this.setState({ hasError: false, error: null })}
+              >
+                Tentar novamente
+              </Button>
+            }
+          />
         </div>
       );
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,11 @@ import { Button } from "@/components/ui/button";
 
 function brandMark() {
   return (
-    <Link to="/" className="flex items-center gap-2.5">
+    <Link
+      to="/"
+      className="flex min-h-11 items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label="Neon Arsenal, página inicial"
+    >
       <span className="h-4 w-4 rounded-sm bg-primary" aria-hidden />
       <span className="text-[15px] font-semibold tracking-tight text-foreground">
         Neon Arsenal
@@ -33,7 +37,7 @@ export function Header() {
   const linkClass = (to: string) => {
     const active =
       to === "/" ? location.pathname === "/" : location.pathname.startsWith(to);
-    return `text-sm transition-colors ${
+    return `inline-flex min-h-11 items-center text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
       active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
     }`;
   };
@@ -48,7 +52,20 @@ export function Header() {
           aria-label="Principal"
         >
           {navLinks.map((item) => (
-            <Link key={item.to} to={item.to} className={linkClass(item.to)}>
+            <Link
+              key={item.to}
+              to={item.to}
+              className={linkClass(item.to)}
+              aria-current={
+                (
+                  item.to === "/"
+                    ? location.pathname === "/"
+                    : location.pathname.startsWith(item.to)
+                )
+                  ? "page"
+                  : undefined
+              }
+            >
               {item.label}
             </Link>
           ))}
@@ -57,7 +74,7 @@ export function Header() {
         <div className="flex items-center gap-1.5">
           <Link
             to="/cart"
-            className="relative rounded-md p-2 text-muted-foreground transition-colors hover:text-foreground"
+            className="relative inline-flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={
               totalItems > 0 ? `Carrinho, ${totalItems} itens` : "Carrinho"
             }
@@ -118,6 +135,15 @@ export function Header() {
               key={item.to}
               to={item.to}
               className={`block rounded-md px-3 py-2.5 text-sm ${linkClass(item.to)}`}
+              aria-current={
+                (
+                  item.to === "/"
+                    ? location.pathname === "/"
+                    : location.pathname.startsWith(item.to)
+                )
+                  ? "page"
+                  : undefined
+              }
               onClick={() => setMenuOpen(false)}
             >
               {item.label}
@@ -126,7 +152,7 @@ export function Header() {
           {isAuthenticated ? (
             <button
               type="button"
-              className="block w-full rounded-md px-3 py-2.5 text-left text-sm text-muted-foreground"
+              className="block min-h-11 w-full rounded-md px-3 py-2.5 text-left text-sm text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               onClick={() => {
                 logout();
                 setMenuOpen(false);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -112,6 +112,7 @@ export function Header() {
             className="md:hidden"
             aria-expanded={menuOpen}
             aria-controls="mobile-nav"
+            aria-haspopup="true"
             onClick={() => setMenuOpen((open) => !open)}
           >
             {menuOpen ? (

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -20,7 +20,7 @@ export function ListingCard({ listing }: { listing: Listing }) {
     <article className="group flex flex-col overflow-hidden rounded-md border border-border bg-card">
       <Link
         to={`/listing/${listing.id}`}
-        className="relative block aspect-[4/3] bg-muted"
+        className="relative block aspect-[4/3] bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <div className="flex h-full items-center justify-center">
           <span className="text-2xl font-semibold tracking-tight text-muted-foreground/70">
@@ -35,7 +35,10 @@ export function ListingCard({ listing }: { listing: Listing }) {
       </Link>
 
       <div className="flex flex-1 flex-col gap-2 p-3">
-        <Link to={`/listing/${listing.id}`}>
+        <Link
+          to={`/listing/${listing.id}`}
+          className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
           <h3 className="line-clamp-2 text-sm font-medium leading-snug text-foreground transition-colors hover:text-primary">
             {productName}
           </h3>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -58,13 +58,15 @@ export function ListingCard({ listing }: { listing: Listing }) {
           <Button
             size="icon"
             variant="outline"
-            className="h-9 w-9"
             onClick={(e) => {
               e.preventDefault();
               addItem(listing);
             }}
             disabled={!isAvailable}
             title={
+              !isAvailable ? "Item não disponível" : "Adicionar ao carrinho"
+            }
+            aria-label={
               !isAvailable ? "Item não disponível" : "Adicionar ao carrinho"
             }
           >

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
-import { PageSkeleton } from "@/components/page-state";
+import { ErrorState, PageSkeleton } from "@/components/page-state";
 import type { Role } from "@/types/api";
 
 interface ProtectedRouteProps {
@@ -29,10 +29,11 @@ export function ProtectedRoute({
     !allowedRoles.includes(user.role)
   ) {
     return (
-      <div className="container py-20 text-center">
-        <p className="text-muted-foreground font-heading text-xl">
-          Acesso negado.
-        </p>
+      <div className="container py-20">
+        <ErrorState
+          title="Acesso negado"
+          description="Esta área exige outra conta ou permissão."
+        />
       </div>
     );
   }

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -40,6 +40,8 @@ describe("Header", () => {
     expect(screen.getByText("Market")).toBeTruthy();
     expect(screen.getByText("Login")).toBeTruthy();
     expect(screen.queryByText("SKINMARKET")).toBeNull();
+    expect(screen.getByLabelText("Carrinho")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Menu" })).toBeTruthy();
   });
 
   it("shows Dashboard for a seller", () => {

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -41,7 +41,10 @@ describe("Header", () => {
     expect(screen.getByText("Login")).toBeTruthy();
     expect(screen.queryByText("SKINMARKET")).toBeNull();
     expect(screen.getByLabelText("Carrinho")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Menu" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Menu" })).toHaveAttribute(
+      "aria-haspopup",
+      "true",
+    );
   });
 
   it("shows Dashboard for a seller", () => {

--- a/src/components/__tests__/page-state.test.tsx
+++ b/src/components/__tests__/page-state.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EmptyState, ErrorState } from "../page-state";
+
+describe("page-state", () => {
+  it("exposes empty content as a status region", () => {
+    render(<EmptyState title="Nenhum listing" description="Crie um item." />);
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText("Nenhum listing")).toBeTruthy();
+  });
+
+  it("exposes errors as an alert", () => {
+    render(
+      <ErrorState title="Erro ao carregar" description="Tente de novo." />,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Erro ao carregar")).toBeTruthy();
+  });
+});

--- a/src/components/page-state.tsx
+++ b/src/components/page-state.tsx
@@ -27,7 +27,7 @@ export function EmptyState({
   action?: Action;
 }) {
   return (
-    <div className="mx-auto max-w-md py-16 text-center">
+    <div className="mx-auto max-w-md py-16 text-center" role="status">
       <h2 className="text-lg font-semibold tracking-tight text-foreground">
         {title}
       </h2>
@@ -49,7 +49,7 @@ export function ErrorState({
   action?: Action;
 }) {
   return (
-    <div className="mx-auto max-w-md py-16 text-center">
+    <div className="mx-auto max-w-md py-16 text-center" role="alert">
       <h2 className="text-lg font-semibold tracking-tight text-foreground">
         {title}
       </h2>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,17 +10,20 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "min-h-11 px-4 py-2",
+        sm: "min-h-11 rounded-md px-3",
+        lg: "h-11 min-h-11 rounded-md px-8",
+        icon: "h-11 w-11 min-h-11 min-w-11",
       },
     },
     defaultVariants: {
@@ -31,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
@@ -39,7 +43,13 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
   },
 );
 Button.displayName = "Button";

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -42,22 +42,40 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+      <DialogPrimitive.Close className="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">Fechar</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
 );
 DialogHeader.displayName = "DialogHeader";
 
-const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
 );
 DialogFooter.displayName = "DialogFooter";
 
@@ -67,7 +85,10 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
     {...props}
   />
 ));
@@ -77,7 +98,11 @@ const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-11 min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-11 min-h-11 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
@@ -36,7 +36,10 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
@@ -50,13 +53,17 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
 ));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
@@ -94,7 +101,11 @@ const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label ref={ref} className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)} {...props} />
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
@@ -125,7 +136,11 @@ const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
 ));
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -116,7 +116,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 focus:bg-accent focus:text-accent-foreground",
+      "relative flex min-h-11 w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 focus:bg-accent focus:text-accent-foreground",
       className,
     )}
     {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -48,32 +48,56 @@ const sheetVariants = cva(
 );
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
-const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
-  ({ side = "right", className, children, ...props }, ref) => (
-    <SheetPortal>
-      <SheetOverlay />
-      <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-        {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
-      </SheetPrimitive.Content>
-    </SheetPortal>
-  ),
-);
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Fechar</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
 );
 SheetHeader.displayName = "SheetHeader";
 
-const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
 );
 SheetFooter.displayName = "SheetFooter";
 
@@ -81,7 +105,11 @@ const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-foreground", className)} {...props} />
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
 ));
 SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
@@ -89,7 +117,11 @@ const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <SheetPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
 ));
 SheetDescription.displayName = SheetPrimitive.Description.displayName;
 

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -56,11 +57,12 @@ function NavItems({
             key={item.href}
             to={item.href}
             onClick={onNavigate}
-            className={`flex min-h-11 items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors ${
+            className={`flex min-h-11 items-center gap-3 rounded-md px-3 py-2.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
               active
                 ? "bg-secondary text-foreground"
                 : "text-muted-foreground hover:bg-muted hover:text-foreground"
             }`}
+            aria-current={active ? "page" : undefined}
           >
             <item.icon className="h-4 w-4 shrink-0" />
             {item.label}
@@ -99,6 +101,7 @@ export default function DashboardLayout() {
               <SheetContent side="left" className="w-72">
                 <SheetHeader>
                   <SheetTitle>{isAdmin ? "Admin" : "Dashboard"}</SheetTitle>
+                  <SheetDescription>Navegação do painel</SheetDescription>
                 </SheetHeader>
                 <div className="mt-4">
                   <NavItems

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -71,7 +71,7 @@ export default function CartPage() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-10 w-10 text-muted-foreground hover:text-destructive"
+                  className="text-muted-foreground hover:text-destructive"
                   onClick={() => removeItem(listing.id)}
                   aria-label={`Remover ${name}`}
                 >

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -19,6 +19,7 @@ export default function ListingDetail() {
     isLoading,
     isError,
     error,
+    refetch,
   } = useQuery({
     queryKey: ["listing", id],
     queryFn: () => getListing(id!),
@@ -83,9 +84,14 @@ export default function ListingDetail() {
               : "Este item não está disponível."
           }
           action={
-            <Button asChild>
-              <Link to="/products">Voltar ao Market</Link>
-            </Button>
+            <div className="flex justify-center gap-2">
+              <Button type="button" variant="outline" onClick={() => refetch()}>
+                Tentar novamente
+              </Button>
+              <Button asChild>
+                <Link to="/products">Voltar ao Market</Link>
+              </Button>
+            </div>
           }
         />
       </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -36,7 +36,11 @@ export default function Login() {
     <div className="flex min-h-screen flex-col bg-background">
       <div className="flex flex-1 items-center justify-center px-4 py-12">
         <div className="w-full max-w-sm">
-          <Link to="/" className="mb-8 flex items-center gap-2.5">
+          <Link
+            to="/"
+            className="mb-8 flex min-h-11 items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Neon Arsenal, página inicial"
+          >
             <span className="h-4 w-4 rounded-sm bg-primary" aria-hidden />
             <span className="text-[15px] font-semibold tracking-tight text-foreground">
               Neon Arsenal
@@ -61,6 +65,7 @@ export default function Login() {
                 required
                 autoComplete="email"
                 aria-invalid={error ? true : undefined}
+                aria-describedby={error ? "login-error" : undefined}
               />
             </div>
             <div>
@@ -76,6 +81,7 @@ export default function Login() {
                   required
                   autoComplete="current-password"
                   aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? "login-error" : undefined}
                 />
                 <button
                   type="button"
@@ -92,7 +98,11 @@ export default function Login() {
               </div>
             </div>
             {error ? (
-              <p className="text-sm text-destructive" role="alert">
+              <p
+                id="login-error"
+                className="text-sm text-destructive"
+                role="alert"
+              >
                 {error}
               </p>
             ) : null}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -79,7 +79,7 @@ export default function Login() {
                 />
                 <button
                   type="button"
-                  className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-muted-foreground hover:text-foreground"
+                  className="absolute right-0 top-0 flex h-11 w-11 items-center justify-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   onClick={() => setShowPassword((open) => !open)}
                   aria-label={showPassword ? "Ocultar senha" : "Mostrar senha"}
                 >

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,24 +1,19 @@
-import { useLocation } from "react-router-dom";
-import { useEffect } from "react";
+import { Link } from "react-router-dom";
+import { EmptyState } from "@/components/page-state";
+import { Button } from "@/components/ui/button";
 
-const NotFound = () => {
-  const location = useLocation();
-
-  useEffect(() => {
-    console.error("404 Error: User attempted to access non-existent route:", location.pathname);
-  }, [location.pathname]);
-
+export default function NotFound() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-muted-foreground">Oops! Page not found</p>
-        <a href="/" className="text-primary underline hover:text-primary/90">
-          Return to Home
-        </a>
-      </div>
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <EmptyState
+        title="Página não encontrada"
+        description="Esse endereço não existe neste site."
+        action={
+          <Button asChild>
+            <Link to="/">Voltar ao início</Link>
+          </Button>
+        }
+      />
     </div>
   );
-};
-
-export default NotFound;
+}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -6,6 +6,7 @@ import { EmptyState, ErrorState } from "@/components/page-state";
 import { listListings } from "@/api/listings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const EXTERIORS = [
@@ -41,7 +42,7 @@ function Chip({
       type="button"
       variant={active ? "default" : "outline"}
       size="sm"
-      className="h-8"
+      aria-pressed={active}
       onClick={onClick}
     >
       {children}
@@ -57,7 +58,7 @@ export default function Products() {
   const [minPrice, setMinPrice] = useState("");
   const [maxPrice, setMaxPrice] = useState("");
 
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: [
       "listings",
       { page, exterior, isStattrak, sort, minPrice, maxPrice },
@@ -109,8 +110,8 @@ export default function Products() {
       </div>
 
       <div className="mb-8 space-y-4 border-b border-border pb-6">
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">Exterior</p>
+        <fieldset className="space-y-1.5">
+          <legend className="text-xs text-muted-foreground">Exterior</legend>
           <div className="flex flex-wrap gap-1.5">
             {EXTERIORS.map((ext) => (
               <Chip
@@ -125,11 +126,11 @@ export default function Products() {
               </Chip>
             ))}
           </div>
-        </div>
+        </fieldset>
 
         <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap">
-          <div className="space-y-1.5">
-            <p className="text-xs text-muted-foreground">StatTrak™</p>
+          <fieldset className="space-y-1.5">
+            <legend className="text-xs text-muted-foreground">StatTrak™</legend>
             <div className="flex flex-wrap gap-1.5">
               {(
                 [
@@ -150,43 +151,46 @@ export default function Products() {
                 </Chip>
               ))}
             </div>
-          </div>
+          </fieldset>
 
-          <div className="space-y-1.5">
-            <p className="text-xs text-muted-foreground">
+          <fieldset className="space-y-1.5">
+            <legend className="text-xs text-muted-foreground">
               Faixa de Preço (USD)
-            </p>
+            </legend>
             <div className="flex items-center gap-2">
+              <Label htmlFor="minPrice" className="sr-only">
+                Preço mínimo
+              </Label>
               <Input
+                id="minPrice"
                 type="number"
                 placeholder="Mín"
                 value={minPrice}
                 onChange={(e) => setMinPrice(e.target.value)}
-                className="h-8 w-24"
+                className="w-24"
               />
               <span className="text-sm text-muted-foreground">–</span>
+              <Label htmlFor="maxPrice" className="sr-only">
+                Preço máximo
+              </Label>
               <Input
+                id="maxPrice"
                 type="number"
                 placeholder="Máx"
                 value={maxPrice}
                 onChange={(e) => setMaxPrice(e.target.value)}
-                className="h-8 w-24"
+                className="w-24"
               />
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-8"
-                onClick={() => setPage(1)}
-              >
+              <Button size="sm" variant="outline" onClick={() => setPage(1)}>
                 <Filter className="mr-1 h-3 w-3" />
                 Filtrar
               </Button>
             </div>
-          </div>
+          </fieldset>
         </div>
 
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">Ordenar</p>
+        <fieldset className="space-y-1.5">
+          <legend className="text-xs text-muted-foreground">Ordenar</legend>
           <div className="flex flex-wrap gap-1.5">
             {SORTS.map(({ value, label }) => (
               <Chip
@@ -198,7 +202,7 @@ export default function Products() {
               </Chip>
             ))}
           </div>
-        </div>
+        </fieldset>
       </div>
 
       {isLoading && (
@@ -220,6 +224,11 @@ export default function Products() {
             error instanceof Error
               ? error.message
               : "Tente novamente em instantes."
+          }
+          action={
+            <Button type="button" variant="outline" onClick={() => refetch()}>
+              Tentar novamente
+            </Button>
           }
         />
       )}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -62,7 +62,11 @@ export default function Register() {
     <div className="flex min-h-screen flex-col bg-background">
       <div className="flex flex-1 items-center justify-center px-4 py-12">
         <div className="w-full max-w-sm">
-          <Link to="/" className="mb-8 flex items-center gap-2.5">
+          <Link
+            to="/"
+            className="mb-8 flex min-h-11 items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Neon Arsenal, página inicial"
+          >
             <span className="h-4 w-4 rounded-sm bg-primary" aria-hidden />
             <span className="text-[15px] font-semibold tracking-tight text-foreground">
               Neon Arsenal
@@ -92,6 +96,7 @@ export default function Register() {
                   className="mt-1.5"
                   required
                   autoComplete="name"
+                  aria-describedby={error ? "register-error" : undefined}
                 />
               </div>
               <div>
@@ -105,6 +110,7 @@ export default function Register() {
                   className="mt-1.5"
                   required
                   autoComplete="email"
+                  aria-describedby={error ? "register-error" : undefined}
                 />
               </div>
               <div>
@@ -120,6 +126,7 @@ export default function Register() {
                     required
                     minLength={6}
                     autoComplete="new-password"
+                    aria-describedby={error ? "register-error" : undefined}
                   />
                   <button
                     type="button"
@@ -192,7 +199,11 @@ export default function Register() {
                 </div>
               ) : null}
               {error ? (
-                <p className="text-sm text-destructive" role="alert">
+                <p
+                  id="register-error"
+                  className="text-sm text-destructive"
+                  role="alert"
+                >
                   {error}
                 </p>
               ) : null}
@@ -224,10 +235,15 @@ export default function Register() {
                   required
                   autoComplete="one-time-code"
                   aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? "register-code-error" : undefined}
                 />
               </div>
               {error ? (
-                <p className="text-sm text-destructive" role="alert">
+                <p
+                  id="register-code-error"
+                  className="text-sm text-destructive"
+                  role="alert"
+                >
                   {error}
                 </p>
               ) : null}

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -123,7 +123,7 @@ export default function Register() {
                   />
                   <button
                     type="button"
-                    className="absolute right-0 top-0 flex h-10 w-10 items-center justify-center text-muted-foreground hover:text-foreground"
+                    className="absolute right-0 top-0 flex h-11 w-11 items-center justify-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     onClick={() => setShowPassword((open) => !open)}
                     aria-label={
                       showPassword ? "Ocultar senha" : "Mostrar senha"
@@ -141,7 +141,7 @@ export default function Register() {
                 <legend className="text-sm font-medium">Tipo de conta</legend>
                 <div className="mt-2 flex gap-2">
                   <label
-                    className={`flex h-10 flex-1 cursor-pointer items-center justify-center rounded-md border text-sm ${
+                    className={`flex min-h-11 flex-1 cursor-pointer items-center justify-center rounded-md border text-sm ${
                       role === "CUSTOMER"
                         ? "border-primary bg-accent text-accent-foreground"
                         : "border-border text-muted-foreground hover:text-foreground"
@@ -157,7 +157,7 @@ export default function Register() {
                     Comprador
                   </label>
                   <label
-                    className={`flex h-10 flex-1 cursor-pointer items-center justify-center rounded-md border text-sm ${
+                    className={`flex min-h-11 flex-1 cursor-pointer items-center justify-center rounded-md border text-sm ${
                       role === "SELLER"
                         ? "border-primary bg-accent text-accent-foreground"
                         : "border-border text-muted-foreground hover:text-foreground"

--- a/src/pages/__tests__/Login.test.tsx
+++ b/src/pages/__tests__/Login.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Login from "../Login";
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    login: vi.fn(),
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+describe("Login", () => {
+  it("labels fields and keeps the submit control disabled-ready", () => {
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText("E-mail")).toBeTruthy();
+    expect(screen.getByLabelText("Senha")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Entrar" })).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Neon Arsenal, página inicial" }),
+    ).toHaveAttribute("href", "/");
+  });
+});

--- a/src/pages/__tests__/NotFound.test.tsx
+++ b/src/pages/__tests__/NotFound.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import NotFound from "../NotFound";
+
+describe("NotFound", () => {
+  it("shows a Portuguese empty state without leftover marketplace chrome", () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Página não encontrada")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Voltar ao início" }),
+    ).toHaveAttribute("href", "/");
+    expect(screen.queryByText(/SKINMARKET/i)).toBeNull();
+    expect(screen.queryByText(/Page not found/i)).toBeNull();
+  });
+});

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -29,9 +29,10 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from "@/components/ui/dialog";
 import {
   AlertDialog,
@@ -45,6 +46,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { EmptyState, ErrorState } from "@/components/page-state";
 import { useToast } from "@/hooks/use-toast";
 import {
   Select,
@@ -114,21 +116,21 @@ export default function SellerListings() {
     }
   };
 
+  const reload = async () => {
+    setLoading(true);
+    setError(null);
+    const sellerId = await loadSeller();
+    if (!sellerId) {
+      setLoading(false);
+      return;
+    }
+    await Promise.all([loadListings(), loadProducts()]);
+  };
+
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      setError(null);
-      const sellerId = await loadSeller();
-      if (cancelled || !sellerId) {
-        if (!sellerId) setLoading(false);
-        return;
-      }
-      await Promise.all([loadListings(), loadProducts()]);
-    })();
-    return () => {
-      cancelled = true;
-    };
+    void reload();
+    // Mount + explicit retry via reload(); load helpers close over setters only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const openCreate = () => {
@@ -271,12 +273,17 @@ export default function SellerListings() {
     }
   };
 
-  if (error && !seller) {
+  if (error) {
     return (
-      <div className="space-y-4">
-        <h1 className="text-2xl font-semibold tracking-tight">Meus listings</h1>
-        <p className="text-sm text-destructive">{error}</p>
-      </div>
+      <ErrorState
+        title="Erro ao carregar listings"
+        description={error}
+        action={
+          <Button type="button" variant="outline" onClick={() => void reload()}>
+            Tentar novamente
+          </Button>
+        }
+      />
     );
   }
 
@@ -305,8 +312,18 @@ export default function SellerListings() {
         >
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
+      ) : listings.length === 0 ? (
+        <EmptyState
+          title="Nenhum listing"
+          description="Crie um item único a partir do catálogo de produtos."
+          action={
+            <Button onClick={openCreate} disabled={!seller}>
+              Novo Listing
+            </Button>
+          }
+        />
       ) : (
-        <div className="rounded-lg border border-border overflow-hidden">
+        <div className="overflow-hidden rounded-lg border border-border">
           <Table>
             <TableHeader>
               <TableRow>
@@ -318,89 +335,80 @@ export default function SellerListings() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {listings.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={5}
-                    className="text-center text-muted-foreground py-8"
-                  >
-                    Nenhum listing. Clique em Novo Listing para criar.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                listings.map((l) => {
-                  const productName = `${l.product.weapon} | ${l.product.skinName} (${l.product.exterior})`;
-                  return (
-                    <TableRow key={l.id}>
-                      <TableCell className="font-medium">
-                        {productName}
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell text-muted-foreground">
-                        {Number(l.floatValue).toFixed(8)}
-                      </TableCell>
-                      <TableCell className="tabular-nums font-medium">
-                        ${Number(l.price).toFixed(2)}
-                      </TableCell>
-                      <TableCell>
-                        <span
-                          className={`text-xs font-medium px-2 py-1 rounded ${
-                            l.status === "ACTIVE"
-                              ? "bg-primary/10 text-primary"
-                              : l.status === "SOLD"
-                                ? "bg-green-500/10 text-green-500"
-                                : "bg-muted text-muted-foreground"
-                          }`}
-                        >
-                          {l.status}
-                        </span>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex items-center justify-end gap-1">
-                          {l.status === "ACTIVE" && (
-                            <>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => openPriceEdit(l)}
-                                title="Atualizar preço"
-                              >
-                                <DollarSign className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={() => openEdit(l)}
-                                title="Editar"
-                              >
-                                <Pencil className="h-4 w-4" />
-                              </Button>
-                            </>
-                          )}
-                          {l.status === "ACTIVE" && (
+              {listings.map((l) => {
+                const productName = `${l.product.weapon} | ${l.product.skinName} (${l.product.exterior})`;
+                return (
+                  <TableRow key={l.id}>
+                    <TableCell className="font-medium">{productName}</TableCell>
+                    <TableCell className="hidden md:table-cell text-muted-foreground">
+                      {Number(l.floatValue).toFixed(8)}
+                    </TableCell>
+                    <TableCell className="tabular-nums font-medium">
+                      ${Number(l.price).toFixed(2)}
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={`text-xs font-medium px-2 py-1 rounded ${
+                          l.status === "ACTIVE"
+                            ? "bg-primary/10 text-primary"
+                            : l.status === "SOLD"
+                              ? "bg-green-500/10 text-green-500"
+                              : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {l.status}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        {l.status === "ACTIVE" && (
+                          <>
                             <Button
                               variant="ghost"
                               size="icon"
-                              onClick={() => handleCancel(l)}
-                              title="Cancelar listing"
+                              onClick={() => openPriceEdit(l)}
+                              title="Atualizar preço"
+                              aria-label="Atualizar preço"
                             >
-                              <EyeOff className="h-4 w-4" />
+                              <DollarSign className="h-4 w-4" />
                             </Button>
-                          )}
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => openEdit(l)}
+                              title="Editar"
+                              aria-label="Editar"
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
+                          </>
+                        )}
+                        {l.status === "ACTIVE" && (
                           <Button
                             variant="ghost"
                             size="icon"
-                            onClick={() => setDeleteTarget(l)}
-                            title="Excluir"
-                            className="text-destructive hover:text-destructive"
+                            onClick={() => handleCancel(l)}
+                            title="Cancelar listing"
+                            aria-label="Cancelar listing"
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <EyeOff className="h-4 w-4" />
                           </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteTarget(l)}
+                          title="Excluir"
+                          aria-label="Excluir"
+                          className="text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </div>
@@ -412,10 +420,17 @@ export default function SellerListings() {
             <DialogTitle>
               {editingListing ? "Editar listing" : "Novo listing"}
             </DialogTitle>
+            <DialogDescription>
+              {editingListing
+                ? "Atualize os dados deste item único."
+                : "Cadastre um item único a partir do catálogo."}
+            </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
-              <Label htmlFor="productId">Produto</Label>
+              <Label htmlFor="productId" id="productId-label">
+                Produto
+              </Label>
               <Select
                 value={form.productId}
                 onValueChange={(value) =>
@@ -423,7 +438,7 @@ export default function SellerListings() {
                 }
                 disabled={!!editingListing}
               >
-                <SelectTrigger>
+                <SelectTrigger id="productId" aria-labelledby="productId-label">
                   <SelectValue placeholder="Selecione um produto" />
                 </SelectTrigger>
                 <SelectContent>
@@ -483,14 +498,16 @@ export default function SellerListings() {
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="currency">Moeda</Label>
+                <Label htmlFor="currency" id="currency-label">
+                  Moeda
+                </Label>
                 <Select
                   value={form.currency}
                   onValueChange={(value) =>
                     setForm((f) => ({ ...f, currency: value }))
                   }
                 >
-                  <SelectTrigger>
+                  <SelectTrigger id="currency" aria-labelledby="currency-label">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -549,6 +566,9 @@ export default function SellerListings() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Atualizar Preço</DialogTitle>
+            <DialogDescription>
+              Informe o novo preço deste listing.
+            </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -93,5 +93,37 @@ describe("SellerListings", () => {
     expect(screen.getByTitle("Editar")).toBeTruthy();
     expect(screen.getByTitle("Atualizar preço")).toBeTruthy();
     expect(screen.getByTitle("Cancelar listing")).toBeTruthy();
+    expect(screen.getByLabelText("Editar")).toBeTruthy();
+  });
+
+  it("shows an empty state when the seller has no listings", async () => {
+    getSellerListings.mockResolvedValue({ items: [], total: 0 });
+
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Nenhum listing")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "Novo Listing" }).length).toBe(
+      2,
+    );
+  });
+
+  it("shows an error state that can be retried", async () => {
+    getSellerMe.mockRejectedValue(new Error("sessão expirada"));
+
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Erro ao carregar listings")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Tentar novamente" }),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Empty states and accessibility on existing routes only. No new features, routes, or `server/` changes.

## Acceptance
- Every existing route has loading, empty, error, and disabled states where they apply.
- Focus rings, labels, contrast, 44px mobile targets, and dialog/menu aria.
- No new product functionality.

## Route states
- Storefront `/`, `/products`, `/listing/:id`: loading, empty/not-found, retry.
- `/cart`, `/checkout`: empty cart; checkout also gates non-buyers and disables PayPal while submitting.
- `/login`, `/register`: labeled fields, error alerts, disabled submit.
- Seller and admin dashboards: loading, empty, retry, and mutation buttons disabled while pending.
- `*`: Portuguese 404 empty state.

## Accessibility
- Shared controls use a 44px minimum hit target (buttons, inputs, selects, select items).
- Dialog/sheet close is **Fechar**; listing dialogs have descriptions; header menu has `aria-expanded` / `aria-controls` / `aria-haspopup`.
- Login/register errors are tied to fields via `aria-describedby`.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test` (61 passing)
- Browser walkthrough (guest): home, market, empty cart, login labels, 404

[empty_states_and_accessibility_walkthrough.mp4](https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_states_and_accessibility_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

