### PR TITLE
[P-front] Q2 — Testes de contrato da UI

### DIFF
--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -192,7 +192,7 @@ describe("ListingCard", () => {
 
   it("shows pattern when present and hides it when null", () => {
     const { rerender } = renderCard(makeListing({ pattern: 412 }));
-    expect(screen.getByText("412")).toBeInTheDocument();
+    expect(screen.getByText("Pattern: 412")).toBeInTheDocument();
 
     rerender(
       <MemoryRouter>
@@ -202,7 +202,7 @@ describe("ListingCard", () => {
         </CartProvider>
       </MemoryRouter>,
     );
-    expect(screen.queryByText("412")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Pattern:/)).not.toBeInTheDocument();
   });
 
   it("links both the image and the title to /listing/:id", () => {

--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -1,52 +1,50 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ListingCard } from "../ProductCard";
-import { CartProvider, useCart } from "@/contexts/CartContext";
+import { CartProvider, useCart } from "../../contexts/CartContext";
 import type { Listing } from "@/types/api";
 
-// Mock framer-motion to avoid animation issues
-vi.mock("framer-motion", () => ({
-  motion: {
-    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => (
-      <div {...props}>{children}</div>
-    ),
-  },
-}));
-
-function makeListing(overrides: Partial<Record<string, unknown>> = {}): Listing {
+function makeListing(overrides: Partial<Listing> = {}): Listing {
   return {
     id: "listing-1",
     productId: "prod-1",
     sellerId: "seller-1",
-    floatValue: 0.14501234,
-    price: 149.99,
+    price: 299.5,
     currency: "USD",
     status: "ACTIVE",
+    floatValue: 0.12345678,
+    pattern: 412,
     tradeLockUntil: null,
     steamAssetId: null,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
     product: {
       id: "prod-1",
       game: "CS2",
       weapon: "AK-47",
       skinName: "Redline",
       rarity: "Classified",
+      collection: "The Phoenix Collection",
       exterior: "Field-Tested",
-      imageUrl: null,
       isStattrak: false,
       isSouvenir: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      imageUrl: "https://example.com/ak.png",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
     },
     seller: {
       id: "seller-1",
-      storeName: "Store Alpha",
-      user: { name: "Bruno", id: "user-1" },
+      storeName: "Neon Store",
+      user: { id: "user-1", name: "Alice" },
     },
     ...overrides,
-  } as unknown as Listing;
+  };
+}
+
+function CartProbe() {
+  const { totalItems } = useCart();
+  return <span data-testid="cart-count">{totalItems}</span>;
 }
 
 function renderCard(listing: Listing) {
@@ -54,119 +52,171 @@ function renderCard(listing: Listing) {
     <MemoryRouter>
       <CartProvider>
         <ListingCard listing={listing} />
+        <CartProbe />
       </CartProvider>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 }
 
+function addButton() {
+  return screen.getByRole("button", {
+    name: /adicionar ao carrinho|item não disponível/i,
+  });
+}
+
 describe("ListingCard", () => {
-  describe("product name display", () => {
-    it("renders weapon | skinName (exterior) format", () => {
-      renderCard(makeListing());
-      const elements = screen.getAllByText(/AK-47 \| Redline \(Field-Tested\)/);
-      expect(elements.length).toBeGreaterThan(0);
-    });
-
-    it("shows StatTrak™ badge for StatTrak items", () => {
-      renderCard(makeListing({ product: { ...makeListing().product, isStattrak: true } }));
-      expect(screen.getByText("StatTrak™")).toBeTruthy();
-    });
-
-    it("does not show StatTrak badge for non-StatTrak items", () => {
-      renderCard(makeListing());
-      expect(screen.queryByText("StatTrak™")).toBeNull();
-    });
+  it("renders weapon | skin (exterior) as the display name", () => {
+    renderCard(makeListing());
+    expect(
+      screen.getByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeInTheDocument();
   });
 
-  describe("price display", () => {
-    it("renders formatted price", () => {
-      renderCard(makeListing({ price: 299.5 }));
-      expect(screen.getByText("$299.50")).toBeTruthy();
-    });
+  it("shows StatTrak badge only when product.isStattrak is true", () => {
+    const { rerender } = renderCard(makeListing());
+    expect(screen.queryByText("StatTrak™")).not.toBeInTheDocument();
 
-    it("handles integer price", () => {
-      renderCard(makeListing({ price: 100 }));
-      expect(screen.getByText("$100.00")).toBeTruthy();
-    });
+    rerender(
+      <MemoryRouter>
+        <CartProvider>
+          <ListingCard
+            listing={makeListing({
+              product: {
+                ...makeListing().product,
+                isStattrak: true,
+              },
+            })}
+          />
+          <CartProbe />
+        </CartProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("StatTrak™")).toBeInTheDocument();
   });
 
-  describe("float value display", () => {
-    it("renders float value with 8 decimal places", () => {
-      renderCard(makeListing({ floatValue: 0.14501234 }));
-      expect(screen.getByText(/Float: 0\.14501234/)).toBeTruthy();
-    });
+  it("formats the listing price with two decimals and a $ prefix", () => {
+    renderCard(makeListing({ price: 299.5 }));
+    expect(screen.getByText("$299.50")).toBeInTheDocument();
   });
 
-  describe("seller info", () => {
-    it("renders seller name", () => {
-      renderCard(makeListing());
-      expect(screen.getByText("Bruno")).toBeTruthy();
-    });
-
-    it("falls back to storeName when user name not available", () => {
-      renderCard(makeListing({ seller: { id: "seller-1", storeName: "CS Skins Shop" } }));
-      expect(screen.getByText("CS Skins Shop")).toBeTruthy();
-    });
+  it("formats whole-dollar prices with two decimals", () => {
+    renderCard(makeListing({ price: 100 }));
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
   });
 
-  describe("add to cart button", () => {
-    it("is enabled for ACTIVE listings without trade lock", () => {
-      renderCard(makeListing());
-      const btn = screen.getByTitle("Adicionar ao carrinho");
-      expect((btn as HTMLButtonElement).disabled).toBe(false);
-    });
-
-    it("is disabled for non-ACTIVE listings", () => {
-      renderCard(makeListing({ status: "SOLD" }));
-      const btn = screen.getByTitle("Item não disponível");
-      expect((btn as HTMLButtonElement).disabled).toBe(true);
-    });
-
-    it("is disabled for trade-locked listings", () => {
-      const futureDate = new Date(Date.now() + 86400000).toISOString();
-      renderCard(makeListing({ tradeLockUntil: futureDate }));
-      const btn = screen.getByTitle("Item não disponível");
-      expect((btn as HTMLButtonElement).disabled).toBe(true);
-    });
-
-    it("adds listing to cart when clicked", () => {
-      const CartObserver = () => {
-        const { totalItems } = useCart();
-        return <span data-testid="cart-count">{totalItems}</span>;
-      };
-
-      render(
-        <MemoryRouter>
-          <CartProvider>
-            <ListingCard listing={makeListing()} />
-            <CartObserver />
-          </CartProvider>
-        </MemoryRouter>
-      );
-
-      expect(screen.getByTestId("cart-count").textContent).toBe("0");
-      fireEvent.click(screen.getByTitle("Adicionar ao carrinho"));
-      expect(screen.getByTestId("cart-count").textContent).toBe("1");
-    });
+  it("formats string prices through Number() with two decimals", () => {
+    renderCard(makeListing({ price: "49.9" as unknown as number }));
+    expect(screen.getByText("$49.90")).toBeInTheDocument();
   });
 
-  describe("pattern display", () => {
-    it("shows pattern when present", () => {
-      renderCard(makeListing({ pattern: 661 }));
-      expect(screen.getByText("Pattern: 661")).toBeTruthy();
-    });
-
-    it("does not show pattern when null/undefined", () => {
-      renderCard(makeListing({ pattern: null }));
-      expect(screen.queryByText(/Pattern:/)).toBeNull();
-    });
+  it("shows float with 8 decimal places", () => {
+    renderCard(makeListing({ floatValue: 0.12345678 }));
+    expect(screen.getByText(/0\.12345678/)).toBeInTheDocument();
   });
 
-  describe("navigation", () => {
-    it("links to /listing/:id", () => {
-      renderCard(makeListing({ id: "abc-123" }));
-      const links = screen.getAllByRole("link");
-      expect(links[0].getAttribute("href")).toBe("/listing/abc-123");
-    });
+  it("shows seller.user.name when present", () => {
+    renderCard(makeListing());
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("falls back to seller.storeName when user name is missing", () => {
+    renderCard(
+      makeListing({
+        seller: {
+          id: "seller-1",
+          storeName: "Backup Store",
+        },
+      }),
+    );
+    expect(screen.getByText("Backup Store")).toBeInTheDocument();
+  });
+
+  it("enables add-to-cart when status is ACTIVE and there is no trade lock", () => {
+    renderCard(makeListing({ status: "ACTIVE", tradeLockUntil: null }));
+    const button = addButton();
+    expect(button).toBeEnabled();
+    expect(button).toHaveAttribute("title", "Adicionar ao carrinho");
+    expect(button).toHaveAttribute("aria-label", "Adicionar ao carrinho");
+  });
+
+  it("enables add-to-cart when trade lock has already expired", () => {
+    renderCard(
+      makeListing({
+        status: "ACTIVE",
+        tradeLockUntil: "2020-01-01T00:00:00.000Z",
+      }),
+    );
+    expect(addButton()).toBeEnabled();
+    expect(addButton()).toHaveAttribute("title", "Adicionar ao carrinho");
+  });
+
+  it("disables add-to-cart when status is SOLD", () => {
+    renderCard(makeListing({ status: "SOLD" }));
+    const button = addButton();
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "Item não disponível");
+    expect(button).toHaveAttribute("aria-label", "Item não disponível");
+  });
+
+  it("disables add-to-cart when status is RESERVED", () => {
+    renderCard(makeListing({ status: "RESERVED" }));
+    expect(addButton()).toBeDisabled();
+    expect(addButton()).toHaveAttribute("title", "Item não disponível");
+  });
+
+  it("disables add-to-cart when status is CANCELED", () => {
+    renderCard(makeListing({ status: "CANCELED" }));
+    expect(addButton()).toBeDisabled();
+    expect(addButton()).toHaveAttribute("title", "Item não disponível");
+  });
+
+  it("disables add-to-cart when tradeLockUntil is in the future", () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    renderCard(makeListing({ tradeLockUntil: future }));
+    expect(addButton()).toBeDisabled();
+    expect(addButton()).toHaveAttribute("title", "Item não disponível");
+  });
+
+  it("does not add a SOLD listing when the disabled button is activated", () => {
+    renderCard(makeListing({ status: "SOLD" }));
+    fireEvent.click(addButton());
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
+  });
+
+  it("adds the listing to the cart when the enabled button is clicked", () => {
+    renderCard(makeListing({ status: "ACTIVE" }));
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
+    fireEvent.click(addButton());
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+  });
+
+  it("shows pattern when present and hides it when null", () => {
+    const { rerender } = renderCard(makeListing({ pattern: 412 }));
+    expect(screen.getByText("412")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <CartProvider>
+          <ListingCard listing={makeListing({ pattern: null })} />
+          <CartProbe />
+        </CartProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText("412")).not.toBeInTheDocument();
+  });
+
+  it("links both the image and the title to /listing/:id", () => {
+    renderCard(makeListing({ id: "listing-abc" }));
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link).toHaveAttribute("href", "/listing/listing-abc");
+    }
+  });
+
+  it("does not leak SKINMARKET or CS2 Skin Marketplace copy", () => {
+    renderCard(makeListing());
+    expect(screen.queryByText(/SKINMARKET/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/CS2 Skin Marketplace/i)).not.toBeInTheDocument();
   });
 });

--- a/src/contexts/__tests__/CartContext.test.tsx
+++ b/src/contexts/__tests__/CartContext.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { CartProvider, useCart } from "../CartContext";
 import type { Listing } from "@/types/api";
 
@@ -11,7 +11,7 @@ function makeListing(overrides: Partial<Listing> = {}): Listing {
     price: 150,
     currency: "USD",
     status: "ACTIVE",
-    floatValue: 0.1,
+    floatValue: 0.15,
     pattern: null,
     tradeLockUntil: null,
     steamAssetId: null,
@@ -20,209 +20,267 @@ function makeListing(overrides: Partial<Listing> = {}): Listing {
     product: {
       id: "prod-1",
       game: "CS2",
-      weapon: "AWP",
-      skinName: "Asiimov",
-      rarity: "Covert",
-      collection: "The Operation Phoenix Collection",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
       exterior: "Field-Tested",
       isStattrak: false,
       isSouvenir: false,
-      imageUrl: "https://example.com/awp.png",
+      imageUrl: null,
       createdAt: "2024-01-01T00:00:00.000Z",
       updatedAt: "2024-01-01T00:00:00.000Z",
     },
-    seller: {
-      id: "seller-1",
-      storeName: "Sniper Shop",
-    },
+    seller: { id: "seller-1", storeName: "Store Alpha" },
     ...overrides,
   };
 }
 
-function wrapper({ children }: { children: React.ReactNode }) {
-  return <CartProvider>{children}</CartProvider>;
+function CartConsumer() {
+  const { items, addItem, removeItem, clearCart, totalItems, totalPrice } =
+    useCart();
+  const futureLock = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  return (
+    <div>
+      <span data-testid="count">{totalItems}</span>
+      <span data-testid="price">{totalPrice.toFixed(2)}</span>
+      <ul>
+        {items.map((item) => (
+          <li key={item.listing.id} data-testid={`item-${item.listing.id}`}>
+            {item.listing.id}
+          </li>
+        ))}
+      </ul>
+      <button
+        data-testid="add-ak"
+        onClick={() => addItem(makeListing({ id: "listing-ak", price: 150 }))}
+      >
+        Add AK
+      </button>
+      <button
+        data-testid="add-m4"
+        onClick={() => addItem(makeListing({ id: "listing-m4", price: 200 }))}
+      >
+        Add M4
+      </button>
+      <button
+        data-testid="add-sold"
+        onClick={() =>
+          addItem(
+            makeListing({ id: "listing-sold", price: 50, status: "SOLD" }),
+          )
+        }
+      >
+        Add Sold
+      </button>
+      <button
+        data-testid="add-reserved"
+        onClick={() =>
+          addItem(makeListing({ id: "listing-reserved", status: "RESERVED" }))
+        }
+      >
+        Add Reserved
+      </button>
+      <button
+        data-testid="add-canceled"
+        onClick={() =>
+          addItem(makeListing({ id: "listing-canceled", status: "CANCELED" }))
+        }
+      >
+        Add Canceled
+      </button>
+      <button
+        data-testid="add-locked"
+        onClick={() =>
+          addItem(
+            makeListing({
+              id: "listing-locked",
+              status: "ACTIVE",
+              tradeLockUntil: futureLock,
+            }),
+          )
+        }
+      >
+        Add Locked
+      </button>
+      <button
+        data-testid="add-string-a"
+        onClick={() =>
+          addItem(
+            makeListing({
+              id: "listing-string-a",
+              price: "10.25" as unknown as number,
+            }),
+          )
+        }
+      >
+        Add string A
+      </button>
+      <button
+        data-testid="add-string-b"
+        onClick={() =>
+          addItem(
+            makeListing({
+              id: "listing-string-b",
+              price: "20.50" as unknown as number,
+            }),
+          )
+        }
+      >
+        Add string B
+      </button>
+      <button data-testid="remove-ak" onClick={() => removeItem("listing-ak")}>
+        Remove AK
+      </button>
+      <button data-testid="clear" onClick={clearCart}>
+        Clear
+      </button>
+    </div>
+  );
+}
+
+function renderCart() {
+  return render(
+    <CartProvider>
+      <CartConsumer />
+    </CartProvider>,
+  );
 }
 
 describe("CartContext", () => {
-  it("starts empty", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
-    expect(result.current.items).toEqual([]);
-    expect(result.current.totalItems).toBe(0);
-    expect(result.current.totalPrice).toBe(0);
+  describe("initial state", () => {
+    it("starts with empty cart", () => {
+      renderCart();
+      expect(screen.getByTestId("count").textContent).toBe("0");
+      expect(screen.getByTestId("price").textContent).toBe("0.00");
+    });
   });
 
-  it("adds an ACTIVE listing", () => {
-    const listing = makeListing();
-    const { result } = renderHook(() => useCart(), { wrapper });
+  describe("addItem()", () => {
+    it("adds a new item to the cart", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
 
-    act(() => {
-      result.current.addItem(listing);
+      expect(screen.getByTestId("count").textContent).toBe("1");
+      expect(screen.getByTestId("item-listing-ak")).toBeTruthy();
     });
 
-    expect(result.current.items).toHaveLength(1);
-    expect(result.current.items[0].listing.id).toBe("listing-1");
-    expect(result.current.totalItems).toBe(1);
-  });
+    it("does not add duplicate items (same listing ID)", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("add-ak"));
 
-  it("does not add the same listing id twice (unique-item cart)", () => {
-    const listing = makeListing();
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(listing);
-      result.current.addItem(listing);
+      expect(screen.getByTestId("count").textContent).toBe("1");
     });
 
-    expect(result.current.items).toHaveLength(1);
-    expect(result.current.totalItems).toBe(1);
-  });
-
-  it("rejects a SOLD listing", () => {
-    const listing = makeListing({ status: "SOLD" });
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(listing);
+    it("does not add SOLD listings", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-sold"));
+      expect(screen.getByTestId("count").textContent).toBe("0");
     });
 
-    expect(result.current.items).toHaveLength(0);
-  });
-
-  it("rejects a RESERVED listing", () => {
-    const listing = makeListing({ status: "RESERVED" });
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(listing);
+    it("does not add RESERVED listings", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-reserved"));
+      expect(screen.getByTestId("count").textContent).toBe("0");
     });
 
-    expect(result.current.items).toHaveLength(0);
-  });
-
-  it("rejects a CANCELED listing", () => {
-    const listing = makeListing({ status: "CANCELED" });
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(listing);
+    it("does not add CANCELED listings", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-canceled"));
+      expect(screen.getByTestId("count").textContent).toBe("0");
     });
 
-    expect(result.current.items).toHaveLength(0);
-  });
-
-  it("still adds an ACTIVE listing that has a future tradeLockUntil (lock is UI-only)", () => {
-    const listing = makeListing({
-      status: "ACTIVE",
-      tradeLockUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-    });
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(listing);
+    it("still adds an ACTIVE listing that has a future tradeLockUntil (lock is UI-only)", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-locked"));
+      expect(screen.getByTestId("count").textContent).toBe("1");
+      expect(screen.getByTestId("item-listing-locked")).toBeTruthy();
     });
 
-    expect(result.current.items).toHaveLength(1);
-    expect(result.current.items[0].listing.id).toBe("listing-1");
+    it("can add multiple different listings", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("add-m4"));
+
+      expect(screen.getByTestId("count").textContent).toBe("2");
+    });
   });
 
-  it("adds two different listings independently", () => {
-    const a = makeListing({ id: "a", price: 10 });
-    const b = makeListing({ id: "b", price: 20 });
-    const { result } = renderHook(() => useCart(), { wrapper });
+  describe("removeItem()", () => {
+    it("removes item from cart", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("remove-ak"));
 
-    act(() => {
-      result.current.addItem(a);
-      result.current.addItem(b);
+      expect(screen.getByTestId("count").textContent).toBe("0");
+      expect(screen.queryByTestId("item-listing-ak")).toBeNull();
     });
 
-    expect(result.current.items).toHaveLength(2);
-    expect(result.current.totalItems).toBe(2);
+    it("does nothing when removing non-existent item", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-m4"));
+      fireEvent.click(screen.getByTestId("remove-ak"));
+
+      expect(screen.getByTestId("count").textContent).toBe("1");
+    });
   });
 
-  it("removes an item by listing id", () => {
-    const listing = makeListing();
-    const { result } = renderHook(() => useCart(), { wrapper });
+  describe("clearCart()", () => {
+    it("empties the cart completely", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("add-m4"));
+      fireEvent.click(screen.getByTestId("clear"));
 
-    act(() => {
-      result.current.addItem(listing);
-      result.current.removeItem("listing-1");
+      expect(screen.getByTestId("count").textContent).toBe("0");
+      expect(screen.queryByTestId("item-listing-ak")).toBeNull();
+      expect(screen.queryByTestId("item-listing-m4")).toBeNull();
+      expect(screen.getByTestId("price").textContent).toBe("0.00");
+    });
+  });
+
+  describe("totalPrice", () => {
+    it("sums prices of all items", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("add-m4"));
+
+      expect(screen.getByTestId("price").textContent).toBe("350.00");
     });
 
-    expect(result.current.items).toHaveLength(0);
-    expect(result.current.totalItems).toBe(0);
-  });
+    it("sums string prices through Number()", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-string-a"));
+      fireEvent.click(screen.getByTestId("add-string-b"));
 
-  it("removeItem is a no-op when the listing is not in the cart", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.removeItem("missing");
+      expect(screen.getByTestId("price").textContent).toBe("30.75");
     });
 
-    expect(result.current.items).toHaveLength(0);
-  });
+    it("recalculates when items are removed", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("add-m4"));
+      fireEvent.click(screen.getByTestId("remove-ak"));
 
-  it("clears all items", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(makeListing({ id: "a" }));
-      result.current.addItem(makeListing({ id: "b" }));
-      result.current.clearCart();
+      expect(screen.getByTestId("price").textContent).toBe("200.00");
     });
 
-    expect(result.current.items).toHaveLength(0);
-    expect(result.current.totalItems).toBe(0);
-    expect(result.current.totalPrice).toBe(0);
-  });
-
-  it("computes totalPrice as the sum of listing prices", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(makeListing({ id: "a", price: 150 }));
-      result.current.addItem(makeListing({ id: "b", price: 200 }));
+    it("returns 0 when cart is empty", () => {
+      renderCart();
+      expect(screen.getByTestId("price").textContent).toBe("0.00");
     });
-
-    expect(result.current.totalPrice).toBe(350);
   });
 
-  it("sums string prices through Number()", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
+  describe("useCart()", () => {
+    it("throws when used outside CartProvider", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    act(() => {
-      result.current.addItem(
-        makeListing({ id: "a", price: "10.25" as unknown as number }),
-      );
-      result.current.addItem(
-        makeListing({ id: "b", price: "20.50" as unknown as number }),
-      );
+      expect(() => {
+        render(<CartConsumer />);
+      }).toThrow("useCart must be used within CartProvider");
+
+      spy.mockRestore();
     });
-
-    expect(result.current.totalPrice).toBe(30.75);
-  });
-
-  it("recomputes totalPrice after remove", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
-
-    act(() => {
-      result.current.addItem(makeListing({ id: "a", price: 150 }));
-      result.current.addItem(makeListing({ id: "b", price: 200 }));
-      result.current.removeItem("a");
-    });
-
-    expect(result.current.totalPrice).toBe(200);
-    expect(result.current.totalItems).toBe(1);
-  });
-
-  it("totalPrice is 0 when the cart is empty", () => {
-    const { result } = renderHook(() => useCart(), { wrapper });
-    expect(result.current.totalPrice).toBe(0);
-  });
-
-  it("throws when useCart is used outside CartProvider", () => {
-    expect(() => renderHook(() => useCart())).toThrow(
-      "useCart must be used within CartProvider",
-    );
   });
 });

--- a/src/contexts/__tests__/CartContext.test.tsx
+++ b/src/contexts/__tests__/CartContext.test.tsx
@@ -1,189 +1,228 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
 import { CartProvider, useCart } from "../CartContext";
 import type { Listing } from "@/types/api";
 
-// Helper component to expose cart state
-function CartConsumer() {
-  const { items, addItem, removeItem, clearCart, totalItems, totalPrice } = useCart();
-  return (
-    <div>
-      <span data-testid="count">{totalItems}</span>
-      <span data-testid="price">{totalPrice.toFixed(2)}</span>
-      <ul>
-        {items.map((item) => (
-          <li key={item.listing.id} data-testid={`item-${item.listing.id}`}>
-            {item.listing.id}
-          </li>
-        ))}
-      </ul>
-      <button data-testid="add-ak" onClick={() => addItem(makeListing("listing-ak", 150))}>
-        Add AK
-      </button>
-      <button data-testid="add-m4" onClick={() => addItem(makeListing("listing-m4", 200))}>
-        Add M4
-      </button>
-      <button
-        data-testid="add-inactive"
-        onClick={() => addItem(makeListing("listing-inactive", 50, "SOLD"))}
-      >
-        Add Inactive
-      </button>
-      <button data-testid="remove-ak" onClick={() => removeItem("listing-ak")}>
-        Remove AK
-      </button>
-      <button data-testid="clear" onClick={clearCart}>
-        Clear
-      </button>
-    </div>
-  );
-}
-
-function makeListing(id: string, price: number, status = "ACTIVE"): Listing {
+function makeListing(overrides: Partial<Listing> = {}): Listing {
   return {
-    id,
+    id: "listing-1",
     productId: "prod-1",
     sellerId: "seller-1",
-    floatValue: 0.15 as unknown as import("@prisma/client/runtime/library").Decimal,
-    price: price as unknown as import("@prisma/client/runtime/library").Decimal,
+    price: 150,
     currency: "USD",
-    status,
+    status: "ACTIVE",
+    floatValue: 0.1,
+    pattern: null,
     tradeLockUntil: null,
     steamAssetId: null,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
     product: {
       id: "prod-1",
       game: "CS2",
-      weapon: "AK-47",
-      skinName: "Redline",
-      rarity: "Classified",
+      weapon: "AWP",
+      skinName: "Asiimov",
+      rarity: "Covert",
+      collection: "The Operation Phoenix Collection",
       exterior: "Field-Tested",
-      imageUrl: null,
       isStattrak: false,
       isSouvenir: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      imageUrl: "https://example.com/awp.png",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
     },
-    seller: { id: "seller-1", storeName: "Store Alpha" },
-  } as unknown as Listing;
+    seller: {
+      id: "seller-1",
+      storeName: "Sniper Shop",
+    },
+    ...overrides,
+  };
 }
 
-function renderCart() {
-  return render(
-    <CartProvider>
-      <CartConsumer />
-    </CartProvider>
-  );
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <CartProvider>{children}</CartProvider>;
 }
 
 describe("CartContext", () => {
-  describe("initial state", () => {
-    it("starts with empty cart", () => {
-      renderCart();
-      expect(screen.getByTestId("count").textContent).toBe("0");
-      expect(screen.getByTestId("price").textContent).toBe("0.00");
-    });
+  it("starts empty", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.totalItems).toBe(0);
+    expect(result.current.totalPrice).toBe(0);
   });
 
-  describe("addItem()", () => {
-    it("adds a new item to the cart", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak"));
+  it("adds an ACTIVE listing", () => {
+    const listing = makeListing();
+    const { result } = renderHook(() => useCart(), { wrapper });
 
-      expect(screen.getByTestId("count").textContent).toBe("1");
-      expect(screen.getByTestId("item-listing-ak")).toBeTruthy();
+    act(() => {
+      result.current.addItem(listing);
     });
 
-    it("does not add duplicate items (same listing ID)", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak"));
-      fireEvent.click(screen.getByTestId("add-ak")); // duplicate
-
-      expect(screen.getByTestId("count").textContent).toBe("1");
-    });
-
-    it("does not add non-ACTIVE listings", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-inactive"));
-
-      expect(screen.getByTestId("count").textContent).toBe("0");
-    });
-
-    it("can add multiple different listings", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak"));
-      fireEvent.click(screen.getByTestId("add-m4"));
-
-      expect(screen.getByTestId("count").textContent).toBe("2");
-    });
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].listing.id).toBe("listing-1");
+    expect(result.current.totalItems).toBe(1);
   });
 
-  describe("removeItem()", () => {
-    it("removes item from cart", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak"));
-      fireEvent.click(screen.getByTestId("remove-ak"));
+  it("does not add the same listing id twice (unique-item cart)", () => {
+    const listing = makeListing();
+    const { result } = renderHook(() => useCart(), { wrapper });
 
-      expect(screen.getByTestId("count").textContent).toBe("0");
-      expect(screen.queryByTestId("item-listing-ak")).toBeNull();
+    act(() => {
+      result.current.addItem(listing);
+      result.current.addItem(listing);
     });
 
-    it("does nothing when removing non-existent item", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-m4"));
-      fireEvent.click(screen.getByTestId("remove-ak")); // listing-ak not in cart
-
-      expect(screen.getByTestId("count").textContent).toBe("1");
-    });
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.totalItems).toBe(1);
   });
 
-  describe("clearCart()", () => {
-    it("empties the cart completely", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak"));
-      fireEvent.click(screen.getByTestId("add-m4"));
-      fireEvent.click(screen.getByTestId("clear"));
+  it("rejects a SOLD listing", () => {
+    const listing = makeListing({ status: "SOLD" });
+    const { result } = renderHook(() => useCart(), { wrapper });
 
-      expect(screen.getByTestId("count").textContent).toBe("0");
-      expect(screen.queryByTestId("item-listing-ak")).toBeNull();
-      expect(screen.queryByTestId("item-listing-m4")).toBeNull();
+    act(() => {
+      result.current.addItem(listing);
     });
+
+    expect(result.current.items).toHaveLength(0);
   });
 
-  describe("totalPrice", () => {
-    it("sums prices of all items", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak")); // $150
-      fireEvent.click(screen.getByTestId("add-m4")); // $200
+  it("rejects a RESERVED listing", () => {
+    const listing = makeListing({ status: "RESERVED" });
+    const { result } = renderHook(() => useCart(), { wrapper });
 
-      expect(screen.getByTestId("price").textContent).toBe("350.00");
+    act(() => {
+      result.current.addItem(listing);
     });
 
-    it("recalculates when items are removed", () => {
-      renderCart();
-      fireEvent.click(screen.getByTestId("add-ak")); // $150
-      fireEvent.click(screen.getByTestId("add-m4")); // $200
-      fireEvent.click(screen.getByTestId("remove-ak")); // remove $150
-
-      expect(screen.getByTestId("price").textContent).toBe("200.00");
-    });
-
-    it("returns 0 when cart is empty", () => {
-      renderCart();
-      expect(screen.getByTestId("price").textContent).toBe("0.00");
-    });
+    expect(result.current.items).toHaveLength(0);
   });
 
-  describe("useCart()", () => {
-    it("throws when used outside CartProvider", () => {
-      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  it("rejects a CANCELED listing", () => {
+    const listing = makeListing({ status: "CANCELED" });
+    const { result } = renderHook(() => useCart(), { wrapper });
 
-      expect(() => {
-        render(<CartConsumer />);
-      }).toThrow("useCart must be used within CartProvider");
-
-      spy.mockRestore();
+    act(() => {
+      result.current.addItem(listing);
     });
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("still adds an ACTIVE listing that has a future tradeLockUntil (lock is UI-only)", () => {
+    const listing = makeListing({
+      status: "ACTIVE",
+      tradeLockUntil: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(listing);
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].listing.id).toBe("listing-1");
+  });
+
+  it("adds two different listings independently", () => {
+    const a = makeListing({ id: "a", price: 10 });
+    const b = makeListing({ id: "b", price: 20 });
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(a);
+      result.current.addItem(b);
+    });
+
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.totalItems).toBe(2);
+  });
+
+  it("removes an item by listing id", () => {
+    const listing = makeListing();
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(listing);
+      result.current.removeItem("listing-1");
+    });
+
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.totalItems).toBe(0);
+  });
+
+  it("removeItem is a no-op when the listing is not in the cart", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.removeItem("missing");
+    });
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("clears all items", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(makeListing({ id: "a" }));
+      result.current.addItem(makeListing({ id: "b" }));
+      result.current.clearCart();
+    });
+
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.totalItems).toBe(0);
+    expect(result.current.totalPrice).toBe(0);
+  });
+
+  it("computes totalPrice as the sum of listing prices", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(makeListing({ id: "a", price: 150 }));
+      result.current.addItem(makeListing({ id: "b", price: 200 }));
+    });
+
+    expect(result.current.totalPrice).toBe(350);
+  });
+
+  it("sums string prices through Number()", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(
+        makeListing({ id: "a", price: "10.25" as unknown as number }),
+      );
+      result.current.addItem(
+        makeListing({ id: "b", price: "20.50" as unknown as number }),
+      );
+    });
+
+    expect(result.current.totalPrice).toBe(30.75);
+  });
+
+  it("recomputes totalPrice after remove", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+
+    act(() => {
+      result.current.addItem(makeListing({ id: "a", price: 150 }));
+      result.current.addItem(makeListing({ id: "b", price: 200 }));
+      result.current.removeItem("a");
+    });
+
+    expect(result.current.totalPrice).toBe(200);
+    expect(result.current.totalItems).toBe(1);
+  });
+
+  it("totalPrice is 0 when the cart is empty", () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    expect(result.current.totalPrice).toBe(0);
+  });
+
+  it("throws when useCart is used outside CartProvider", () => {
+    expect(() => renderHook(() => useCart())).toThrow(
+      "useCart must be used within CartProvider",
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Activity

Q2 — Testes de contrato da UI (`scripts/p-front/activities.json`).

Tests-only. No `server/` changes. No product/UI features. Q3 is not in this PR.

## What changed

Strengthened owner-file contract coverage without weakening existing cases.

`ListingCard`:
- Display name `weapon | skin (exterior)`
- StatTrak badge only when `isStattrak`
- Price `$` + two decimals, including string prices via `Number()`
- Float 8 decimals
- Seller `user.name` with `storeName` fallback
- Add-to-cart enabled for `ACTIVE` with no lock or expired lock
- Add-to-cart disabled for `SOLD` / `RESERVED` / `CANCELED` / future `tradeLockUntil`
- Disabled SOLD click does not increment cart (`CartProbe`)
- Enabled click increments cart
- Pattern shown as `Pattern: 412` and hidden when null
- Both links go to `/listing/:id`
- No SKINMARKET / CS2 Skin Marketplace leak

`CartContext` (kept sequential `CartConsumer` clicks so uniqueness stays a real UI contract):
- Empty start
- Unique-item cart (same listing id stays 1)
- Rejects `SOLD` / `RESERVED` / `CANCELED`
- Still adds `ACTIVE` with future `tradeLockUntil` (lock is UI-only)
- Remove / clear / totalPrice sum, including string prices
- `useCart` throws outside provider

## Verification

- `npm test` → 18 files, 69 tests passed
- `npm run typecheck` → passed
- `npm run lint` → 0 errors (9 pre-existing react-refresh warnings)

## Out of scope

- Q3 visual desktop/mobile pass
- Product implementation changes (`ListingCard` / `CartContext`)
- Any `server/` work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be8d64f-d540-4b0a-9df3-3b0128cad5b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

