### PR TITLE
[P-back] B0.1 — Contrato e orquestrador P-back

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,3 +439,7 @@ The main roadmap for this project prioritizes:
 - architecture documentation
 
 Do not start a lower-priority initiative while a higher-priority correctness issue is known and unresolved, unless explicitly requested.
+
+P-back (backend control plane, not application architecture): `docs/backend-sprint.md`. Next activity: `python3 scripts/p-back/next.py`. Do not implement AWS/Terraform until that catalog reaches C2 and C1 selected AWS.
+
+P-front (frontend control plane, `src/` only): `docs/frontend-sprint.md`. Next activity: `python3 scripts/p-front/next.py`. Unqualified `next` on a backend agent means P-back only.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -26,7 +26,12 @@ If code and documentation disagree, the agent must inspect the code and flag the
 
 The team is intentionally **sequential by default**. Parallel agents are used only when their work has no overlapping files or semantic dependencies.
 
-The P-front UI rebuild is one explicit parallel track (`src/` only). Agents must follow `docs/agents/p-front-orchestrator.md` and pick work with `python3 scripts/p-front/next.py` instead of hand-pasted issue prompts.
+Two file-disjoint control-plane tracks may run in parallel. They are sprint catalogs, not application orchestrators:
+
+- **P-back** (`server/`, backend docs): `docs/agents/p-back-orchestrator.md` — `python3 scripts/p-back/next.py`
+- **P-front** (`src/` only): `docs/agents/p-front-orchestrator.md` — `python3 scripts/p-front/next.py`
+
+Do not hand-paste issue prompts for those tracks. Unqualified `next` on a backend agent means P-back only.
 
 Recommended roles:
 

--- a/docs/agents/orchestrator.md
+++ b/docs/agents/orchestrator.md
@@ -110,6 +110,8 @@ A task that fails verification twice for the same root cause should escalate to 
 
 ## Parallelism
 
+P-back and P-front are specialized **sprint control planes** on top of this contract (`docs/agents/p-back-orchestrator.md`, `docs/agents/p-front-orchestrator.md`). They pick work from `scripts/p-back/activities.json` / `scripts/p-front/activities.json`. They must not add Kafka, Redis, or a workflow engine to the application.
+
 Parallel execution is allowed only when scopes and invariants are independent. Examples include independent documentation sections or separate read-only reviews.
 
 Do not parallelize:

--- a/docs/agents/p-back-orchestrator.md
+++ b/docs/agents/p-back-orchestrator.md
@@ -1,0 +1,85 @@
+# P-back orchestrator
+
+P-back is a **control-plane loop**, not a second application orchestrator.
+
+The backend remains a modular monolith. This document defines how a Cursor/cloud agent picks and executes the next backend sprint activity without colliding with P-front.
+
+## Why this exists
+
+P-front already has `docs/agents/p-front-orchestrator.md` + `scripts/p-front/next.py`. Backend work was still driven by ad-hoc roadmap reading, which made it easy to jump to P2 AWS after P1.4.
+
+`AGENTS.md` priority and `docs/agents/decision-policy.md` say:
+
+- correctness / reliability before cloud collecting
+- switching Render → ECS is a **human** architecture decision
+- do not invent provider contracts
+
+The catalog encodes that order so `next` cannot select Terraform before the cloud ADR.
+
+## Isolation
+
+| Agent | Allowed | Forbidden |
+|---|---|---|
+| P-back | `server/`, backend docs, `docs/backend-sprint.md`, `scripts/p-back/` | `src/`, `scripts/p-front/` |
+| P-front | `src/`, frontend docs, `scripts/p-front/` | `server/` |
+
+Disjoint paths mean the two tracks can run in parallel on separate branches. Do not “help” the other track.
+
+## Loop
+
+```text
+1. python3 scripts/p-back/next.py --prompt
+2. Create branch cursor/p-back-<id>-<suffix> from origin/main
+3. Implement only that activity's ownerFiles / invariants
+4. Commit with [P-back] <ID> in the subject
+5. Open one PR whose title contains [P-back] <ID>
+6. Stop. Do not merge. Do not start the next activity on the same branch.
+```
+
+`next.py` will treat the activity as **busy** while that PR is open, and **done** after the commit is on `origin/main`.
+
+## Detection
+
+| State | Source | Default marker |
+|---|---|---|
+| done | `git log origin/main --pretty=%s` | `[P-back] <ID>` |
+| busy | `gh pr list --state open` titles | `[P-back] <ID>` |
+
+Exceptions live on the activity object:
+
+- `legacyDone: true` — already on `main` under old commit subjects (P0.1–P1.3)
+- `doneMarkers` / `busyMarkers` — extra substrings (P1.4 landed as `P1.4: Performance evidence...`)
+
+## Selecting the next activity
+
+Walk `scripts/p-back/activities.json` in array order. The next activity is the first one that is:
+
+1. not done
+2. not busy
+3. every `dependsOn` id is done
+
+If every remaining activity is busy, `next.py` exits 2 (blocked). If the catalog is complete, exit 0 with `QUEUE_COMPLETE`.
+
+## `next` disambiguation
+
+| Context | Command |
+|---|---|
+| Backend / P-back conversation | `python3 scripts/p-back/next.py` |
+| Frontend / P-front conversation | `python3 scripts/p-front/next.py` |
+| Unqualified `next` on a **backend** agent | P-back only. Do not run the frontend catalog. |
+
+## What this orchestrator must not do
+
+- Must not add Kafka, Redis, SQS, or a workflow engine to the application.
+- Must not implement AWS/Terraform until activity **C2**, and only if **C1** selected AWS.
+- Must not invent PayPal refund or capture APIs.
+- Must not close GitHub issues (read-only `gh` in this environment).
+- Must not merge PRs.
+
+## Human gates
+
+Stop and ask when `docs/agents/decision-policy.md` requires it, including:
+
+- undefined PayPal refund/capture-after-expiry semantics (R2)
+- Render vs ECS (C1) — the ADR is the artifact; the choice is human
+- destructive migrations, auth weakening, deleting constraints

--- a/docs/backend-sprint.md
+++ b/docs/backend-sprint.md
@@ -1,0 +1,84 @@
+# Backend sprint — P-back
+
+This is the **backend control plane**, not application architecture.
+
+The backend is already a modular monolith (`server/src/modules/*`). P-back does not add a second runtime orchestrator. It is the same pattern as P-front: a **sprint catalog + `next.py`** so one agent executes **one activity, one branch, one PR**.
+
+## Isolation
+
+| Track | Owns | Must not touch |
+|---|---|---|
+| **P-back** | `server/`, `server/prisma/`, backend tests, backend ADRs, this file, `scripts/p-back/` | `src/` (Vite client), `scripts/p-front/` |
+| **P-front** | `src/`, frontend docs, `scripts/p-front/` | `server/` |
+
+Shared files (`docs/roadmap.md`, `AGENTS.md`, `docs/agents/README.md`) may be updated **lightly** when a sprint activity requires it. Do not rewrite `docs/frontend-sprint.md` except the parallelism pointer in B0.1.
+
+## How to start the next activity
+
+```bash
+python3 scripts/p-back/next.py --prompt
+```
+
+Then follow the printed prompt. The machine-readable equivalent is `python3 scripts/p-back/next.py --json`.
+
+Done detection: a commit on `origin/main` whose subject contains a configured marker (default `[P-back] <ID>`). Historical P0/P1 work that landed before this convention is marked `legacyDone` in `scripts/p-back/activities.json`.
+
+Busy detection: an **open** GitHub PR whose title contains a configured busy marker.
+
+## Priority (why this order)
+
+`AGENTS.md` priority is correctness → security → reliability → testability → observability → performance → maintainability → DX → features.
+
+P0/P1 flagship work is already on `main`. The remaining queue is **not AWS next**. Cloud/Terraform is gated on activity **C1** (an ADR that chooses Render vs ECS). Until that ADR exists and selects AWS, do not implement Terraform.
+
+| ID | Title | Why now |
+|---|---|---|
+| **B0.1** | This contract | So `next` is deterministic |
+| **R1** | Payment-link idempotency | `POST /payments` can create a second PayPal order on client retry; order creation already has `Idempotency-Key` |
+| **R2** | Capture-after-expiry ops | Documented gap: capture after expiry has no refund/ops path. **Do not invent a PayPal refund API.** |
+| **O1** | Render operations | Real production is Render (`render.yaml`), not ECS. Health vs ready, seed-on-boot, runbook. |
+| **D1 / D2** | Threat model + C4 | Interview/ops docs listed on the roadmap and still missing |
+| **C1** | Cloud target ADR | Human-facing architecture choice. Writes the ADR only. |
+| **C2** | AWS/Terraform | **Only if C1 selected AWS.** If C1 keeps Render, land a skip commit so the queue can close. |
+
+## Activity catalog
+
+The executable graph is `scripts/p-back/activities.json`. Human summary:
+
+| ID | Title | Depends on |
+|---|---|---|
+| P0.1–P1.4 | Historical P0/P1 (legacy done on `main`) | chain |
+| B0.1 | Orchestrator contract | — |
+| R1 | Payment-link idempotency | B0.1, P0.3 |
+| R2 | Capture-after-expiry ops | B0.1, P0.2 |
+| O1 | Render runbook + health alignment | B0.1, P1.3 |
+| D1 | Threat model | B0.1 |
+| D2 | C4 diagrams | B0.1 |
+| C1 | Cloud target ADR | O1, D1 |
+| C2 | AWS/Terraform (conditional) | C1 |
+
+## Rules for every activity
+
+1. One activity, one branch, one PR.
+2. Do not merge the PR. Do not close GitHub issues (`gh` is read-only in this environment).
+3. Do not edit `src/`.
+4. Do not introduce Redis, Kafka, RabbitMQ, SQS, or microservices.
+5. Do not invent PayPal APIs, environment variables, or refund semantics. If a payment activity needs an undefined provider contract, stop and ask (`docs/agents/decision-policy.md`).
+6. PostgreSQL remains the source of truth for transactional state.
+7. Prefer the smallest correct change. Tests must prove the invariant, not merely increase coverage.
+
+## Commit and PR convention
+
+- Commit subject: `[P-back] <ID> — <short description>`
+- PR title: `[P-back] <ID> — <short description>`
+- Branch: `cursor/p-back-<id>-<suffix>` (lowercase). Example: `cursor/p-back-r1-9103`.
+
+## Prompt to reuse
+
+```text
+Execute the next unblocked P-back activity.
+Run: python3 scripts/p-back/next.py --prompt
+Then follow that printed prompt exactly.
+Do not edit src/. Do not start AWS/Terraform unless the activity is C2 and the cloud ADR selected AWS.
+Do not merge. Do not close issues.
+```

--- a/docs/frontend-sprint.md
+++ b/docs/frontend-sprint.md
@@ -78,4 +78,4 @@ In progress = an open PR whose title contains `[P-front] <ID>`.
 
 ## Parallelism with backend
 
-Backend P1 (`server/` only) may run in a separate agent/PR at the same time. Do not mix `src/` and `server/` in one PR.
+Backend uses its own control plane: `docs/backend-sprint.md` and `python3 scripts/p-back/next.py`. A P-back agent/PR may run at the same time. Do not mix `src/` and `server/` in one PR. Do not edit `docs/backend-sprint.md` or `scripts/p-back/` from P-front.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -109,18 +109,7 @@ Secrets Manager
 CloudWatch + OpenTelemetry
 ```
 
-Implement progressively:
-
-- production Docker image;
-- CI/CD;
-- AWS deployment;
-- RDS;
-- Secrets Manager;
-- health/readiness checks;
-- centralized logs;
-- Terraform;
-- migration strategy;
-- rollback/runbook.
+Do **not** start AWS/Terraform from this list. Remaining backend work is the P-back catalog (`docs/backend-sprint.md`): payment-link idempotency, capture-after-expiry ops, Render runbook, threat model, C4, then a **cloud-target ADR (C1)**. Implement AWS only if that ADR selects it (C2). Render (`render.yaml`) is the current production deploy.
 
 ## Documentation deliverables
 
@@ -138,11 +127,15 @@ Maintain:
 
 Documentation is part of the implementation whenever a design or operational decision changes.
 
-## P-front — Frontend rebuild (parallel to P1, `src/` only)
+## P-back — Backend sprint (control plane)
+
+Post-P1 remaining work is **not** AWS next. Catalog and agent loop: `docs/backend-sprint.md`, `docs/agents/p-back-orchestrator.md`. Next activity: `python3 scripts/p-back/next.py`.
+
+## P-front — Frontend rebuild (parallel, `src/` only)
 
 Rebuild the existing Vite/React client. No new product features. Locked decisions and activity graph: `docs/frontend-sprint.md`. Agent loop: `docs/agents/p-front-orchestrator.md`. Next activity: `python3 scripts/p-front/next.py`.
 
-May run beside backend P1 only while PRs stay disjoint (`src/` vs `server/`).
+May run beside P-back only while PRs stay disjoint (`src/` vs `server/`).
 
 ## Agent execution rule
 
@@ -150,4 +143,4 @@ Only one roadmap item should normally be in active implementation at a time. Spl
 
 A lower-priority item must not distract the team from a known unresolved correctness problem.
 
-P-front is an explicit exception for **file-disjoint** parallelism with P1: frontend agents own `src/` and `docs/frontend-sprint.md`; backend agents own `server/`.
+P-front / P-back are an explicit exception for **file-disjoint** parallelism: frontend agents own `src/` and `docs/frontend-sprint.md`; backend agents own `server/` and `docs/backend-sprint.md`.

--- a/scripts/p-back-next.sh
+++ b/scripts/p-back-next.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec python3 "$(dirname "$0")/p-back/next.py" "$@"

--- a/scripts/p-back/activities.json
+++ b/scripts/p-back/activities.json
@@ -1,0 +1,232 @@
+{
+  "sprint": "P-back",
+  "prTitlePrefix": "[P-back]",
+  "commitConvention": "[P-back] <ID> — <short title>",
+  "forbiddenGlobally": [
+    "src/",
+    "docs/frontend-sprint.md",
+    "scripts/p-front/"
+  ],
+  "lockedDecisions": {
+    "architecture": "Modular monolith. PostgreSQL is the source of truth. Do not add Redis, Kafka, RabbitMQ, SQS, or microservices.",
+    "payments": "Do not invent PayPal APIs, refunds, or environment variables. OrdersCreate and OrdersCapture are not retried.",
+    "cloud": "Render is current production (render.yaml). Do not implement AWS/Terraform until C2, and only if C1 selected AWS."
+  },
+  "activities": [
+    {
+      "id": "P0.1",
+      "title": "Reservation lifecycle",
+      "dependsOn": [],
+      "legacyDone": true,
+      "ownerFiles": ["server/src/modules/listings/", "server/src/modules/orders/"],
+      "roles": ["Backend", "Database/Concurrency", "Test", "Verification"],
+      "verify": [],
+      "acceptance": ["Historical. Already on origin/main."]
+    },
+    {
+      "id": "P0.2",
+      "title": "PayPal webhook reliability",
+      "dependsOn": ["P0.1"],
+      "legacyDone": true,
+      "ownerFiles": ["server/src/modules/payments/", "docs/adr/0002-paypal-webhook-reliability.md"],
+      "roles": ["Backend", "Reliability", "Security", "Test", "Verification"],
+      "verify": [],
+      "acceptance": ["Historical. Already on origin/main."]
+    },
+    {
+      "id": "P0.3",
+      "title": "Order creation idempotency",
+      "dependsOn": ["P0.2"],
+      "legacyDone": true,
+      "ownerFiles": ["server/src/modules/orders/", "docs/adr/0003-order-creation-idempotency.md"],
+      "roles": ["Backend", "Database/Concurrency", "Test", "Verification"],
+      "verify": [],
+      "acceptance": ["Historical. Already on origin/main."]
+    },
+    {
+      "id": "P1.1",
+      "title": "PostgreSQL integration tests",
+      "dependsOn": ["P0.3"],
+      "legacyDone": true,
+      "ownerFiles": ["server/src/__tests__/", "docs/testing.md"],
+      "roles": ["Test", "Verification"],
+      "verify": [],
+      "acceptance": ["Historical. Already on origin/main."]
+    },
+    {
+      "id": "P1.2",
+      "title": "Observability",
+      "dependsOn": ["P1.1"],
+      "legacyDone": true,
+      "ownerFiles": ["server/src/shared/observability/", "docs/observability.md"],
+      "roles": ["Backend", "Verification"],
+      "verify": [],
+      "acceptance": ["Historical. Already on origin/main."]
+    },
+    {
+      "id": "P1.3",
+      "title": "Resilience",
+      "dependsOn": ["P1.2"],
+      "legacyDone": true,
+      "ownerFiles": ["server/src/shared/resilience/", "docs/adr/0005-external-retry-and-graceful-shutdown.md"],
+      "roles": ["Reliability", "Test", "Verification"],
+      "verify": [],
+      "acceptance": ["Historical. Already on origin/main."]
+    },
+    {
+      "id": "P1.4",
+      "title": "Performance evidence",
+      "dependsOn": ["P1.3"],
+      "legacyDone": true,
+      "doneMarkers": [
+        "[P-back] P1.4",
+        "P1.4: Performance",
+        "add P1.4 query-plan"
+      ],
+      "busyMarkers": ["[P-back] P1.4", "P1.4:"],
+      "ownerFiles": [
+        "server/prisma/migrations/",
+        "server/src/shared/perf/",
+        "docs/performance.md",
+        "docs/adr/0006-hot-path-indexes.md"
+      ],
+      "roles": ["Backend", "Verification"],
+      "verify": ["npm run perf:evidence --prefix server"],
+      "acceptance": ["Historical. Merged as PR #33 before the [P-back] marker existed."]
+    },
+    {
+      "id": "B0.1",
+      "title": "Contrato e orquestrador P-back",
+      "dependsOn": [],
+      "ownerFiles": [
+        "docs/backend-sprint.md",
+        "docs/agents/p-back-orchestrator.md",
+        "scripts/p-back/",
+        "scripts/p-back-next.sh",
+        "docs/roadmap.md",
+        "docs/agents/README.md",
+        "docs/agents/orchestrator.md",
+        "AGENTS.md",
+        "docs/frontend-sprint.md"
+      ],
+      "roles": ["Planner", "Verification"],
+      "verify": [
+        "python3 scripts/p-back/next.py --json",
+        "python3 -m unittest scripts/p-back/test_next.py"
+      ],
+      "acceptance": [
+        "Later agents can run python3 scripts/p-back/next.py and implement one activity without inventing AWS/Terraform.",
+        "Catalog encodes AGENTS.md priority: remaining payment/ops/docs before cloud.",
+        "P-front isolation is explicit: no src/, docs/frontend-sprint.md, or scripts/p-front/ edits.",
+        "Done/busy detection covers legacy P0/P1 commits that predate [P-back] <ID>."
+      ]
+    },
+    {
+      "id": "R1",
+      "title": "Idempotência do link de pagamento",
+      "dependsOn": ["B0.1", "P0.3"],
+      "ownerFiles": [
+        "server/src/modules/payments/",
+        "server/prisma/schema.prisma",
+        "docs/architecture/failure-modes.md",
+        "docs/architecture/domain-invariants.md"
+      ],
+      "roles": ["Backend", "Reliability", "Database/Concurrency", "Test", "Verification"],
+      "verify": [
+        "cd server && npx vitest run src/modules/payments/__tests__/payments.service.test.ts",
+        "cd server && npm run test:integration"
+      ],
+      "acceptance": [
+        "Retrying POST /payments for the same unpaid order does not call PayPal OrdersCreate a second time once a paypalOrderId exists (or a durable idempotency record exists).",
+        "Concurrent identical POST /payments have one business effect.",
+        "OrdersCreate remains unretried inside the PayPal client.",
+        "No src/ changes. Do not invent a new PayPal API."
+      ]
+    },
+    {
+      "id": "R2",
+      "title": "Operação de capture após expiração",
+      "dependsOn": ["B0.1", "P0.2"],
+      "ownerFiles": [
+        "docs/architecture/failure-modes.md",
+        "docs/operations/runbook.md"
+      ],
+      "roles": ["Reliability", "Verification"],
+      "verify": ["docs-only unless an existing PayPal refund/void contract is already in this repo"],
+      "acceptance": [
+        "Inspect server/src/shared/utils/paypal.ts and payments code for any existing refund/void helper. Do not invent a PayPal refund API or env var.",
+        "If no provider contract exists, document the operational gap (webhook 200, listing not SOLD, money captured) and the human steps. Stop and ask HUMAN rather than guessing refund semantics.",
+        "Do not mark listings SOLD after expiry. Do not edit src/."
+      ]
+    },
+    {
+      "id": "O1",
+      "title": "Runbook Render e alinhamento health/ready",
+      "dependsOn": ["B0.1", "P1.3"],
+      "ownerFiles": [
+        "render.yaml",
+        "docs/operations/runbook.md",
+        "server/src/shared/"
+      ],
+      "roles": ["Reliability", "Verification"],
+      "verify": ["docs and render.yaml review; targeted tests if /ready vs /health mapping changes"],
+      "acceptance": [
+        "docs/operations/runbook.md exists and covers deploy, health vs ready, shutdown drain, seed-on-boot (SEED_DEMO_DATA), and how to inspect payments/reservations.",
+        "Render healthCheckPath is aligned with the documented liveness vs readiness intent. Do not invent new env vars.",
+        "No AWS/Terraform. No src/ changes."
+      ]
+    },
+    {
+      "id": "D1",
+      "title": "Threat model",
+      "dependsOn": ["B0.1"],
+      "parallelGroup": "interview-docs",
+      "ownerFiles": ["docs/architecture/threat-model.md"],
+      "roles": ["Security", "Verification"],
+      "verify": ["docs-only diff"],
+      "acceptance": [
+        "docs/architecture/threat-model.md exists and covers auth, webhooks, secrets, trust boundaries, and abuse controls that already exist in code.",
+        "Do not invent controls that are not implemented. Do not edit src/ or server/ behavior."
+      ]
+    },
+    {
+      "id": "D2",
+      "title": "Diagramas C4",
+      "dependsOn": ["B0.1"],
+      "parallelGroup": "interview-docs",
+      "ownerFiles": ["docs/architecture/c4.md"],
+      "roles": ["Architecture", "Verification"],
+      "verify": ["docs-only diff"],
+      "acceptance": [
+        "docs/architecture/c4.md describes the current modular monolith + Render + PostgreSQL + PayPal/Resend, not a hypothetical ECS topology as if it were live.",
+        "Do not edit src/ or server/ behavior."
+      ]
+    },
+    {
+      "id": "C1",
+      "title": "ADR do alvo de cloud (Render vs ECS)",
+      "dependsOn": ["O1", "D1"],
+      "ownerFiles": ["docs/adr/", "docs/roadmap.md"],
+      "roles": ["Planner", "Architecture", "Verification"],
+      "verify": ["docs-only diff"],
+      "acceptance": [
+        "One ADR states the current production target (Render today) and whether the portfolio ECS/Fargate diagram is a future option or a committed migration.",
+        "The ADR is the artifact. Do not provision AWS, write Terraform, or change render.yaml except to reference the decision.",
+        "If the choice is materially architectural, stop for HUMAN per docs/agents/decision-policy.md rather than silently picking ECS."
+      ]
+    },
+    {
+      "id": "C2",
+      "title": "AWS/Terraform (condicional)",
+      "dependsOn": ["C1"],
+      "ownerFiles": ["infra/", "docs/adr/"],
+      "roles": ["Planner", "Infra/Backend", "Security", "Reliability", "Verification"],
+      "verify": ["only if C1 selected AWS; otherwise a skip commit with [P-back] C2"],
+      "acceptance": [
+        "If C1 selected AWS: implement only what that ADR scoped. Do not invent Secrets Manager/VPC layout beyond the ADR.",
+        "If C1 kept Render: do not add Terraform. Land a skip commit whose subject contains [P-back] C2 so the queue can close.",
+        "No src/ changes."
+      ]
+    }
+  ]
+}

--- a/scripts/p-back/create-issues.py
+++ b/scripts/p-back/create-issues.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Optional: create GitHub issues from scripts/p-back/activities.json.
+
+This Cloud Agent cannot create issues (gh is read-only here).
+Run on a machine with write access:
+
+  python3 scripts/p-back/create-issues.py --dry-run
+  python3 scripts/p-back/create-issues.py
+
+Idempotent: skips an activity if an open or closed issue already
+has "[P-back] <ID>" in the title. Skips legacyDone historical items.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTIVITIES_PATH = Path(__file__).resolve().parent / "activities.json"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=ROOT, text=True, capture_output=True)
+
+
+def existing_titles() -> set[str]:
+    result = run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "200",
+            "--json",
+            "title",
+        ]
+    )
+    if result.returncode != 0:
+        raise SystemExit(result.stderr or "gh issue list failed")
+    return {item["title"] for item in json.loads(result.stdout)}
+
+
+def issue_body(activity: dict, catalog: dict) -> str:
+    deps = ", ".join(activity.get("dependsOn") or []) or "none"
+    files = "\n".join(f"- `{path}`" for path in activity.get("ownerFiles") or [])
+    acceptance = "\n".join(f"- [ ] {item}" for item in activity.get("acceptance") or [])
+    verify = "\n".join(f"- `{cmd}`" for cmd in activity.get("verify") or [])
+    roles = ", ".join(activity.get("roles") or [])
+    locked = catalog.get("lockedDecisions") or {}
+    return f"""## Objective
+{activity["title"]}
+
+## Sprint
+P-back. Source of truth: `docs/backend-sprint.md` and `scripts/p-back/activities.json`.
+Prefer the orchestrator (`python3 scripts/p-back/next.py`) over hand-picking issues.
+
+## Locked decisions
+- {locked.get("architecture", "")}
+- {locked.get("payments", "")}
+- {locked.get("cloud", "")}
+
+## Depends on
+{deps}
+
+## Scope files
+{files or "- (see sprint doc)"}
+
+## Out of scope
+- `src/`
+- `docs/frontend-sprint.md`
+- `scripts/p-front/`
+- AWS/Terraform unless this activity is C2 and C1 selected AWS
+- Inventing PayPal APIs, refunds, or environment variables
+
+## Acceptance criteria
+{acceptance}
+
+## Verify
+{verify}
+
+## Required review
+{roles}
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--label", default="enhancement")
+    args = parser.parse_args()
+
+    catalog = json.loads(ACTIVITIES_PATH.read_text(encoding="utf-8"))
+    titles = existing_titles() if not args.dry_run else set()
+    created = 0
+    skipped = 0
+
+    parent_title = "[P-back] Backend sprint — reliability before cloud"
+    if parent_title not in titles and not args.dry_run:
+        locked = catalog.get("lockedDecisions") or {}
+        body = f"""## Objective
+Execute remaining backend production-maturity work with a deterministic next-activity loop.
+
+## Execution
+Do not paste activities by hand. After this issue exists, agents run:
+
+```text
+python3 scripts/p-back/next.py --prompt
+```
+
+and implement only the printed activity.
+
+## Locked decisions
+- {locked.get("architecture", "")}
+- {locked.get("payments", "")}
+- {locked.get("cloud", "")}
+
+## Source of truth
+- `docs/backend-sprint.md`
+- `docs/agents/p-back-orchestrator.md`
+- `scripts/p-back/activities.json`
+"""
+        result = run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                parent_title,
+                "--body",
+                body,
+                "--label",
+                args.label,
+            ]
+        )
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            return result.returncode
+        print(result.stdout.strip())
+        created += 1
+    else:
+        skipped += 1
+        print(f"skip parent ({'exists' if parent_title in titles else 'dry-run'})")
+
+    for activity in catalog["activities"]:
+        if activity.get("legacyDone"):
+            print(f"skip {activity['id']} (legacyDone)")
+            skipped += 1
+            continue
+        title = f"[P-back] {activity['id']} — {activity['title']}"
+        if title in titles:
+            print(f"skip {activity['id']} (exists)")
+            skipped += 1
+            continue
+        body = issue_body(activity, catalog)
+        if args.dry_run:
+            print(f"dry-run {title}")
+            skipped += 1
+            continue
+        result = run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                args.label,
+            ]
+        )
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            return result.returncode
+        print(result.stdout.strip())
+        created += 1
+
+    print(f"created={created} skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p-back/next.py
+++ b/scripts/p-back/next.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Pick the next unblocked P-back activity from git history and open PRs.
+
+Done  = legacyDone, or a commit on origin/main whose subject contains a done marker
+        (default "[P-back] <ID>")
+Busy  = open PR whose title contains a busy marker (default "[P-back] <ID>")
+Next  = first activity whose dependsOn are all done and which is not done/busy
+
+Usage:
+  python3 scripts/p-back/next.py
+  python3 scripts/p-back/next.py --json
+  python3 scripts/p-back/next.py --prompt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTIVITIES_PATH = Path(__file__).resolve().parent / "activities.json"
+
+
+def run(args: list[str]) -> str:
+    result = subprocess.run(args, cwd=ROOT, text=True, capture_output=True)
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def load_catalog() -> dict[str, Any]:
+    return json.loads(ACTIVITIES_PATH.read_text(encoding="utf-8"))
+
+
+def default_marker(activity_id: str) -> str:
+    return f"[P-back] {activity_id}"
+
+
+def done_markers_for(activity: dict[str, Any]) -> list[str]:
+    markers = activity.get("doneMarkers")
+    if markers:
+        return list(markers)
+    return [default_marker(activity["id"])]
+
+
+def busy_markers_for(activity: dict[str, Any]) -> list[str]:
+    markers = activity.get("busyMarkers")
+    if markers:
+        return list(markers)
+    return [default_marker(activity["id"])]
+
+
+def activity_is_done(activity: dict[str, Any], log: str) -> bool:
+    if activity.get("legacyDone"):
+        return True
+    return any(marker in log for marker in done_markers_for(activity))
+
+
+def activity_busy_url(
+    activity: dict[str, Any], prs: list[dict[str, Any]]
+) -> str | None:
+    markers = busy_markers_for(activity)
+    for pr in prs:
+        title = pr.get("title") or ""
+        if any(marker in title for marker in markers):
+            return pr.get("url") or f"#{pr.get('number')}"
+    return None
+
+
+def done_ids(catalog: dict[str, Any], log: str) -> set[str]:
+    found: set[str] = set()
+    for activity in catalog["activities"]:
+        if activity_is_done(activity, log):
+            found.add(activity["id"])
+    return found
+
+
+def busy_ids(
+    catalog: dict[str, Any], prs: list[dict[str, Any]]
+) -> dict[str, str]:
+    busy: dict[str, str] = {}
+    for activity in catalog["activities"]:
+        url = activity_busy_url(activity, prs)
+        if url:
+            busy[activity["id"]] = url
+    return busy
+
+
+def select_next(
+    catalog: dict[str, Any], done: set[str], busy: dict[str, str]
+) -> list[dict[str, Any]]:
+    ready: list[dict[str, Any]] = []
+    for activity in catalog["activities"]:
+        activity_id = activity["id"]
+        if activity_id in done or activity_id in busy:
+            continue
+        deps = set(activity.get("dependsOn") or [])
+        if deps <= done:
+            ready.append(activity)
+    return ready
+
+
+def fetch_commit_log() -> str:
+    return run(["git", "log", "origin/main", "--pretty=%s"])
+
+
+def fetch_open_prs() -> list[dict[str, Any]]:
+    raw = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "50",
+            "--json",
+            "title,url,number",
+        ]
+    )
+    if not raw.strip():
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return parsed
+
+
+def agent_prompt(activity: dict[str, Any], catalog: dict[str, Any]) -> str:
+    owner = "\n".join(
+        f"- {path}" for path in activity.get("ownerFiles") or ["(see sprint doc)"]
+    )
+    acceptance = "\n".join(f"- {item}" for item in activity.get("acceptance") or [])
+    verify = "\n".join(f"- `{cmd}`" for cmd in activity.get("verify") or [])
+    locked = catalog.get("lockedDecisions") or {}
+    branch_id = activity["id"].lower().replace(".", "")
+    return f"""Execute SOMENTE a atividade {activity["id"]} — {activity["title"]}.
+
+Obrigatório ler, nesta ordem:
+1. AGENTS.md
+2. docs/agents/README.md
+3. docs/agents/roles.md
+4. docs/agents/context-policy.md
+5. docs/agents/decision-policy.md
+6. docs/agents/execution-protocol.md
+7. docs/architecture/domain-invariants.md
+8. docs/backend-sprint.md
+9. docs/agents/p-back-orchestrator.md
+10. só os arquivos do escopo abaixo
+
+Decisões travadas:
+- {locked.get("architecture", "")}
+- {locked.get("payments", "")}
+- {locked.get("cloud", "")}
+
+Arquivos desta atividade:
+{owner}
+
+Não pode:
+- editar arquivos fora de ownerFiles
+- editar src/ ou scripts/p-front/ (P-front)
+- começar AWS/Terraform a menos que a atividade seja C2 e o ADR C1 tenha escolhido AWS
+- inventar API PayPal, refund ou variável de ambiente
+- introduzir Redis, Kafka, SQS ou microsserviços
+- enfraquecer auth, CORS, rate limit ou testes
+- começar outra atividade no mesmo PR
+
+Critérios de aceite:
+{acceptance}
+
+Verificação:
+{verify}
+
+Branch: cursor/p-back-{branch_id}-9103
+Título do PR: [P-back] {activity["id"]} — {activity["title"]}
+PR draft até Verification PASS. Não mergear. Não fechar issue.
+Handoff no formato docs/agents/handoff-template.md.
+Parar quando os critérios de aceite estiverem provados.
+"""
+
+
+def build_payload(
+    catalog: dict[str, Any], done: set[str], busy: dict[str, str]
+) -> dict[str, Any]:
+    ready = select_next(catalog, done, busy)
+    return {
+        "done": sorted(done),
+        "inProgress": busy,
+        "ready": [
+            {
+                "id": item["id"],
+                "title": item["title"],
+                "parallelGroup": item.get("parallelGroup"),
+            }
+            for item in ready
+        ],
+        "next": (
+            {
+                "id": ready[0]["id"],
+                "title": ready[0]["title"],
+                "parallelGroup": ready[0].get("parallelGroup"),
+            }
+            if ready
+            else None
+        ),
+        "complete": not ready and not busy and len(done) == len(catalog["activities"]),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--prompt", action="store_true")
+    args = parser.parse_args()
+
+    catalog = load_catalog()
+    done = done_ids(catalog, fetch_commit_log())
+    busy = busy_ids(catalog, fetch_open_prs())
+    payload = build_payload(catalog, done, busy)
+    ready = select_next(catalog, done, busy)
+
+    if args.json:
+        json.dump(payload, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+
+    if payload["complete"]:
+        print("P-back complete. No remaining activities.")
+        return 0
+
+    if not ready:
+        print("No unblocked activity. Waiting on in-progress work:")
+        for activity_id, url in busy.items():
+            print(f"  {activity_id}: {url}")
+        return 2
+
+    nxt = ready[0]
+    if args.prompt:
+        sys.stdout.write(agent_prompt(nxt, catalog))
+        return 0
+
+    print(f"next: {nxt['id']} — {nxt['title']}")
+    if len(ready) > 1:
+        extras = ", ".join(f"{item['id']} ({item['title']})" for item in ready[1:])
+        print(f"also unblocked (parallel if files are disjoint): {extras}")
+    if done:
+        print("done: " + ", ".join(sorted(done)))
+    if busy:
+        print("in progress: " + ", ".join(f"{k}={v}" for k, v in busy.items()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/p-back/test_next.py
+++ b/scripts/p-back/test_next.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Unit tests for P-back next-activity selection (no git/gh required)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("p_back_next", HERE / "next.py")
+assert SPEC and SPEC.loader
+p_back_next = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(p_back_next)
+
+
+def catalog() -> dict:
+    return json.loads((HERE / "activities.json").read_text(encoding="utf-8"))
+
+
+class MarkerTests(unittest.TestCase):
+    def test_default_done_marker(self) -> None:
+        activity = {"id": "R1"}
+        self.assertEqual(p_back_next.done_markers_for(activity), ["[P-back] R1"])
+        self.assertTrue(
+            p_back_next.activity_is_done(
+                activity, "[P-back] R1 — Idempotência do link de pagamento\n"
+            )
+        )
+        self.assertFalse(
+            p_back_next.activity_is_done(activity, "[P-back] R2 — other\n")
+        )
+
+    def test_legacy_done_ignores_git_log(self) -> None:
+        activity = {"id": "P0.1", "legacyDone": True}
+        self.assertTrue(p_back_next.activity_is_done(activity, ""))
+
+    def test_p14_historical_commit_subject(self) -> None:
+        activities = {item["id"]: item for item in catalog()["activities"]}
+        p14 = activities["P1.4"]
+        log = "feat(perf): add P1.4 query-plan evidence and hot-path indexes\n"
+        self.assertTrue(p_back_next.activity_is_done(p14, log))
+
+    def test_busy_default_and_custom_markers(self) -> None:
+        prs = [
+            {
+                "title": "P1.4: Performance evidence and hot-path indexes",
+                "url": "https://example.test/p14",
+                "number": 33,
+            }
+        ]
+        p14 = {
+            "id": "P1.4",
+            "busyMarkers": ["[P-back] P1.4", "P1.4:"],
+        }
+        self.assertEqual(
+            p_back_next.activity_busy_url(p14, prs), "https://example.test/p14"
+        )
+        self.assertIsNone(p_back_next.activity_busy_url({"id": "R1"}, prs))
+
+
+class SelectNextTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.catalog = catalog()
+
+    def test_b01_is_next_when_historical_done(self) -> None:
+        done = {item["id"] for item in self.catalog["activities"] if item.get("legacyDone")}
+        ready = p_back_next.select_next(self.catalog, done, {})
+        self.assertEqual(ready[0]["id"], "B0.1")
+
+    def test_after_b01_r1_is_first_among_unblocked(self) -> None:
+        done = {
+            item["id"]
+            for item in self.catalog["activities"]
+            if item.get("legacyDone") or item["id"] == "B0.1"
+        }
+        ready = p_back_next.select_next(self.catalog, done, {})
+        self.assertEqual(ready[0]["id"], "R1")
+        self.assertEqual(
+            [item["id"] for item in ready],
+            ["R1", "R2", "O1", "D1", "D2"],
+        )
+
+    def test_skips_busy_and_waits_for_deps(self) -> None:
+        done = {"B0.1", "P0.3"}
+        busy = {"R1": "https://example.test/r1"}
+        ready = p_back_next.select_next(self.catalog, done, busy)
+        ids = [item["id"] for item in ready]
+        self.assertNotIn("R1", ids)
+        self.assertNotIn("C1", ids)
+        self.assertIn("R2", ids)
+        self.assertIn("D1", ids)
+
+    def test_c1_waits_for_o1_and_d1(self) -> None:
+        done = {"B0.1", "P1.3", "O1"}
+        ready_ids = [item["id"] for item in p_back_next.select_next(self.catalog, done, {})]
+        self.assertNotIn("C1", ready_ids)
+        done.add("D1")
+        ready_ids = [item["id"] for item in p_back_next.select_next(self.catalog, done, {})]
+        self.assertIn("C1", ready_ids)
+
+    def test_c2_only_after_c1(self) -> None:
+        done = {item["id"] for item in self.catalog["activities"] if item["id"] != "C2"}
+        ready = p_back_next.select_next(self.catalog, done, {})
+        self.assertEqual([item["id"] for item in ready], ["C2"])
+
+    def test_complete_payload(self) -> None:
+        ids = {item["id"] for item in self.catalog["activities"]}
+        payload = p_back_next.build_payload(self.catalog, ids, {})
+        self.assertTrue(payload["complete"])
+        self.assertIsNone(payload["next"])
+
+    def test_blocked_is_not_complete(self) -> None:
+        done = {item["id"] for item in self.catalog["activities"] if item["id"] != "B0.1"}
+        payload = p_back_next.build_payload(
+            self.catalog, done, {"B0.1": "https://example.test/b01"}
+        )
+        self.assertFalse(payload["complete"])
+        self.assertIsNone(payload["next"])
+
+
+class CatalogContractTests(unittest.TestCase):
+    def test_forbidden_paths_protect_p_front(self) -> None:
+        data = catalog()
+        self.assertIn("src/", data["forbiddenGlobally"])
+        self.assertIn("docs/frontend-sprint.md", data["forbiddenGlobally"])
+        self.assertIn("scripts/p-front/", data["forbiddenGlobally"])
+
+    def test_activity_ids_unique_and_ordered(self) -> None:
+        ids = [item["id"] for item in catalog()["activities"]]
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertEqual(
+            ids,
+            [
+                "P0.1",
+                "P0.2",
+                "P0.3",
+                "P1.1",
+                "P1.2",
+                "P1.3",
+                "P1.4",
+                "B0.1",
+                "R1",
+                "R2",
+                "O1",
+                "D1",
+                "D2",
+                "C1",
+                "C2",
+            ],
+        )
+
+    def test_cloud_is_gated_on_c1(self) -> None:
+        activities = {item["id"]: item for item in catalog()["activities"]}
+        self.assertEqual(activities["C1"]["dependsOn"], ["O1", "D1"])
+        self.assertEqual(activities["C2"]["dependsOn"], ["C1"])
+        self.assertIn("AWS", catalog()["lockedDecisions"]["cloud"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/p-back/test_next.py
+++ b/scripts/p-back/test_next.py
@@ -83,14 +83,14 @@ class SelectNextTests(unittest.TestCase):
         )
 
     def test_skips_busy_and_waits_for_deps(self) -> None:
-        done = {"B0.1", "P0.3"}
+        done = {
+            item["id"]
+            for item in self.catalog["activities"]
+            if item.get("legacyDone") or item["id"] == "B0.1"
+        }
         busy = {"R1": "https://example.test/r1"}
         ready = p_back_next.select_next(self.catalog, done, busy)
-        ids = [item["id"] for item in ready]
-        self.assertNotIn("R1", ids)
-        self.assertNotIn("C1", ids)
-        self.assertIn("R2", ids)
-        self.assertIn("D1", ids)
+        self.assertEqual([item["id"] for item in ready], ["R2", "O1", "D1", "D2"])
 
     def test_c1_waits_for_o1_and_d1(self) -> None:
         done = {"B0.1", "P1.3", "O1"}
@@ -156,6 +156,13 @@ class CatalogContractTests(unittest.TestCase):
         self.assertEqual(activities["C1"]["dependsOn"], ["O1", "D1"])
         self.assertEqual(activities["C2"]["dependsOn"], ["C1"])
         self.assertIn("AWS", catalog()["lockedDecisions"]["cloud"])
+
+    def test_prompt_names_activity_and_forbids_src(self) -> None:
+        activities = {item["id"]: item for item in catalog()["activities"]}
+        prompt = p_back_next.agent_prompt(activities["R1"], catalog())
+        self.assertIn("R1", prompt)
+        self.assertIn("editar src/", prompt)
+        self.assertIn("cursor/p-back-r1-9103", prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Add a **P-back** sprint control plane matching P-front: catalog + `next.py` so one backend agent executes one activity, one branch, one PR.

This is not application architecture. The backend stays a modular monolith.

## Why

After P1.4 it is easy to treat P2 AWS/Terraform as next. `AGENTS.md` priority and `docs/agents/decision-policy.md` say remaining reliability/ops/docs come first, and Render vs ECS is a human ADR (C1).

## What landed

- `docs/backend-sprint.md` — human catalog and rules
- `docs/agents/p-back-orchestrator.md` — agent loop
- `scripts/p-back/activities.json` + `next.py` + `test_next.py`
- Pointers in `AGENTS.md`, `docs/roadmap.md`, `docs/agents/README.md`

## Queue after this merges

`P0.1–P1.4` are `legacyDone`. Next ready activities (first pick **R1**):

1. **R1** payment-link idempotency (`POST /payments`)
2. **R2** capture-after-expiry ops (no invented PayPal refund API)
3. **O1** Render runbook / health vs ready
4. **D1 / D2** threat model and C4 (parallel, disjoint files)
5. **C1** cloud-target ADR
6. **C2** AWS/Terraform only if C1 selected AWS; otherwise a skip commit

## Isolation

- Does not edit `src/` or `scripts/p-front/`
- One-line P-front parallelism pointer only

## Verification

```text
python3 -m unittest scripts/p-back/test_next.py
→ 15 tests OK

python3 scripts/p-back/next.py --json
→ P0.1–P1.4 done (legacyDone); B0.1 inProgress as this PR; ready=[] until merge
```

After merge, `next.py` selects **R1**.

Do not merge from the agent. Do not close issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

