### PR TITLE
[P-back] R2 — Operação de capture após expiração

### DIFF
--- a/docs/architecture/failure-modes.md
+++ b/docs/architecture/failure-modes.md
@@ -19,9 +19,43 @@ Classification lives in `server/src/shared/resilience/retry.ts`. Circuit breaker
 
 - Duplicate PayPal events: unique `(provider, externalEventId)` plus `confirmPayment` claim. See `docs/adr/0002-paypal-webhook-reliability.md`.
 - Out-of-order `CHECKOUT.ORDER.APPROVED` then capture: approved events are stored as `IGNORED`; only `PAYMENT.CAPTURE.COMPLETED` sells listings.
-- Capture after reservation expiry: local confirm rolls back; webhook returns HTTP 200 so PayPal stops; money captured then needs an operational refund.
+- Capture after reservation expiry: local confirm rolls back; webhook returns HTTP 200 so PayPal stops. Money may already be captured at PayPal. See **Capture after reservation expiry** below and `docs/operations/runbook.md`.
 - Capture that cannot resolve a local order yet: HTTP 503 so PayPal retries.
 - Process crash after PayPal capture and before local commit: webhook retry or in-process GET reconciliation (60s, min age 2 minutes, batch 20).
+
+## Capture after reservation expiry
+
+This is a split-brain between PayPal and PostgreSQL. It is intentional: unique listings must not become `SOLD` after the hold expired.
+
+### What the code does (inspected)
+
+- `server/src/shared/utils/paypal.ts` exposes `OrdersCreate`, `OrdersCapture`, and `OrdersGet`. There is **no** refund, void, or capture-reversal helper. `capturePayPalOrder` is defined and unused; checkout `intent` is `CAPTURE`, so funds move when the buyer approves on PayPal, not via that helper.
+- `server/src/types/paypal.d.ts` declares only `OrdersCreateRequest` and `OrdersCaptureRequest`.
+- `confirmPayment` sells listings only when they are still `RESERVED`, `reservedByOrderId` matches the paying order, and `reservationExpiresAt` is in the future. Otherwise it throws HTTP 409 and rolls back the local payment claim.
+- On that 409, `handleWebhook` stores `PaymentWebhookEvent` as `FAILED` / `reservation_expired` and **returns**. The HTTP controller then responds **200**, so PayPal stops retrying.
+- GET reconciliation that sees a remote `COMPLETED` order calls `confirmPayment` and, on 409, logs and skips. It does not create a refund.
+- The expiry sweep may later set the listing `ACTIVE` and the unpaid order `CANCELLED`. A later buyer can reserve the listing. A stale capture still cannot sell it (`reservedByOrderId` must match).
+
+Local end state after this failure (before or after the sweep):
+
+| Field | Typical value |
+|---|---|
+| `Listing.status` | still `RESERVED` with `reservationExpiresAt` in the past, or `ACTIVE` after the sweep (or `RESERVED` by a later order) |
+| `Order.paymentStatus` | `PENDING` |
+| `Order.status` | `PENDING`, then `CANCELLED` after the sweep |
+| `SellerTransaction` | none for this order |
+| `PaymentWebhookEvent` | `FAILED`, `failureReason = reservation_expired` |
+| PayPal | capture completed; funds moved |
+
+### What this repository does not do
+
+There is no in-app refund or void. R2 does **not** add a PayPal refund client, env var, or `Order.paymentStatus = REFUNDED` transition. Guessing that contract would violate `docs/agents/decision-policy.md`.
+
+Operator steps (dashboard only, until a human chooses an API) are in `docs/operations/runbook.md`.
+
+### HUMAN decision required
+
+Should Neon Arsenal later reverse captured funds automatically, and with which **existing** PayPal contract (dashboard-only vs a refund/void API already supported by the account)? Until that decision, do not implement refund code.
 
 ## Reservations and orders
 

--- a/docs/architecture/failure-modes.md
+++ b/docs/architecture/failure-modes.md
@@ -49,7 +49,7 @@ Local end state after this failure (before or after the sweep):
 
 ### What this repository does not do
 
-There is no in-app refund or void. R2 does **not** add a PayPal refund client, env var, or `Order.paymentStatus = REFUNDED` transition. Guessing that contract would violate `docs/agents/decision-policy.md`.
+There is no in-app refund or void. Schema comments allow `Order.paymentStatus = REFUNDED`, but no code path sets it for this failure. R2 does **not** add a PayPal refund client, env var, or that transition. Guessing the PayPal contract would violate `docs/agents/decision-policy.md`.
 
 Operator steps (dashboard only, until a human chooses an API) are in `docs/operations/runbook.md`.
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,0 +1,65 @@
+# Operations runbook
+
+PostgreSQL is the source of truth for listings, orders, and seller balances. PayPal is an unreliable external ledger. This file starts with the capture-after-expiry procedure (P-back **R2**). Deploy, health vs ready, shutdown drain, and `SEED_DEMO_DATA` belong in a later Render ops pass (P-back **O1**).
+
+## Capture after reservation expiry
+
+PayPal can capture funds after the local reservation TTL has elapsed. The marketplace **must not** mark the listing `SOLD` or pay the seller. That invariant is already implemented (`confirmPayment` 409 + webhook HTTP 200). Returning the money is **not** implemented in this repository.
+
+### Code inspection (do not invent an API)
+
+Inspected:
+
+- `server/src/shared/utils/paypal.ts` — `createPayPalOrder`, `capturePayPalOrder` (unused), `getPayPalOrder`. No refund/void function.
+- `server/src/types/paypal.d.ts` — only OrdersCreate and OrdersCapture types.
+- `server/src/modules/payments/payments.service.ts` — expired capture → webhook event `FAILED` / `reservation_expired`; reconciliation skips the same 409.
+- No `PAYPAL_*` refund environment variable exists.
+
+Do not add a PayPal refund client, capture-void helper, or new env var until a human selects a provider contract.
+
+### How to detect
+
+1. Logs: `paypal webhook not applied: reservation expired` or `paypal reconciliation skipped: reservation expired`.
+2. Database:
+
+```sql
+SELECT e."externalEventId", e.status, e."failureReason", e."orderId",
+       o."paypalOrderId", o.status AS order_status, o."paymentStatus",
+       i."listingId"
+FROM "PaymentWebhookEvent" e
+JOIN "Order" o ON o.id = e."orderId"
+JOIN "OrderItem" i ON i."orderId" = o.id
+WHERE e."failureReason" = 'reservation_expired'
+ORDER BY e."receivedAt" DESC;
+```
+
+3. Confirm the listing is **not** `SOLD` and there is **no** `SellerTransaction` for that `orderId`.
+4. In the PayPal account (sandbox or live, matching `PAYPAL_MODE`), open the captured payment for `Order.paypalOrderId`. If PayPal shows captured funds, local and remote ledgers disagree.
+
+### What to do (manual, out of band)
+
+Until the HUMAN decision below is answered:
+
+1. Do **not** set `Listing.status = SOLD`.
+2. Do **not** set `Order.paymentStatus = PAID` or create a `SellerTransaction`.
+3. Do **not** call undocumented PayPal URLs from this app.
+4. If funds were captured, reverse them in the **PayPal account UI** for that capture / order id (the same dashboard used to inspect sandbox or live payments). This runbook does not specify a REST path or request body; that would be inventing a contract this repo does not implement.
+5. After a dashboard reversal, local rows stay `PENDING` / `CANCELLED` and `FAILED`. There is no local `REFUNDED` write path. Leave them; the listing is already eligible for another buyer once `ACTIVE`.
+6. If the listing is still `RESERVED` with `reservationExpiresAt` in the past, the in-process expiry sweep (30s) will release it. Do not force `SOLD`.
+
+### What not to do
+
+- Replay the webhook hoping it will sell the listing. It will 409 again and stay `FAILED`.
+- Rely on GET reconciliation to fix money. It will skip the 409 forever.
+- Implement `OrdersCapture` retries or a new refund helper as part of incident response.
+
+### HUMAN decision (required before any refund code)
+
+1. **Decision:** Should capture-after-expiry stay dashboard-only, or should the API reverse funds automatically?
+2. **Options:**
+   - A. Dashboard only (current). Operators follow this runbook. No new PayPal contract in the repo.
+   - B. Automated reverse, but only after documenting the **existing** PayPal API the account actually supports (refund vs void vs other), with timeout/idempotency, in a new activity — not guessed here.
+3. **Consequences:** A leaves rare captured-but-unsold money as a manual process. B without an inspected contract risks calling the wrong PayPal operation (voiding an already-captured order, double-refund, or marking `SOLD` incorrectly).
+4. **Recommendation:** Keep **A** until someone inspects the live/sandbox PayPal account and names the exact API. R2 must not guess.
+
+See also `docs/architecture/failure-modes.md` and `docs/adr/0002-paypal-webhook-reliability.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Document capture-after-expiry operations. Unique listings must not become `SOLD` after the hold expired, even if PayPal already captured money.

## Inspection

There is **no** PayPal refund/void helper in this repo:

- `server/src/shared/utils/paypal.ts` — create / unused capture / get only
- `server/src/types/paypal.d.ts` — OrdersCreate and OrdersCapture only
- Schema comments allow `REFUNDED`; no path writes it for this failure

R2 does not invent that API.

## What landed

- `docs/architecture/failure-modes.md` — local vs PayPal state, webhook 200, reconciliation skip
- `docs/operations/runbook.md` — detect, inspect, dashboard-only steps, **HUMAN** gate before any refund code

O1 can extend the runbook with Render health/seed. This PR only covers the expiry-capture gap.

## HUMAN decision (required before refund code)

Should capture-after-expiry stay PayPal-dashboard-only, or should the API reverse funds automatically using a **documented existing** PayPal contract?

Recommendation: keep dashboard-only until that contract is inspected. Do not guess refund vs void.

## Verification

Docs only. Grep shows no refund client under `server/src`. No `src/` edits.

Do not merge from the agent. Do not close issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

