### PR TITLE
[P-back] O1 — Runbook Render e alinhamento health/ready

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,6 +1,93 @@
 # Operations runbook
 
-PostgreSQL is the source of truth for listings, orders, and seller balances. PayPal is an unreliable external ledger. This file starts with the capture-after-expiry procedure (P-back **R2**). Deploy, health vs ready, shutdown drain, and `SEED_DEMO_DATA` belong in a later Render ops pass (P-back **O1**).
+PostgreSQL is the source of truth for listings, orders, and seller balances. PayPal is an unreliable external ledger. Production compute for the API is **Render** (`render.yaml`), not AWS/ECS.
+
+## Deploy
+
+API service: `neon-arsenal-api` (Docker, `server/Dockerfile`, context `server/`).
+
+1. Render builds the image, then starts the container.
+2. `server/entrypoint.sh` runs `prisma migrate deploy`.
+3. If `SEED_DEMO_DATA=true`, the entrypoint also runs `npm run db:seed`.
+4. `node dist/index.js` starts. It binds **`0.0.0.0:$PORT`** (`PORT` is `3001` in the Blueprint). If `SEED_DEMO_DATA=true`, `index.ts` seeds again. Both passes upsert; they do not overwrite existing rows.
+5. In-process jobs start after listen: reservation expiry (30s) and PayPal GET reconciliation (60s).
+
+The Blueprint also defines static `neon-arsenal-web`. The public demo often uses Vercel for the Vite client and Render only for the API; set `FRONTEND_URL` on the API and `API_URL` on the frontend. Do not invent env vars.
+
+Secrets (`PAYPAL_*`, `RESEND_API_KEY`, `EMAIL_FROM`, `JWT_*`) stay in Render env / `sync: false`. Never commit them.
+
+Rollback: Render Dashboard → previous deploy. Schema rollback is a new Prisma migration, not `migrate down`.
+
+## Health vs ready
+
+The API exposes two GET routes. Render has **one** probe (`healthCheckPath`).
+
+| Probe | Path | Success | Failure | Who uses it |
+|---|---|---|---|---|
+| Liveness | `GET /health` | 200 `{ status: "ok" }` even during SIGTERM drain | Process not listening | Docker `HEALTHCHECK` in `server/Dockerfile` |
+| Readiness | `GET /ready` | 200 `{ status: "ready" }` when PostgreSQL answers `SELECT 1` | 503 `unavailable` (DB down) or 503 `shutting_down` (SIGTERM/SIGINT) | Render `healthCheckPath: /ready` |
+
+Do not point Render at `/health`. That would keep a draining or DB-less instance in rotation. Do not point Docker HEALTHCHECK at `/ready`; a drain would look like a dead container and Docker would restart it mid-shutdown.
+
+A new Render deploy does not take traffic until `GET /ready` is 2xx/3xx (Postgres up, not shutting down).
+
+## Shutdown drain
+
+On SIGTERM/SIGINT (`docs/adr/0005-external-retry-and-graceful-shutdown.md`):
+
+1. Mark shutting down → `GET /ready` is 503 `shutting_down`.
+2. Stop reservation-expiry and PayPal-reconciliation timers (in-flight sweeps may finish).
+3. `server.close()`: no new HTTP connections; in-flight requests get **10s** (`SHUTDOWN_DRAIN_MS`), then remaining connections are closed.
+4. Disconnect Prisma.
+5. Shut down OpenTelemetry exporters.
+
+`GET /health` stays 200 until exit.
+
+Render `maxShutdownDelaySeconds` is **30** in `render.yaml` (platform default). The app drain is 10s, so the platform wait is enough. If Render SIGKILLs before 10s, in-flight HTTP is dropped; payment recovery is still webhook + GET reconciliation.
+
+Zero-downtime: Render starts the new instance, waits for `/ready`, shifts traffic, then SIGTERM on the old instance. Failed `/ready` on the old instance after SIGTERM is expected.
+
+## Seed on boot (`SEED_DEMO_DATA`)
+
+Existing env var. Do not add another.
+
+| Value | Effect |
+|---|---|
+| `true` (current Blueprint) | Demo catalog upserts on every boot (entrypoint + `index.ts`). Portfolio/demo only. |
+| unset / not `true` | No seed. Use this for a real marketplace. |
+
+Re-running seed is idempotent. It still touches the database on every deploy when `true`. To stop seeding, set `SEED_DEMO_DATA` to a value other than `true` in Render (or change the Blueprint). Do not invent `SEED_ON_MIGRATE`.
+
+## Inspect payments and reservations
+
+Listings: `ACTIVE → RESERVED → SOLD` (or back to `ACTIVE` on expiry). Payment confirmation cannot sell an expired or re-reserved listing.
+
+```sql
+-- Holds that should expire
+SELECT id, status, "reservedByOrderId", "reservationExpiresAt"
+FROM "Listing"
+WHERE status = 'RESERVED'
+ORDER BY "reservationExpiresAt";
+
+-- Unpaid orders still pending vs cancelled after expiry sweep
+SELECT id, status, "paymentStatus", "paypalOrderId", "updatedAt"
+FROM "Order"
+WHERE "paymentStatus" = 'PENDING'
+ORDER BY "updatedAt" DESC
+LIMIT 50;
+
+-- Webhook outcomes
+SELECT "externalEventId", "eventType", status, "failureReason", "orderId", "receivedAt"
+FROM "PaymentWebhookEvent"
+ORDER BY "receivedAt" DESC
+LIMIT 50;
+```
+
+Logs (no secrets): `paypal webhook received`, `paypal capture webhook processed`, `paypal webhook duplicate ignored`, `paypal webhook not applied: reservation expired`, `paypal reconciliation skipped: reservation expired`, `graceful shutdown started`.
+
+Capture after the reservation TTL is a split-brain with PayPal. Procedure: **Capture after reservation expiry** below.
+
+---
 
 ## Capture after reservation expiry
 

--- a/render.yaml
+++ b/render.yaml
@@ -17,6 +17,8 @@ services:
       - key: PORT
         value: "3001"
       - key: SEED_DEMO_DATA
+        # Demo catalog for the public portfolio. Idempotent upserts. Set false
+        # on a real marketplace so boots do not re-run seed. See docs/operations/runbook.md.
         value: "true"
       - key: DATABASE_URL
         fromDatabase:
@@ -46,7 +48,12 @@ services:
         value: "10000"
       - key: FRONTEND_URL
         sync: false
-    healthCheckPath: /health
+    # Render has a single probe. Use readiness: Postgres reachable and not draining.
+    # Docker HEALTHCHECK in server/Dockerfile stays on /health (liveness) so a
+    # SIGTERM drain does not look like a dead container.
+    healthCheckPath: /ready
+    # App drain is 10s (SHUTDOWN_DRAIN_MS). Default platform delay is 30s.
+    maxShutdownDelaySeconds: 30
     autoDeploy: true
 
   - type: web

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -119,7 +119,7 @@ export const openApiSpec = {
         tags: ["Health"],
         summary: "Readiness check",
         description:
-          "Returns 200 when PostgreSQL is reachable. Returns 503 `unavailable` when the database check fails, or 503 `shutting_down` after SIGTERM/SIGINT so load balancers can drain the instance.",
+          "Returns 200 when PostgreSQL is reachable. Returns 503 `unavailable` when the database check fails, or 503 `shutting_down` after SIGTERM/SIGINT so Render (`healthCheckPath: /ready`) can stop sending traffic. Liveness remains `GET /health`.",
         security: [],
         responses: {
           200: { description: "Process can serve traffic", content: { "application/json": { schema: { type: "object", properties: { status: { type: "string", example: "ready" } } } } } },

--- a/server/src/shared/lifecycle/shutdown.ts
+++ b/server/src/shared/lifecycle/shutdown.ts
@@ -4,7 +4,8 @@ import { disconnectPrisma } from "../database/prisma.js";
 import { shutdownTelemetry } from "../observability/sdk.js";
 import { beginShutdown, isProcessShuttingDown } from "./state.js";
 
-/** Bound wait for in-flight HTTP requests before connections are forced closed. */
+/** Bound wait for in-flight HTTP requests before connections are forced closed.
+ * Keep this below Render `maxShutdownDelaySeconds` (30 in render.yaml). */
 export const SHUTDOWN_DRAIN_MS = 10_000;
 
 export type GracefulShutdownParams = {

--- a/server/src/shared/routes/__tests__/health.test.ts
+++ b/server/src/shared/routes/__tests__/health.test.ts
@@ -38,11 +38,23 @@ describe("Health routes", () => {
   });
 
   describe("GET /health", () => {
+    beforeEach(async () => {
+      const { resetLifecycleForTests } = await import("../../lifecycle/state.js");
+      resetLifecycleForTests();
+    });
+
     it("returns 200 and status ok", async () => {
       const res = await fetch(`${baseUrl}/health`);
       expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual({ status: "ok" });
+      expect(await res.json()).toEqual({ status: "ok" });
+    });
+
+    it("stays 200 while the process is shutting down", async () => {
+      const { beginShutdown } = await import("../../lifecycle/state.js");
+      beginShutdown();
+      const res = await fetch(`${baseUrl}/health`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ status: "ok" });
     });
   });
 

--- a/server/src/shared/routes/health.routes.ts
+++ b/server/src/shared/routes/health.routes.ts
@@ -5,12 +5,18 @@ import { logger } from "../logger.js";
 
 const router = Router();
 
-/** Liveness: process is up */
+/**
+ * Liveness: the process is up. Used by Docker HEALTHCHECK.
+ * Stays 200 during SIGTERM drain so a liveness probe does not kill a draining instance.
+ */
 router.get("/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok" });
 });
 
-/** Readiness: app can serve traffic (e.g. DB reachable) */
+/**
+ * Readiness: this instance may receive traffic.
+ * Used by Render `healthCheckPath`. 503 while shutting down or if PostgreSQL is unreachable.
+ */
 router.get("/ready", async (_req: Request, res: Response) => {
   if (isProcessShuttingDown()) {
     res.status(503).json({ status: "shutting_down" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Align Render’s single health probe with readiness, and document deploy / drain / seed.

## Mapping

| Probe | Path | Role |
|---|---|---|
| Render `healthCheckPath` | `GET /ready` | Postgres up, not shutting down |
| Docker `HEALTHCHECK` | `GET /health` | Process alive; stays 200 during the 10s drain |

`maxShutdownDelaySeconds: 30` (drain is 10s). No new env vars. `SEED_DEMO_DATA=true` stays on the demo Blueprint and is documented.

## Verification

```text
npx vitest run src/shared/routes/__tests__/health.test.ts src/shared/lifecycle/__tests__/shutdown.test.ts
→ 7 passed (including /health 200 during shutdown)
```

Do not merge from the agent. Do not close issues. No `src/` (frontend) changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

