### PR TITLE
[P-back] C1 — ADR do alvo de cloud (Render vs ECS)

### DIFF
--- a/docs/adr/0007-cloud-target-render.md
+++ b/docs/adr/0007-cloud-target-render.md
@@ -1,0 +1,48 @@
+# ADR 0007 — Cloud production target (Render vs ECS)
+
+## Status
+
+Accepted
+
+## Context
+
+The modular monolith already runs in production-shaped config as **Render** (`render.yaml`): Docker API `neon-arsenal-api`, managed PostgreSQL `neon-arsenal-db`, env-based secrets, `healthCheckPath: /ready`. Operations are in `docs/operations/runbook.md`. C4 of the live system is `docs/architecture/c4.md`.
+
+`AGENTS.md` and the P2 roadmap still show a **portfolio sketch**:
+
+```text
+Internet → Load Balancer → ECS/Fargate API → RDS → Secrets Manager → CloudWatch
+```
+
+That sketch was never provisioned. There is no Terraform, no AWS account layout in this repo, and no measured scaling trigger that the monolith-on-Render cannot absorb (`docs/architecture/scaling-path.md`).
+
+P-back activity **C1** must say, in one ADR, whether that sketch is a **committed migration** or a **future option**. Implementing AWS (C2) is forbidden unless this ADR selects AWS. `docs/agents/decision-policy.md` forbids an agent from silently changing the cloud/architecture boundary to ECS.
+
+A committed ECS migration would be a material cloud-architecture change (new runtime, networking, secrets, observability). That is a **human** decision. This ADR does **not** make it.
+
+## Decision
+
+1. **Current production target is Render.** The API, database, probes, drain, and secrets model in `render.yaml` / the runbook are the system to operate and interview against.
+2. **The ECS/Fargate diagram is a future option, not a committed migration.** Keep it as a sentence in the roadmap so the portfolio can discuss an AWS path. Do not treat ALB, ECS, RDS, or Secrets Manager as live. Do not write Terraform in C2.
+3. **Frontend hosting is orthogonal.** The documented split is Vercel (Vite) + Render (API). The Blueprint also defines Render static `neon-arsenal-web`. Neither is ECS.
+4. **PostgreSQL remains the source of truth** wherever the process runs. Moving compute to Fargate would not change reservation, payment, or webhook invariants.
+5. **Revisit only with a human supersession** of this ADR, plus a concrete reason such as: a measured scaling trigger that Render cannot meet, a compliance requirement for a specific AWS control, or an explicit owner request to migrate. Until then, agents must not “start AWS to look senior.”
+
+Rejected alternatives:
+
+- Silently selecting ECS/Fargate as the production target and implementing Terraform in the next PR.
+- Deleting the ECS sketch so interviews cannot discuss a future AWS option.
+- Dual “we are on Render and also on ECS” language that makes C4 and the runbook lie.
+
+## Consequences
+
+- **C2 (AWS/Terraform) is a skip:** land a commit whose subject contains `[P-back] C2` and add no `infra/` Terraform. Do not invent VPC/Secrets Manager layouts.
+- Interview drawings should start from `docs/architecture/c4.md` (Render + Postgres + PayPal/Resend). The P2 ECS boxes are labeled **optional future**, not current.
+- Cost, TLS, deploys, and logs stay on Render (and Vercel for the common SPA). Optional OpenTelemetry (`OTEL_ENABLED`) is not CloudWatch.
+- A later owner who wants AWS should change this ADR’s status to **Superseded** with a new ADR that scopes the migration; only then may C2-style Terraform exist.
+
+## What this ADR does not change
+
+- `render.yaml` (already the production Blueprint).
+- Application behavior, PayPal contracts, or domain invariants.
+- The open R2 human decision on capture-after-expiry refund/void (dashboard vs a real PayPal API).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,23 +93,26 @@ See `docs/performance.md`, `docs/architecture/scaling-path.md` and `docs/adr/000
 
 ## P2 — Cloud and operational maturity
 
-Target architecture:
+**Current production** (see `docs/adr/0007-cloud-target-render.md`):
 
 ```text
 Internet
    ↓
-Load Balancer
+Vite SPA (Vercel, or Render static neon-arsenal-web)
    ↓
-ECS/Fargate API
+Render web service neon-arsenal-api (Docker)
    ↓
-RDS PostgreSQL
-   ↓
-Secrets Manager
-   ↓
-CloudWatch + OpenTelemetry
+Render PostgreSQL neon-arsenal-db
+   + PayPal / Resend
 ```
 
-Do **not** start AWS/Terraform from this list. Remaining backend work is the P-back catalog (`docs/backend-sprint.md`): payment-link idempotency, capture-after-expiry ops, Render runbook, threat model, C4, then a **cloud-target ADR (C1)**. Implement AWS only if that ADR selects it (C2). Render (`render.yaml`) is the current production deploy.
+The ECS/Fargate sketch below is a **future option**, not a committed migration. Do not provision it. C2 must skip Terraform while ADR 0007 stands.
+
+```text
+Internet → Load Balancer → ECS/Fargate API → RDS → Secrets Manager → CloudWatch
+```
+
+Remaining P-back work after this ADR: **C2 skip commit** (no AWS). Catalog: `docs/backend-sprint.md`. Live topology: `docs/architecture/c4.md`. Operations: `docs/operations/runbook.md`.
 
 ## Documentation deliverables
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P-back **C1**: ADR 0007 records the cloud production target.

- **Current production:** Render (`render.yaml` — API + Postgres).
- **ECS/Fargate P2 sketch:** a **future option**, not a committed migration.
- This agent did **not** select ECS. A committed AWS move would be a human supersession of this ADR.

`docs/roadmap.md` P2 section now matches that decision. No Terraform, no `render.yaml` change, no `src/` / `server/` behavior.

## Acceptance

- [x] One ADR states Render today vs ECS as future option (not committed)
- [x] Artifact is the ADR (+ roadmap pointer). No AWS provisioning
- [x] Did not silently pick ECS (`docs/agents/decision-policy.md`)

## C2 implication

While ADR 0007 stands, **C2 is a skip commit** (`[P-back] C2`) with no `infra/` Terraform. That is a **separate** activity — not this PR.

Do not merge from this agent. Do not close issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

