### PR TITLE
[P-back] C2 — Skip Terraform (Render kept)

### DIFF
--- a/docs/adr/0007-cloud-target-render.md
+++ b/docs/adr/0007-cloud-target-render.md
@@ -36,7 +36,7 @@ Rejected alternatives:
 
 ## Consequences
 
-- **C2 (AWS/Terraform) is a skip:** land a commit whose subject contains `[P-back] C2` and add no `infra/` Terraform. Do not invent VPC/Secrets Manager layouts.
+- **C2 (AWS/Terraform) is a skip:** see `docs/adr/0008-c2-skip-terraform.md`. Do not invent VPC/Secrets Manager layouts.
 - Interview drawings should start from `docs/architecture/c4.md` (Render + Postgres + PayPal/Resend). The P2 ECS boxes are labeled **optional future**, not current.
 - Cost, TLS, deploys, and logs stay on Render (and Vercel for the common SPA). Optional OpenTelemetry (`OTEL_ENABLED`) is not CloudWatch.
 - A later owner who wants AWS should change this ADR’s status to **Superseded** with a new ADR that scopes the migration; only then may C2-style Terraform exist.

--- a/docs/adr/0008-c2-skip-terraform.md
+++ b/docs/adr/0008-c2-skip-terraform.md
@@ -1,0 +1,23 @@
+# ADR 0008 — C2 skip: no AWS/Terraform
+
+## Status
+
+Accepted
+
+## Context
+
+P-back **C2** is conditional on **C1**. ADR 0007 kept **Render** as the production target and classified ECS/Fargate as a future option, not a committed migration.
+
+C2 acceptance: if C1 kept Render, do not add Terraform; land a skip commit whose subject contains `[P-back] C2`.
+
+## Decision
+
+1. **Do not add Terraform, an `infra/` tree, VPC, ECS, RDS, or Secrets Manager layout.** ADR 0007 did not select AWS.
+2. Production remains Render (`render.yaml`). PostgreSQL remains the source of truth.
+3. A later human supersession of ADR 0007 is required before any AWS IaC exists in this repository.
+
+## Consequences
+
+- The P-back catalog can close: this commit is the C2 skip.
+- Agents must not “fill in” AWS to look complete. Interview cloud talk starts from C4 + ADR 0007.
+- R2 capture-after-expiry refund/void remains an unrelated open human decision.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P-back **C2** is a **skip**. ADR 0007 kept Render; this PR does **not** add Terraform, `infra/`, VPC, ECS, RDS, or Secrets Manager.

- New `docs/adr/0008-c2-skip-terraform.md` records the skip
- ADR 0007 now points at that skip instead of “land a C2 commit” as unfinished work

No `src/` or `server/` changes. After this lands on `main`, `python3 scripts/p-back/next.py` should report the catalog complete.

## Acceptance

- [x] C1 kept Render → no Terraform
- [x] Skip commit subject contains `[P-back] C2`
- [x] No `src/` changes

Do not merge from this agent. Do not close issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2500f3-aefd-4f1b-a4f8-222e7ed09103&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

