### PR TITLE
#82 — [Frontend] Enviar Idempotency-Key na criação de pedido e reutilizar a mesma chave em retry

### DIFF
--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api, tokenStorage } from "../client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("api extra headers", () => {
+  beforeEach(() => {
+    tokenStorage.clear();
+    tokenStorage.setTokens("access-token", "refresh-token");
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    tokenStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards Idempotency-Key on post without dropping auth", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(jsonResponse({ id: "order-1" }, 201));
+
+    await api.post(
+      "/orders",
+      { items: [{ listingId: "listing-ak" }] },
+      { headers: { "Idempotency-Key": "retry-key-1" } },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/orders$/);
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "Idempotency-Key": "retry-key-1",
+      Authorization: "Bearer access-token",
+    });
+  });
+
+  it("forwards Idempotency-Key on patch", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(jsonResponse({ id: "order-1" }));
+
+    await api.patch(
+      "/orders/order-1/status",
+      { status: "PAID" },
+      { headers: { "Idempotency-Key": "patch-key" } },
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe("PATCH");
+    expect(init?.headers).toMatchObject({
+      "Idempotency-Key": "patch-key",
+      Authorization: "Bearer access-token",
+    });
+  });
+});

--- a/src/api/__tests__/orders.test.ts
+++ b/src/api/__tests__/orders.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createOrder } from "../orders";
+
+const post = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    post: (...args: unknown[]) => post(...args),
+  },
+}));
+
+describe("createOrder", () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue({ id: "order-1" });
+  });
+
+  it("sends Idempotency-Key on POST /orders", async () => {
+    await createOrder(
+      { items: [{ listingId: "listing-ak" }] },
+      { idempotencyKey: "11111111-1111-4111-8111-111111111111" },
+    );
+
+    expect(post).toHaveBeenCalledWith(
+      "/orders",
+      { items: [{ listingId: "listing-ak" }] },
+      {
+        headers: {
+          "Idempotency-Key": "11111111-1111-4111-8111-111111111111",
+        },
+      },
+    );
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -43,6 +43,27 @@ async function refreshAccessToken(): Promise<string> {
   return data.accessToken;
 }
 
+function mergeHeaders(
+  ...sources: Array<HeadersInit | undefined>
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const source of sources) {
+    if (!source) continue;
+    if (source instanceof Headers) {
+      source.forEach((value, key) => {
+        merged[key] = value;
+      });
+    } else if (Array.isArray(source)) {
+      for (const [key, value] of source) {
+        merged[key] = value;
+      }
+    } else {
+      Object.assign(merged, source);
+    }
+  }
+  return merged;
+}
+
 async function request<T>(
   path: string,
   options: RequestInit & { skipAuth?: boolean } = {},
@@ -54,12 +75,11 @@ async function request<T>(
   let access = !skipAuth ? tokenStorage.getAccessToken() : null;
 
   const doFetch = (token: string | null) => {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      ...(init.headers as Record<string, string>),
-    };
-    if (token)
-      (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+    const headers = mergeHeaders(
+      { "Content-Type": "application/json" },
+      init.headers,
+    );
+    if (token) headers.Authorization = `Bearer ${token}`;
     return fetch(url, { ...init, headers });
   };
 

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -1,8 +1,13 @@
 import { api } from "./client";
 import type { Order } from "@/types/api";
 
-export function createOrder(body: { items: { listingId: string }[] }): Promise<Order & { totalAmount?: number }> {
-  return api.post<Order & { totalAmount?: number }>("/orders", body);
+export function createOrder(
+  body: { items: { listingId: string }[] },
+  options: { idempotencyKey: string },
+): Promise<Order & { totalAmount?: number }> {
+  return api.post<Order & { totalAmount?: number }>("/orders", body, {
+    headers: { "Idempotency-Key": options.idempotencyKey },
+  });
 }
 
 export function listOrders(): Promise<Order[]> {
@@ -13,13 +18,16 @@ export function getOrder(id: string): Promise<Order> {
   return api.get<Order>(`/orders/${id}`);
 }
 
-export function updateOrderStatus(orderId: string, status: string): Promise<Order> {
+export function updateOrderStatus(
+  orderId: string,
+  status: string,
+): Promise<Order> {
   return api.patch<Order>(`/orders/${orderId}/status`, { status });
 }
 
 export function updateOrderTracking(
   orderId: string,
-  body: { trackingCode?: string; trackingCarrier?: string }
+  body: { trackingCode?: string; trackingCarrier?: string },
 ): Promise<Order> {
   return api.patch<Order>(`/orders/${orderId}/tracking`, body);
 }

--- a/src/lib/__tests__/checkoutIdempotency.test.ts
+++ b/src/lib/__tests__/checkoutIdempotency.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  IDEMPOTENCY_KEY_MAX_LENGTH,
+  resolveCheckoutIdempotencyKey,
+} from "../checkoutIdempotency";
+
+describe("resolveCheckoutIdempotencyKey", () => {
+  it("reuses the key while the listing set is unchanged", () => {
+    const first = resolveCheckoutIdempotencyKey(
+      null,
+      ["b", "a"],
+      () => "key-1",
+    );
+    const second = resolveCheckoutIdempotencyKey(
+      first,
+      ["a", "b"],
+      () => "key-2",
+    );
+
+    expect(first.key).toBe("key-1");
+    expect(second.key).toBe("key-1");
+    expect(second.fingerprint).toBe(first.fingerprint);
+  });
+
+  it("issues a new key when the listing set changes", () => {
+    const first = resolveCheckoutIdempotencyKey(null, ["a"], () => "key-1");
+    const second = resolveCheckoutIdempotencyKey(
+      first,
+      ["a", "c"],
+      () => "key-2",
+    );
+
+    expect(second.key).toBe("key-2");
+    expect(second.fingerprint).not.toBe(first.fingerprint);
+  });
+
+  it("rejects keys longer than the API maximum", () => {
+    expect(() =>
+      resolveCheckoutIdempotencyKey(null, ["a"], () =>
+        "k".repeat(IDEMPOTENCY_KEY_MAX_LENGTH + 1),
+      ),
+    ).toThrow(/1–128/);
+  });
+});

--- a/src/lib/checkoutIdempotency.ts
+++ b/src/lib/checkoutIdempotency.ts
@@ -1,0 +1,35 @@
+/** Max length accepted by `POST /orders` `Idempotency-Key`. */
+export const IDEMPOTENCY_KEY_MAX_LENGTH = 128;
+
+export type CheckoutIdempotencyState = {
+  fingerprint: string;
+  key: string;
+};
+
+export function listingSetFingerprint(listingIds: string[]): string {
+  return [...new Set(listingIds)].sort().join(",");
+}
+
+export function createCheckoutIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Stable key for one checkout attempt. Reuses the previous UUID while the
+ * listing id set is unchanged; a different set starts a new attempt.
+ */
+export function resolveCheckoutIdempotencyKey(
+  current: CheckoutIdempotencyState | null,
+  listingIds: string[],
+  createKey: () => string = createCheckoutIdempotencyKey,
+): CheckoutIdempotencyState {
+  const fingerprint = listingSetFingerprint(listingIds);
+  if (current?.fingerprint === fingerprint && current.key) {
+    return current;
+  }
+  const key = createKey();
+  if (!key || key.length > IDEMPOTENCY_KEY_MAX_LENGTH) {
+    throw new Error("Idempotency-Key must be 1–128 characters");
+  }
+  return { fingerprint, key };
+}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useCart } from "@/contexts/CartContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -6,6 +6,10 @@ import { createOrder } from "@/api/orders";
 import { createPaymentLink } from "@/api/payments";
 import { EmptyState } from "@/components/page-state";
 import { Button } from "@/components/ui/button";
+import {
+  resolveCheckoutIdempotencyKey,
+  type CheckoutIdempotencyState,
+} from "@/lib/checkoutIdempotency";
 
 export default function Checkout() {
   const { items, totalPrice } = useCart();
@@ -13,6 +17,8 @@ export default function Checkout() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const inFlightRef = useRef(false);
+  const idempotencyRef = useRef<CheckoutIdempotencyState | null>(null);
   const serviceFee = totalPrice * 0.05;
   const total = totalPrice * 1.05;
 
@@ -57,12 +63,20 @@ export default function Checkout() {
   }
 
   const handlePay = async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
     setError(null);
     setLoading(true);
     try {
-      const order = await createOrder({
-        items: items.map(({ listing }) => ({ listingId: listing.id })),
-      });
+      const listingIds = items.map(({ listing }) => listing.id);
+      idempotencyRef.current = resolveCheckoutIdempotencyKey(
+        idempotencyRef.current,
+        listingIds,
+      );
+      const order = await createOrder(
+        { items: listingIds.map((listingId) => ({ listingId })) },
+        { idempotencyKey: idempotencyRef.current.key },
+      );
       const payment = await createPaymentLink({ orderId: order.id });
       if (payment.approvalUrl) {
         window.location.href = payment.approvalUrl;
@@ -74,6 +88,7 @@ export default function Checkout() {
     } catch (e) {
       setError(e instanceof Error ? e.message : "Falha ao criar pedido");
     } finally {
+      inFlightRef.current = false;
       setLoading(false);
     }
   };
@@ -146,7 +161,9 @@ export default function Checkout() {
           >
             {loading
               ? "Abrindo o PayPal..."
-              : `Pagar com PayPal — $${total.toFixed(2)}`}
+              : error
+                ? "Tentar novamente"
+                : `Pagar com PayPal — $${total.toFixed(2)}`}
           </Button>
           <p className="text-center text-xs text-muted-foreground">
             Sem confirmação local até o retorno do PayPal.

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Checkout from "../Checkout";
@@ -34,9 +34,9 @@ vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
 }));
 
-function listing(price = 100): Listing {
+function listing(price = 100, id = "listing-ak"): Listing {
   return {
-    id: "listing-ak",
+    id,
     productId: "prod-1",
     sellerId: "seller-1",
     floatValue: 0.15 as unknown as Listing["floatValue"],
@@ -64,15 +64,41 @@ function listing(price = 100): Listing {
   } as Listing;
 }
 
-function renderCheckout() {
-  return render(
+function CheckoutHarness({ nonce = 0 }: { nonce?: number }) {
+  void nonce;
+  return (
     <MemoryRouter>
       <Checkout />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
+function renderCheckout(nonce = 0) {
+  return render(<CheckoutHarness nonce={nonce} />);
+}
+
+function asCustomer() {
+  authState.isAuthenticated = true;
+  authState.user = {
+    id: "u1",
+    name: "Buyer",
+    email: "buyer@test.com",
+    role: "CUSTOMER",
+  } as User;
+}
+
+function idempotencyKeyOf(call: unknown[]): string {
+  const options = call[1] as { idempotencyKey: string };
+  return options.idempotencyKey;
+}
+
 describe("Checkout", () => {
+  const uuidKeys = [
+    "11111111-1111-4111-8111-111111111111",
+    "22222222-2222-4222-8222-222222222222",
+    "33333333-3333-4333-8333-333333333333",
+  ];
+
   beforeEach(() => {
     cartState.items = [];
     cartState.totalPrice = 0;
@@ -81,6 +107,14 @@ describe("Checkout", () => {
     authState.isAuthenticated = false;
     createOrder.mockReset();
     createPaymentLink.mockReset();
+    let uuidIndex = 0;
+    vi.spyOn(crypto, "randomUUID").mockImplementation(
+      () => uuidKeys[uuidIndex++] ?? "overflow-uuid",
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("keeps empty-cart gate and does not offer PayPal", () => {
@@ -102,13 +136,7 @@ describe("Checkout", () => {
   it("shows 5% fee and does not claim payment succeeded", () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
-    authState.isAuthenticated = true;
-    authState.user = {
-      id: "u1",
-      name: "Buyer",
-      email: "buyer@test.com",
-      role: "CUSTOMER",
-    } as User;
+    asCustomer();
 
     renderCheckout();
 
@@ -126,13 +154,7 @@ describe("Checkout", () => {
   it("calls createOrder + createPaymentLink and errors without claiming success", async () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
-    authState.isAuthenticated = true;
-    authState.user = {
-      id: "u1",
-      name: "Buyer",
-      email: "buyer@test.com",
-      role: "CUSTOMER",
-    } as User;
+    asCustomer();
     createOrder.mockResolvedValue({ id: "order-1" });
     createPaymentLink.mockResolvedValue({});
 
@@ -140,9 +162,10 @@ describe("Checkout", () => {
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => {
-      expect(createOrder).toHaveBeenCalledWith({
-        items: [{ listingId: "listing-ak" }],
-      });
+      expect(createOrder).toHaveBeenCalledWith(
+        { items: [{ listingId: "listing-ak" }] },
+        { idempotencyKey: uuidKeys[0] },
+      );
       expect(createPaymentLink).toHaveBeenCalledWith({ orderId: "order-1" });
     });
 
@@ -151,5 +174,108 @@ describe("Checkout", () => {
     ).toBeTruthy();
     expect(cartState.clearCart).not.toHaveBeenCalled();
     expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Tentar novamente" }),
+    ).toBeTruthy();
+  });
+
+  it("sends a non-empty Idempotency-Key of at most 128 characters", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    asCustomer();
+    createOrder.mockRejectedValue(new Error("Falha de rede"));
+
+    renderCheckout();
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
+
+    const key = idempotencyKeyOf(createOrder.mock.calls[0]);
+    expect(key).toBe(uuidKeys[0]);
+    expect(key.length).toBeGreaterThan(0);
+    expect(key.length).toBeLessThanOrEqual(128);
+  });
+
+  it("reuses the same Idempotency-Key when retrying with the same listings", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    asCustomer();
+    createOrder.mockRejectedValue(new Error("Falha de rede"));
+
+    renderCheckout();
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Falha de rede")).toBeTruthy();
+      expect(
+        screen.getByRole("button", { name: "Tentar novamente" }),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(2));
+
+    expect(idempotencyKeyOf(createOrder.mock.calls[0])).toBe(uuidKeys[0]);
+    expect(idempotencyKeyOf(createOrder.mock.calls[1])).toBe(uuidKeys[0]);
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues a new Idempotency-Key when the listing set changes", async () => {
+    cartState.items = [{ listing: listing(100, "listing-ak") }];
+    cartState.totalPrice = 100;
+    asCustomer();
+    createOrder.mockRejectedValue(new Error("Falha de rede"));
+
+    const view = renderCheckout(0);
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
+
+    cartState.items = [
+      { listing: listing(80, "listing-ak") },
+      { listing: listing(20, "listing-awp") },
+    ];
+    cartState.totalPrice = 100;
+    view.rerender(<CheckoutHarness nonce={1} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(2));
+
+    expect(idempotencyKeyOf(createOrder.mock.calls[0])).toBe(uuidKeys[0]);
+    expect(idempotencyKeyOf(createOrder.mock.calls[1])).toBe(uuidKeys[1]);
+    expect(createOrder.mock.calls[1][0]).toEqual({
+      items: [{ listingId: "listing-ak" }, { listingId: "listing-awp" }],
+    });
+  });
+
+  it("does not fire two POSTs with different keys on double-click", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    asCustomer();
+
+    let release: (value: { id: string }) => void = () => {};
+    createOrder.mockImplementation(
+      () =>
+        new Promise<{ id: string }>((resolve) => {
+          release = resolve;
+        }),
+    );
+    createPaymentLink.mockResolvedValue({});
+
+    renderCheckout();
+    const button = screen.getByRole("button", { name: /Pagar com PayPal/ });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
+    expect(
+      screen.getByRole("button", { name: "Abrindo o PayPal..." }),
+    ).toBeDisabled();
+
+    release({ id: "order-1" });
+    await waitFor(() => expect(createPaymentLink).toHaveBeenCalledTimes(1));
+
+    expect(createOrder).toHaveBeenCalledTimes(1);
+    expect(idempotencyKeyOf(createOrder.mock.calls[0])).toBe(uuidKeys[0]);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Send a stable `Idempotency-Key` on `POST /orders` from checkout so retries and double-clicks do not create a second order.

Closes the client gap for GitHub issue #82. Does not change server reservation or payment semantics.

## Changes

- `api.post` / `api.patch` forward extra headers; `Authorization` still wins.
- `createOrder` requires `{ idempotencyKey }` and sends `Idempotency-Key` (≤128 chars).
- Checkout keeps a UUID in memory keyed by the sorted listing-id set; retry reuses it; a different set gets a new key.
- In-flight guard plus disabled pay button for double-click.
- Tests cover header, reuse, new set, and double-click.

## Verification

```text
npm run typecheck → pass
npm run lint → 0 errors
npm test → 21 files / 79 tests pass
```

Does not edit `server/`. Do not merge from the agent. Do not close the GitHub issue from this environment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

