### PR TITLE
#40 — P0 — Implementar máquina de estados de Order

### DIFF
--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -74,6 +74,10 @@ Order creation currently uses a PostgreSQL transaction and an atomic conditional
 
 Expired reservations are released by an in-process sweep that calls `listingsService.expireReservations()`. The listing UPDATE is conditional on `status = RESERVED` and `reservationExpiresAt <= now`, so it cannot overwrite `SOLD`. Payment confirmation requires `status = RESERVED`, `reservedByOrderId = orderId` and `reservationExpiresAt > now`; if that UPDATE does not cover every order item, the payment transaction rolls back. Unpaid orders are cancelled when they no longer hold their listings, including the case where the listing was reserved by a later order.
 
+### Order status
+
+`PATCH /orders/:id/status` applies an explicit fulfillment graph (`PENDING → CONFIRMED | CANCELLED`, `CONFIRMED → SHIPPED | CANCELLED`, `SHIPPED → DELIVERED`; `DELIVERED` and `CANCELLED` are terminal). The write is a conditional `UPDATE` on current status so concurrent PATCHes cannot both succeed. Role rules: SELLER is forbidden; CUSTOMER may cancel own `PENDING`/`CONFIRMED` orders and confirm `SHIPPED → DELIVERED`; ADMIN may apply any graph edge. Payment confirmation still performs `PENDING → CONFIRMED` internally and is not a customer PATCH.
+
 ### Payment confirmation
 
 Payment creation calls PayPal outside the database transaction, with an explicit timeout (`PAYPAL_API_TIMEOUT_MS`, default 10s). `OrdersCreate` and `OrdersCapture` are not retried. Idempotent PayPal reads (order GET, OAuth token, webhook certificate) retry HTTP 5xx/429, timeouts and network errors up to 3 times with exponential backoff. The PayPal order ID is stored on the local order.

--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -29,6 +29,13 @@ Rules:
 
 ## Orders
 
+Allowed fulfillment lifecycle:
+
+```text
+PENDING → CONFIRMED → SHIPPED → DELIVERED
+       ↘ CANCELLED ↙
+```
+
 1. An order belongs to one customer.
 2. Each listing may appear at most once in an order.
 3. Order item price is a snapshot of the price at purchase/reservation time.
@@ -37,6 +44,9 @@ Rules:
 6. `POST /orders` requires a customer-scoped `Idempotency-Key`; repeated requests with the same key and canonical listing set must return the original order without creating another order or reservation.
 7. Reusing the same `Idempotency-Key` for a different canonical listing set must be rejected deterministically.
 8. The idempotency record must commit in the same transaction as order creation and reservation so crash-before-commit leaves no business effect and crash-after-commit can be retried safely.
+9. `Order.status` follows an explicit state machine. Allowed transitions: `PENDING → CONFIRMED | CANCELLED`, `CONFIRMED → SHIPPED | CANCELLED`, `SHIPPED → DELIVERED`. `DELIVERED` and `CANCELLED` are terminal.
+10. A client must never force an arbitrary order status. `PATCH /orders/:id/status` applies only a valid transition, atomically (`UPDATE … WHERE id = $id AND status = $from`). A concurrent winner leaves the loser with HTTP 409 and exactly one committed successor.
+11. Role rules for `PATCH /orders/:id/status`: SELLER cannot change fulfillment status. CUSTOMER may cancel their own `PENDING` or `CONFIRMED` order and may mark their own `SHIPPED` order `DELIVERED`. ADMIN may apply any graph edge. `PENDING → CONFIRMED` for payment remains the trusted payment-confirmation path, not a customer PATCH. Cancelling a `CONFIRMED` order does not invent a PayPal refund; `paymentStatus` is unchanged.
 
 ## Payments
 

--- a/server/README.md
+++ b/server/README.md
@@ -89,7 +89,7 @@ Variáveis: `OTEL_ENABLED`, `OTEL_EXPORTER` (`none` | `console` | `otlp`), `OTEL
 | `GET/POST/PATCH/DELETE /products` | CRUD (POST/PATCH/DELETE = SELLER/ADMIN) |
 | `POST /orders`        | Criar pedido (CUSTOMER, body: items: [{ productId, quantity }]) |
 | `GET /orders`, `GET /orders/:id` | Listar/detalhe (auth)        |
-| `PATCH /orders/:id/status` | Atualizar status (CUSTOMER/ADMIN, não SELLER) |
+| `PATCH /orders/:id/status` | Transição explícita (CUSTOMER: cancelar PENDING/CONFIRMED ou SHIPPED→DELIVERED; ADMIN: grafo completo; SELLER: 403). Terminais: DELIVERED, CANCELLED |
 | `POST /payments/create` | Link PayPal (body: orderId) (auth)  |
 | `POST /payments/webhook` | Webhook PayPal (sem auth)        |
 | `GET /commissions/transactions` | Transações (SELLER/ADMIN)   |

--- a/server/src/__tests__/order.status.integration.test.ts
+++ b/server/src/__tests__/order.status.integration.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "../shared/errors/AppError.js";
+import { prisma } from "../shared/database/index.js";
+import { ordersService } from "../modules/orders/orders.service.js";
+import { createCheckoutGraph, createOrder, createUser, orderKey } from "./helpers/index.js";
+
+describe("order status machine (postgres)", () => {
+  it("persists ADMIN PENDING → CONFIRMED and rejects an illegal skip", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("admin-confirm"));
+
+    const confirmed = await ordersService.updateStatus(created.id, "admin-id", "ADMIN", "CONFIRMED");
+    expect(confirmed.status).toBe("CONFIRMED");
+
+    const committed = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(committed?.status).toBe("CONFIRMED");
+
+    await expect(
+      ordersService.updateStatus(created.id, "admin-id", "ADMIN", "DELIVERED")
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Invalid status transition from CONFIRMED to DELIVERED",
+    });
+
+    const unchanged = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(unchanged?.status).toBe("CONFIRMED");
+  });
+
+  it("walks CONFIRMED → SHIPPED → DELIVERED and then refuses further changes", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("fulfill"));
+    await prisma.order.update({ where: { id: created.id }, data: { status: "CONFIRMED" } });
+
+    const shipped = await ordersService.updateStatus(created.id, "admin-id", "ADMIN", "SHIPPED");
+    expect(shipped.status).toBe("SHIPPED");
+
+    const delivered = await ordersService.updateStatus(created.id, "admin-id", "ADMIN", "DELIVERED");
+    expect(delivered.status).toBe("DELIVERED");
+
+    await expect(
+      ordersService.updateStatus(created.id, "admin-id", "ADMIN", "CANCELLED")
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Invalid status transition from DELIVERED to CANCELLED",
+    });
+
+    const committed = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(committed?.status).toBe("DELIVERED");
+  });
+
+  it("lets CUSTOMER cancel their own PENDING order and forbids skipping payment", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("customer-cancel"));
+
+    await expect(
+      ordersService.updateStatus(created.id, fixture.customer.id, "CUSTOMER", "CONFIRMED")
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    const cancelled = await ordersService.updateStatus(
+      created.id,
+      fixture.customer.id,
+      "CUSTOMER",
+      "CANCELLED"
+    );
+    expect(cancelled.status).toBe("CANCELLED");
+
+    const committed = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(committed?.status).toBe("CANCELLED");
+    expect(committed?.paymentStatus).toBe("PENDING");
+
+    await expect(
+      ordersService.updateStatus(created.id, fixture.customer.id, "CUSTOMER", "PENDING")
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Invalid status transition from CANCELLED to PENDING",
+    });
+  });
+
+  it("lets CUSTOMER confirm receipt of a SHIPPED order", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("receipt"));
+    await prisma.order.update({ where: { id: created.id }, data: { status: "SHIPPED" } });
+
+    const delivered = await ordersService.updateStatus(
+      created.id,
+      fixture.customer.id,
+      "CUSTOMER",
+      "DELIVERED"
+    );
+    expect(delivered.status).toBe("DELIVERED");
+  });
+
+  it("does not let SELLER change fulfillment status", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("seller-denied"));
+
+    await expect(
+      ordersService.updateStatus(created.id, fixture.sellerUser.id, "SELLER", "CANCELLED")
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      message: "Sellers cannot edit orders",
+    });
+
+    const committed = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(committed?.status).toBe("PENDING");
+  });
+
+  it("does not let CUSTOMER cancel another customer's order", async () => {
+    const fixture = await createCheckoutGraph();
+    const other = await createUser({ name: "Other buyer" });
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("not-yours"));
+
+    await expect(
+      ordersService.updateStatus(created.id, other.id, "CUSTOMER", "CANCELLED")
+    ).rejects.toMatchObject({ statusCode: 403, message: "Not your order" });
+
+    const committed = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(committed?.status).toBe("PENDING");
+  });
+
+  it("allows only one concurrent transition to win from PENDING", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(fixture.customer.id, [fixture.listings[0].id], orderKey("race"));
+
+    const results = await Promise.allSettled([
+      ordersService.updateStatus(created.id, "admin-id", "ADMIN", "CONFIRMED"),
+      ordersService.updateStatus(created.id, "admin-id", "ADMIN", "CANCELLED"),
+    ]);
+
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const conflict = (rejected[0] as PromiseRejectedResult).reason as AppError;
+    expect(conflict).toMatchObject({ statusCode: 409, message: "Order status changed concurrently" });
+
+    const committed = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(["CONFIRMED", "CANCELLED"]).toContain(committed?.status);
+    expect(committed?.status).toBe(
+      (fulfilled[0] as PromiseFulfilledResult<{ status: string }>).value.status
+    );
+  });
+});

--- a/server/src/modules/orders/__tests__/order-status.test.ts
+++ b/server/src/modules/orders/__tests__/order-status.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { OrderStatus } from "../../../shared/types/roles.js";
+import {
+  ORDER_STATUS_TRANSITIONS,
+  ORDER_STATUS_TRANSITIONS_BY_ROLE,
+  TERMINAL_ORDER_STATUSES,
+  assertOrderStatusTransition,
+  isAllowedOrderStatusTransition,
+  isTerminalOrderStatus,
+  parseOrderStatus,
+} from "../order-status.js";
+
+describe("order status machine", () => {
+  it("allows the documented fulfillment graph", () => {
+    expect(ORDER_STATUS_TRANSITIONS.PENDING).toEqual(["CONFIRMED", "CANCELLED"]);
+    expect(ORDER_STATUS_TRANSITIONS.CONFIRMED).toEqual(["SHIPPED", "CANCELLED"]);
+    expect(ORDER_STATUS_TRANSITIONS.SHIPPED).toEqual(["DELIVERED"]);
+    expect(isAllowedOrderStatusTransition("PENDING", "CONFIRMED")).toBe(true);
+    expect(isAllowedOrderStatusTransition("PENDING", "CANCELLED")).toBe(true);
+    expect(isAllowedOrderStatusTransition("CONFIRMED", "SHIPPED")).toBe(true);
+    expect(isAllowedOrderStatusTransition("CONFIRMED", "CANCELLED")).toBe(true);
+    expect(isAllowedOrderStatusTransition("SHIPPED", "DELIVERED")).toBe(true);
+  });
+
+  it("treats DELIVERED and CANCELLED as terminal", () => {
+    expect(TERMINAL_ORDER_STATUSES).toEqual(["DELIVERED", "CANCELLED"]);
+    expect(isTerminalOrderStatus("DELIVERED")).toBe(true);
+    expect(isTerminalOrderStatus("CANCELLED")).toBe(true);
+    expect(ORDER_STATUS_TRANSITIONS.DELIVERED).toEqual([]);
+    expect(ORDER_STATUS_TRANSITIONS.CANCELLED).toEqual([]);
+  });
+
+  it.each([
+    ["PENDING", "SHIPPED"],
+    ["PENDING", "DELIVERED"],
+    ["PENDING", "PENDING"],
+    ["CONFIRMED", "PENDING"],
+    ["CONFIRMED", "DELIVERED"],
+    ["SHIPPED", "CANCELLED"],
+    ["SHIPPED", "CONFIRMED"],
+    ["DELIVERED", "CANCELLED"],
+    ["DELIVERED", "SHIPPED"],
+    ["CANCELLED", "PENDING"],
+    ["CANCELLED", "CONFIRMED"],
+  ] as const)("rejects %s → %s", (from, to) => {
+    expect(isAllowedOrderStatusTransition(from, to)).toBe(false);
+    try {
+      assertOrderStatusTransition(from, to, "ADMIN");
+      throw new Error("expected transition to throw");
+    } catch (err) {
+      expect(err).toMatchObject({
+        statusCode: 400,
+        message: `Invalid status transition from ${from} to ${to}`,
+      });
+    }
+  });
+
+  it("ADMIN may apply every graph edge", () => {
+    (Object.entries(ORDER_STATUS_TRANSITIONS) as Array<[OrderStatus, readonly OrderStatus[]]>).forEach(
+      ([from, targets]) => {
+        for (const to of targets) {
+          expect(() => assertOrderStatusTransition(from, to, "ADMIN")).not.toThrow();
+          expect(ORDER_STATUS_TRANSITIONS_BY_ROLE.ADMIN[from]).toContain(to);
+        }
+      }
+    );
+  });
+
+  it("CUSTOMER may cancel PENDING or CONFIRMED and confirm SHIPPED → DELIVERED", () => {
+    expect(() => assertOrderStatusTransition("PENDING", "CANCELLED", "CUSTOMER")).not.toThrow();
+    expect(() => assertOrderStatusTransition("CONFIRMED", "CANCELLED", "CUSTOMER")).not.toThrow();
+    expect(() => assertOrderStatusTransition("SHIPPED", "DELIVERED", "CUSTOMER")).not.toThrow();
+  });
+
+  it("CUSTOMER cannot skip payment or fulfill shipment", () => {
+    try {
+      assertOrderStatusTransition("PENDING", "CONFIRMED", "CUSTOMER");
+      throw new Error("expected CUSTOMER PENDING→CONFIRMED to throw");
+    } catch (err) {
+      expect(err).toMatchObject({
+        statusCode: 403,
+        message: "Role CUSTOMER cannot transition order from PENDING to CONFIRMED",
+      });
+    }
+    try {
+      assertOrderStatusTransition("CONFIRMED", "SHIPPED", "CUSTOMER");
+      throw new Error("expected CUSTOMER CONFIRMED→SHIPPED to throw");
+    } catch (err) {
+      expect(err).toMatchObject({
+        statusCode: 403,
+        message: "Role CUSTOMER cannot transition order from CONFIRMED to SHIPPED",
+      });
+    }
+  });
+
+  it("SELLER cannot apply any fulfillment transition", () => {
+    try {
+      assertOrderStatusTransition("PENDING", "CANCELLED", "SELLER");
+      throw new Error("expected SELLER to throw");
+    } catch (err) {
+      expect(err).toMatchObject({ statusCode: 403, message: "Sellers cannot edit orders" });
+    }
+    try {
+      assertOrderStatusTransition("CONFIRMED", "SHIPPED", "SELLER");
+      throw new Error("expected SELLER to throw");
+    } catch (err) {
+      expect(err).toMatchObject({ statusCode: 403, message: "Sellers cannot edit orders" });
+    }
+  });
+
+  it("rejects unknown stored statuses", () => {
+    try {
+      parseOrderStatus("REFUNDED");
+      throw new Error("expected unknown status to throw");
+    } catch (err) {
+      expect(err).toMatchObject({ statusCode: 400, message: "Unknown order status: REFUNDED" });
+    }
+  });
+});

--- a/server/src/modules/orders/__tests__/orders.service.test.ts
+++ b/server/src/modules/orders/__tests__/orders.service.test.ts
@@ -35,6 +35,7 @@ vi.mock("../orders.repository.js", () => ({
     findManyByCustomerId: vi.fn(),
     findManyBySellerId: vi.fn(),
     findMany: vi.fn(),
+    transitionStatus: vi.fn(),
   },
 }));
 
@@ -436,14 +437,93 @@ describe("ordersService", () => {
       ).rejects.toMatchObject({ statusCode: 403 });
     });
 
-    it("ADMIN can update any order status", async () => {
-      vi.mocked(ordersRepository.findById).mockResolvedValue(mockOrder() as never);
-      vi.mocked(prisma.order.update).mockResolvedValue({ ...mockOrder(), status: "SHIPPED" } as never);
+    it("ADMIN can apply a valid graph transition", async () => {
+      const pending = mockOrder();
+      const confirmed = { ...mockOrder(), status: "CONFIRMED" };
+      vi.mocked(ordersRepository.findById)
+        .mockResolvedValueOnce(pending as never)
+        .mockResolvedValueOnce(confirmed as never);
+      vi.mocked(ordersRepository.transitionStatus).mockResolvedValue(1);
 
-      await ordersService.updateStatus("order-1", "admin-id", "ADMIN", "SHIPPED");
-      expect(prisma.order.update).toHaveBeenCalledWith(
-        expect.objectContaining({ data: { status: "SHIPPED" } })
+      const result = await ordersService.updateStatus("order-1", "admin-id", "ADMIN", "CONFIRMED");
+      expect(ordersRepository.transitionStatus).toHaveBeenCalledWith("order-1", "PENDING", "CONFIRMED");
+      expect(result.status).toBe("CONFIRMED");
+    });
+
+    it("rejects an invalid graph skip PENDING → SHIPPED", async () => {
+      vi.mocked(ordersRepository.findById).mockResolvedValue(mockOrder() as never);
+
+      await expect(
+        ordersService.updateStatus("order-1", "admin-id", "ADMIN", "SHIPPED")
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Invalid status transition from PENDING to SHIPPED",
+      });
+      expect(ordersRepository.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it("rejects transitions out of terminal DELIVERED", async () => {
+      vi.mocked(ordersRepository.findById).mockResolvedValue(
+        mockOrder({ status: "DELIVERED" }) as never
       );
+
+      await expect(
+        ordersService.updateStatus("order-1", "admin-id", "ADMIN", "CANCELLED")
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Invalid status transition from DELIVERED to CANCELLED",
+      });
+      expect(ordersRepository.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it("rejects transitions out of terminal CANCELLED", async () => {
+      vi.mocked(ordersRepository.findById).mockResolvedValue(
+        mockOrder({ status: "CANCELLED" }) as never
+      );
+
+      await expect(
+        ordersService.updateStatus("order-1", "admin-id", "ADMIN", "PENDING")
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        message: "Invalid status transition from CANCELLED to PENDING",
+      });
+    });
+
+    it("CUSTOMER can cancel their own PENDING order", async () => {
+      const pending = mockOrder();
+      const cancelled = { ...mockOrder(), status: "CANCELLED" };
+      vi.mocked(ordersRepository.findById)
+        .mockResolvedValueOnce(pending as never)
+        .mockResolvedValueOnce(cancelled as never);
+      vi.mocked(ordersRepository.transitionStatus).mockResolvedValue(1);
+
+      const result = await ordersService.updateStatus("order-1", "user-1", "CUSTOMER", "CANCELLED");
+      expect(ordersRepository.transitionStatus).toHaveBeenCalledWith("order-1", "PENDING", "CANCELLED");
+      expect(result.status).toBe("CANCELLED");
+    });
+
+    it("CUSTOMER cannot mark their own order CONFIRMED", async () => {
+      vi.mocked(ordersRepository.findById).mockResolvedValue(mockOrder() as never);
+
+      await expect(
+        ordersService.updateStatus("order-1", "user-1", "CUSTOMER", "CONFIRMED")
+      ).rejects.toMatchObject({
+        statusCode: 403,
+        message: "Role CUSTOMER cannot transition order from PENDING to CONFIRMED",
+      });
+      expect(ordersRepository.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 when a concurrent transition already moved the row", async () => {
+      vi.mocked(ordersRepository.findById).mockResolvedValue(mockOrder() as never);
+      vi.mocked(ordersRepository.transitionStatus).mockResolvedValue(0);
+
+      await expect(
+        ordersService.updateStatus("order-1", "admin-id", "ADMIN", "CANCELLED")
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        message: "Order status changed concurrently",
+      });
     });
   });
 

--- a/server/src/modules/orders/order-status.ts
+++ b/server/src/modules/orders/order-status.ts
@@ -1,0 +1,87 @@
+import { AppError } from "../../shared/errors/AppError.js";
+import { ORDER_STATUSES, ROLES, type OrderStatus, type Role } from "../../shared/types/roles.js";
+
+/**
+ * Fulfillment graph for Order.status.
+ *
+ * Payment confirmation still performs PENDING → CONFIRMED internally.
+ * Reservation expiry still performs PENDING → CANCELLED internally.
+ * PATCH /orders/:id/status must use this graph and the role subset below.
+ */
+export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, readonly OrderStatus[]> = {
+  PENDING: ["CONFIRMED", "CANCELLED"],
+  CONFIRMED: ["SHIPPED", "CANCELLED"],
+  SHIPPED: ["DELIVERED"],
+  DELIVERED: [],
+  CANCELLED: [],
+};
+
+export const TERMINAL_ORDER_STATUSES = ["DELIVERED", "CANCELLED"] as const;
+export type TerminalOrderStatus = (typeof TERMINAL_ORDER_STATUSES)[number];
+
+/**
+ * HTTP PATCH role rules. ADMIN may apply any graph edge. CUSTOMER may cancel
+ * an unpaid/unshipped order and confirm receipt after shipment. SELLER cannot
+ * change fulfillment status (tracking uses PATCH /orders/:id/tracking).
+ */
+export const ORDER_STATUS_TRANSITIONS_BY_ROLE: Record<Role, Record<OrderStatus, readonly OrderStatus[]>> = {
+  ADMIN: {
+    PENDING: ORDER_STATUS_TRANSITIONS.PENDING,
+    CONFIRMED: ORDER_STATUS_TRANSITIONS.CONFIRMED,
+    SHIPPED: ORDER_STATUS_TRANSITIONS.SHIPPED,
+    DELIVERED: ORDER_STATUS_TRANSITIONS.DELIVERED,
+    CANCELLED: ORDER_STATUS_TRANSITIONS.CANCELLED,
+  },
+  CUSTOMER: {
+    PENDING: ["CANCELLED"],
+    CONFIRMED: ["CANCELLED"],
+    SHIPPED: ["DELIVERED"],
+    DELIVERED: [],
+    CANCELLED: [],
+  },
+  SELLER: {
+    PENDING: [],
+    CONFIRMED: [],
+    SHIPPED: [],
+    DELIVERED: [],
+    CANCELLED: [],
+  },
+};
+
+export function isOrderStatus(value: string): value is OrderStatus {
+  return (ORDER_STATUSES as readonly string[]).includes(value);
+}
+
+export function isTerminalOrderStatus(status: OrderStatus): boolean {
+  return (TERMINAL_ORDER_STATUSES as readonly string[]).includes(status);
+}
+
+export function isAllowedOrderStatusTransition(from: OrderStatus, to: OrderStatus): boolean {
+  return ORDER_STATUS_TRANSITIONS[from].includes(to);
+}
+
+export function parseOrderStatus(value: string): OrderStatus {
+  if (!isOrderStatus(value)) {
+    throw new AppError(400, `Unknown order status: ${value}`);
+  }
+  return value;
+}
+
+export function assertOrderStatusTransition(from: OrderStatus, to: OrderStatus, role: string): void {
+  if (!isAllowedOrderStatusTransition(from, to)) {
+    throw new AppError(400, `Invalid status transition from ${from} to ${to}`);
+  }
+
+  if (role === "SELLER") {
+    throw new AppError(403, "Sellers cannot edit orders");
+  }
+
+  if (!(ROLES as readonly string[]).includes(role)) {
+    throw new AppError(403, "Forbidden");
+  }
+
+  const allowedForRole = ORDER_STATUS_TRANSITIONS_BY_ROLE[role as Role][from];
+  if (!allowedForRole.includes(to)) {
+    throw new AppError(403, `Role ${role} cannot transition order from ${from} to ${to}`);
+  }
+}

--- a/server/src/modules/orders/orders.repository.ts
+++ b/server/src/modules/orders/orders.repository.ts
@@ -136,4 +136,16 @@ export const ordersRepository = {
       include: { items: true },
     });
   },
+
+  /**
+   * Atomically apply from → to. Concurrent PATCH or expiry/payment races
+   * lose when `status` is no longer `from`.
+   */
+  async transitionStatus(orderId: string, from: OrderStatus, to: OrderStatus) {
+    const result = await prisma.order.updateMany({
+      where: { id: orderId, status: from },
+      data: { status: to },
+    });
+    return result.count;
+  },
 };

--- a/server/src/modules/orders/orders.service.ts
+++ b/server/src/modules/orders/orders.service.ts
@@ -4,6 +4,10 @@ import { ordersRepository } from "./orders.repository.js";
 import { AppError } from "../../shared/errors/AppError.js";
 import { buildReservationWindow } from "../../shared/config/reservation.js";
 import type { CreateOrderInput, UpdateOrderTrackingInput } from "./orders.dto.js";
+import {
+  assertOrderStatusTransition,
+  parseOrderStatus,
+} from "./order-status.js";
 import { Prisma } from "@prisma/client";
 import { appMetrics } from "../../shared/observability/metrics.js";
 import { markSpanOutcome } from "../../shared/observability/outcomes.js";
@@ -229,23 +233,19 @@ export const ordersService = {
     if (role === "SELLER") throw new AppError(403, "Sellers cannot edit orders");
     if (role === "CUSTOMER" && order.customer.id !== userId)
       throw new AppError(403, "Not your order");
-    return prisma.order.update({
-      where: { id: orderId },
-      data: { status: status as "PENDING" | "CONFIRMED" | "SHIPPED" | "DELIVERED" | "CANCELLED" },
-      include: {
-        customer: { select: { id: true, name: true, email: true } },
-        items: {
-          include: {
-            listing: {
-              include: {
-                product: { select: { id: true, weapon: true, skinName: true, exterior: true } },
-              },
-            },
-            seller: { select: { id: true, storeName: true } },
-          },
-        },
-      },
-    });
+
+    const fromStatus = parseOrderStatus(order.status);
+    const toStatus = parseOrderStatus(status);
+    assertOrderStatusTransition(fromStatus, toStatus, role);
+
+    const moved = await ordersRepository.transitionStatus(orderId, fromStatus, toStatus);
+    if (moved !== 1) {
+      throw new AppError(409, "Order status changed concurrently");
+    }
+
+    const updated = await ordersRepository.findById(orderId);
+    if (!updated) throw new AppError(404, "Order not found");
+    return updated;
   },
 
   async updateTracking(orderId: string, userId: string, role: string, input: UpdateOrderTrackingInput) {

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -351,6 +351,39 @@ export const openApiSpec = {
         },
       },
     },
+    "/orders/{id}/status": {
+      patch: {
+        tags: ["Orders"],
+        summary: "Apply a valid order status transition",
+        description:
+          "Replaces free status updates with the fulfillment state machine. Allowed: PENDING→CONFIRMED|CANCELLED, CONFIRMED→SHIPPED|CANCELLED, SHIPPED→DELIVERED. DELIVERED and CANCELLED are terminal. CUSTOMER may cancel own PENDING/CONFIRMED orders and confirm SHIPPED→DELIVERED. ADMIN may apply any graph edge. SELLER cannot change status. Concurrent transitions from the same row return 409.",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["status"],
+                properties: {
+                  status: {
+                    type: "string",
+                    enum: ["PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"],
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: { description: "Transition applied", content: { "application/json": { schema: { $ref: "#/components/schemas/Order" } } } },
+          400: { description: "Invalid or terminal transition" },
+          403: { description: "Role cannot apply this transition, or the order is not the caller's" },
+          404: { description: "Order not found" },
+          409: { description: "A concurrent request already changed the order status" },
+        },
+      },
+    },
     "/payments/create": {
       post: {
         tags: ["Payments"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Replace free-form `Order.status` updates with an explicit fulfillment graph and atomic conditional writes.

Implements GitHub issue #40. Payment confirmation still owns `PENDING → CONFIRMED`. No PayPal refund API is invented.

## Graph

- `PENDING → CONFIRMED | CANCELLED`
- `CONFIRMED → SHIPPED | CANCELLED`
- `SHIPPED → DELIVERED`
- `DELIVERED` and `CANCELLED` are terminal

CUSTOMER: own order only; cannot confirm payment. ADMIN: full graph. SELLER: 403 (unchanged). Concurrent transitions from the same row: one winner, HTTP 409.

## Verification

```text
cd server && npm run test:unit → 26 files, 170 passed
cd server && npm run test:integration → 9 files, 54 passed
```

No Prisma schema/migration change. Does not edit `src/`.

Known limits: cancelling `CONFIRMED` does not reverse payment, listings, or payouts; cancelling `PENDING` still relies on reservation expiry to release the listing.

Do not merge from the agent. Do not close the GitHub issue from this environment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

