### PR TITLE
fix: enable trust proxy for Render deployment

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -21,6 +21,8 @@ import { getAllowedCorsOrigins, isCorsOriginAllowed } from "./shared/config/cors
 
 const app = express();
 
+app.set("trust proxy", true);
+
 app.use(requestId);
 app.use(httpTelemetry);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The backend API was logging repeated `ValidationError` warnings on Render:

```
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default).
This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users.
```

This was causing the rate limiting middleware to fail to correctly identify client IPs behind Render's proxy infrastructure.

## Solution

Added `app.set('trust proxy', true)` to the Express configuration in `server/src/app.ts`.

This tells Express to trust the `X-Forwarded-For` header set by Render's proxy, which is necessary for:
- Accurate client IP identification
- Proper rate limiting functionality
- Correct security middleware behavior

## Changes

- `server/src/app.ts`: Added trust proxy configuration immediately after Express app initialization

## Testing

- ✅ All unit tests pass
- ✅ TypeScript type checking passes
- ✅ No breaking changes to existing functionality

## References

- [Express behind proxies documentation](https://expressjs.com/en/guide/behind-proxies.html)
- [express-rate-limit trust proxy docs](https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/)
- [Render platform constraints](.cursor/rules/render-platform.mdc)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0718c-e934-7007-b7f4-6db4f447a8cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0718c-e934-7007-b7f4-6db4f447a8cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

