### PR TITLE
#83 — [UX] Implementar retorno e cancelamento do PayPal com páginas de pedido pendente, pago e falho

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Products from "./pages/Products";
 import ListingDetail from "./pages/ListingDetail";
 import CartPage from "./pages/CartPage";
 import Checkout from "./pages/Checkout";
+import OrderStatusPage from "./pages/OrderStatus";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import SellerDashboard from "./pages/SellerDashboard";
@@ -42,6 +43,30 @@ const App = () => (
                   <Route path="/listing/:id" element={<ListingDetail />} />
                   <Route path="/cart" element={<CartPage />} />
                   <Route path="/checkout" element={<Checkout />} />
+                  <Route
+                    path="/orders/:id/return"
+                    element={
+                      <ProtectedRoute>
+                        <OrderStatusPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/orders/:id/cancel"
+                    element={
+                      <ProtectedRoute>
+                        <OrderStatusPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/orders/:id"
+                    element={
+                      <ProtectedRoute>
+                        <OrderStatusPage />
+                      </ProtectedRoute>
+                    }
+                  />
                 </Route>
                 <Route path="/login" element={<Login />} />
                 <Route path="/register" element={<Register />} />

--- a/src/api/__tests__/orders.test.ts
+++ b/src/api/__tests__/orders.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createOrder } from "../orders";
+import { createOrder, getOrder } from "../orders";
 
 const post = vi.fn();
+const get = vi.fn();
 
 vi.mock("../client", () => ({
   api: {
     post: (...args: unknown[]) => post(...args),
+    get: (...args: unknown[]) => get(...args),
   },
 }));
 
@@ -30,5 +32,17 @@ describe("createOrder", () => {
         },
       },
     );
+  });
+});
+
+describe("getOrder", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue({ id: "order-1", paymentStatus: "PENDING" });
+  });
+
+  it("GETs /orders/:id without inventing a paid state", async () => {
+    await getOrder("order-1");
+    expect(get).toHaveBeenCalledWith("/orders/order-1");
   });
 });

--- a/src/api/__tests__/payments.test.ts
+++ b/src/api/__tests__/payments.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPaymentLink } from "../payments";
+
+const post = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    post: (...args: unknown[]) => post(...args),
+  },
+}));
+
+describe("createPaymentLink", () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue({ approvalUrl: "https://paypal.example/approve" });
+  });
+
+  it("posts absolute returnUrl and cancelUrl with the order id", async () => {
+    await createPaymentLink({
+      orderId: "order-1",
+      returnUrl: "https://app.example/orders/order-1/return",
+      cancelUrl: "https://app.example/orders/order-1/cancel",
+    });
+
+    expect(post).toHaveBeenCalledWith("/payments/create", {
+      orderId: "order-1",
+      returnUrl: "https://app.example/orders/order-1/return",
+      cancelUrl: "https://app.example/orders/order-1/cancel",
+    });
+  });
+});

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -2,6 +2,8 @@ import { api } from "./client";
 
 export interface CreatePaymentBody {
   orderId: string;
+  returnUrl?: string;
+  cancelUrl?: string;
 }
 
 export interface CreatePaymentResponse {
@@ -10,6 +12,8 @@ export interface CreatePaymentResponse {
   [key: string]: unknown;
 }
 
-export function createPaymentLink(body: CreatePaymentBody): Promise<CreatePaymentResponse> {
+export function createPaymentLink(
+  body: CreatePaymentBody,
+): Promise<CreatePaymentResponse> {
   return api.post<CreatePaymentResponse>("/payments/create", body);
 }

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
-import type { Listing } from '@/types/api';
+import { createContext, useContext, useState, ReactNode } from "react";
+import type { Listing } from "@/types/api";
 
 export interface CartItem {
   listing: Listing;
@@ -9,6 +9,7 @@ interface CartContextType {
   items: CartItem[];
   addItem: (listing: Listing) => void;
   removeItem: (listingId: string) => void;
+  removeItems: (listingIds: string[]) => void;
   clearCart: () => void;
   totalItems: number;
   totalPrice: number;
@@ -21,24 +22,40 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
   const addItem = (listing: Listing) => {
     // Check if listing is already in cart
-    if (items.some(i => i.listing.id === listing.id)) {
+    if (items.some((i) => i.listing.id === listing.id)) {
       return; // Already in cart, each listing is unique
     }
     // Check if listing is available
-    if (listing.status !== 'ACTIVE') {
+    if (listing.status !== "ACTIVE") {
       return; // Cannot add non-active listings
     }
-    setItems(prev => [...prev, { listing }]);
+    setItems((prev) => [...prev, { listing }]);
   };
 
-  const removeItem = (listingId: string) => setItems(prev => prev.filter(i => i.listing.id !== listingId));
+  const removeItem = (listingId: string) =>
+    setItems((prev) => prev.filter((i) => i.listing.id !== listingId));
+
+  const removeItems = (listingIds: string[]) => {
+    const ids = new Set(listingIds);
+    setItems((prev) => prev.filter((i) => !ids.has(i.listing.id)));
+  };
 
   const clearCart = () => setItems([]);
   const totalItems = items.length; // Each item is unique, no quantity
   const totalPrice = items.reduce((s, i) => s + Number(i.listing.price), 0);
 
   return (
-    <CartContext.Provider value={{ items, addItem, removeItem, clearCart, totalItems, totalPrice }}>
+    <CartContext.Provider
+      value={{
+        items,
+        addItem,
+        removeItem,
+        removeItems,
+        clearCart,
+        totalItems,
+        totalPrice,
+      }}
+    >
       {children}
     </CartContext.Provider>
   );
@@ -46,6 +63,6 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
 export const useCart = () => {
   const ctx = useContext(CartContext);
-  if (!ctx) throw new Error('useCart must be used within CartProvider');
+  if (!ctx) throw new Error("useCart must be used within CartProvider");
   return ctx;
 };

--- a/src/contexts/__tests__/CartContext.test.tsx
+++ b/src/contexts/__tests__/CartContext.test.tsx
@@ -36,8 +36,15 @@ function makeListing(overrides: Partial<Listing> = {}): Listing {
 }
 
 function CartConsumer() {
-  const { items, addItem, removeItem, clearCart, totalItems, totalPrice } =
-    useCart();
+  const {
+    items,
+    addItem,
+    removeItem,
+    removeItems,
+    clearCart,
+    totalItems,
+    totalPrice,
+  } = useCart();
   const futureLock = new Date(Date.now() + 60 * 60 * 1000).toISOString();
 
   return (
@@ -132,6 +139,12 @@ function CartConsumer() {
       <button data-testid="remove-ak" onClick={() => removeItem("listing-ak")}>
         Remove AK
       </button>
+      <button
+        data-testid="remove-ordered"
+        onClick={() => removeItems(["listing-ak"])}
+      >
+        Remove ordered
+      </button>
       <button data-testid="clear" onClick={clearCart}>
         Clear
       </button>
@@ -223,6 +236,19 @@ describe("CartContext", () => {
       fireEvent.click(screen.getByTestId("remove-ak"));
 
       expect(screen.getByTestId("count").textContent).toBe("1");
+    });
+  });
+
+  describe("removeItems()", () => {
+    it("removes only the listings that entered the order", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("add-m4"));
+      fireEvent.click(screen.getByTestId("remove-ordered"));
+
+      expect(screen.getByTestId("count").textContent).toBe("1");
+      expect(screen.queryByTestId("item-listing-ak")).toBeNull();
+      expect(screen.getByTestId("item-listing-m4")).toBeTruthy();
     });
   });
 

--- a/src/lib/__tests__/orderPaymentView.test.ts
+++ b/src/lib/__tests__/orderPaymentView.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { Order } from "@/types/api";
+import {
+  canRetryPayment,
+  formatReservationCountdown,
+  isOrderAccessError,
+  isPaymentConfirmed,
+  orderPageIntent,
+  orderPollIntervalMs,
+  ORDER_POLL_INTERVAL_MS,
+} from "../orderPaymentView";
+
+function order(overrides: Partial<Order> = {}): Order {
+  return {
+    id: "order-1",
+    totalAmount: 105,
+    status: "PENDING",
+    paymentStatus: "PENDING",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    items: [
+      {
+        id: "item-1",
+        listingId: "listing-ak",
+        sellerId: "seller-1",
+        priceSnapshot: 100,
+        listing: {
+          id: "listing-ak",
+          reservationExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("orderPaymentView", () => {
+  it("treats only PAID as locally displayable confirmation", () => {
+    expect(isPaymentConfirmed(order({ paymentStatus: "PAID" }))).toBe(true);
+    expect(isPaymentConfirmed(order({ paymentStatus: "PENDING" }))).toBe(false);
+    expect(isPaymentConfirmed(order({ paymentStatus: "REFUNDED" }))).toBe(
+      false,
+    );
+  });
+
+  it("detects return/cancel/view intents from the path", () => {
+    expect(orderPageIntent("/orders/abc/return")).toBe("return");
+    expect(orderPageIntent("/orders/abc/cancel")).toBe("cancel");
+    expect(orderPageIntent("/orders/abc")).toBe("view");
+  });
+
+  it("allows retry only while payment is PENDING and the reservation is live", () => {
+    const now = Date.parse("2026-09-05T12:00:00.000Z");
+    const live = order({
+      items: [
+        {
+          id: "item-1",
+          listingId: "listing-ak",
+          sellerId: "seller-1",
+          priceSnapshot: 100,
+          listing: {
+            id: "listing-ak",
+            reservationExpiresAt: "2026-09-05T12:10:00.000Z",
+            product: {
+              id: "prod-1",
+              weapon: "AK-47",
+              skinName: "Redline",
+              exterior: "Field-Tested",
+            },
+          },
+        },
+      ],
+    });
+    expect(canRetryPayment(live, now)).toBe(true);
+    expect(canRetryPayment({ ...live, paymentStatus: "PAID" }, now)).toBe(
+      false,
+    );
+    expect(canRetryPayment({ ...live, status: "CANCELLED" }, now)).toBe(false);
+    expect(
+      canRetryPayment(
+        {
+          ...live,
+          items: [
+            {
+              ...live.items![0],
+              listing: {
+                ...live.items![0].listing!,
+                reservationExpiresAt: "2026-09-05T11:59:00.000Z",
+              },
+            },
+          ],
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("formats remaining reservation time as mm:ss", () => {
+    const now = Date.parse("2026-09-05T12:00:00.000Z");
+    expect(
+      formatReservationCountdown(Date.parse("2026-09-05T12:05:07.000Z"), now),
+    ).toBe("05:07");
+    expect(
+      formatReservationCountdown(Date.parse("2026-09-05T11:59:00.000Z"), now),
+    ).toBe("00:00");
+  });
+
+  it("polls only pending unpaid return/view orders", () => {
+    expect(orderPollIntervalMs(order(), "return")).toBe(ORDER_POLL_INTERVAL_MS);
+    expect(orderPollIntervalMs(order(), "view")).toBe(ORDER_POLL_INTERVAL_MS);
+    expect(orderPollIntervalMs(order(), "cancel")).toBe(false);
+    expect(
+      orderPollIntervalMs(order({ paymentStatus: "PAID" }), "return"),
+    ).toBe(false);
+  });
+
+  it("maps 403/404 order errors to an access failure", () => {
+    expect(isOrderAccessError(new Error("Order not found"))).toBe(true);
+    expect(isOrderAccessError(new Error("Not your order"))).toBe(true);
+    expect(isOrderAccessError(new Error("Request failed: 403"))).toBe(true);
+    expect(isOrderAccessError(new Error("Falha de rede"))).toBe(false);
+  });
+});

--- a/src/lib/__tests__/paypalCheckoutUrls.test.ts
+++ b/src/lib/__tests__/paypalCheckoutUrls.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { paypalCheckoutUrls } from "../paypalCheckoutUrls";
+
+describe("paypalCheckoutUrls", () => {
+  it("builds absolute http return and cancel URLs", () => {
+    const urls = paypalCheckoutUrls(
+      "order-1",
+      "https://market.neonarsenal.example",
+    );
+
+    expect(urls.returnUrl).toBe(
+      "https://market.neonarsenal.example/orders/order-1/return",
+    );
+    expect(urls.cancelUrl).toBe(
+      "https://market.neonarsenal.example/orders/order-1/cancel",
+    );
+    expect(() => new URL(urls.returnUrl)).not.toThrow();
+    expect(() => new URL(urls.cancelUrl)).not.toThrow();
+  });
+
+  it("encodes the order id in the path", () => {
+    const urls = paypalCheckoutUrls("ord/../x", "https://app.example");
+    expect(urls.returnUrl).toBe(
+      "https://app.example/orders/ord%2F..%2Fx/return",
+    );
+    expect(urls.cancelUrl).toBe(
+      "https://app.example/orders/ord%2F..%2Fx/cancel",
+    );
+  });
+
+  it("rejects a non-http origin", () => {
+    expect(() => paypalCheckoutUrls("order-1", "ftp://files.example")).toThrow(
+      /absolute http\(s\)/i,
+    );
+  });
+});

--- a/src/lib/orderPaymentView.ts
+++ b/src/lib/orderPaymentView.ts
@@ -1,0 +1,109 @@
+import type { Order } from "@/types/api";
+
+export type OrderPageIntent = "return" | "cancel" | "view";
+
+export const ORDER_POLL_INTERVAL_MS = 4000;
+
+export function orderPageIntent(pathname: string): OrderPageIntent {
+  if (pathname.endsWith("/cancel")) return "cancel";
+  if (pathname.endsWith("/return")) return "return";
+  return "view";
+}
+
+export function isPaymentConfirmed(
+  order: Pick<Order, "paymentStatus">,
+): boolean {
+  return order.paymentStatus === "PAID";
+}
+
+export function earliestReservationExpiresAt(
+  order: Pick<Order, "items">,
+): number | null {
+  const timestamps =
+    order.items
+      ?.map((item) => item.listing?.reservationExpiresAt)
+      .filter((value): value is string => Boolean(value))
+      .map((value) => Date.parse(value))
+      .filter((value) => Number.isFinite(value)) ?? [];
+  if (timestamps.length === 0) return null;
+  return Math.min(...timestamps);
+}
+
+export function isReservationExpired(
+  order: Pick<Order, "items" | "paymentStatus">,
+  now = Date.now(),
+): boolean {
+  if (isPaymentConfirmed(order)) return false;
+  const expiresAt = earliestReservationExpiresAt(order);
+  if (expiresAt != null) return expiresAt <= now;
+  return false;
+}
+
+export function canRetryPayment(
+  order: Pick<Order, "paymentStatus" | "status" | "items">,
+  now = Date.now(),
+): boolean {
+  if (order.paymentStatus !== "PENDING") return false;
+  if (order.status === "CANCELLED") return false;
+  return !isReservationExpired(order, now);
+}
+
+export function formatReservationCountdown(
+  expiresAt: number | null,
+  now = Date.now(),
+): string | null {
+  if (expiresAt == null) return null;
+  const totalSec = Math.max(0, Math.floor((expiresAt - now) / 1000));
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function orderPollIntervalMs(
+  order: Order | undefined,
+  intent: OrderPageIntent,
+): number | false {
+  if (!order) return false;
+  if (intent === "cancel") return false;
+  if (isPaymentConfirmed(order)) return false;
+  if (order.status === "CANCELLED") return false;
+  if (isReservationExpired(order)) return false;
+  if (order.paymentStatus === "PENDING") return ORDER_POLL_INTERVAL_MS;
+  return false;
+}
+
+export function isOrderAccessError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    /order not found/i.test(message) ||
+    /not your order/i.test(message) ||
+    /pedido não encontrado/i.test(message) ||
+    /request failed: 403/i.test(message) ||
+    /request failed: 404/i.test(message)
+  );
+}
+
+export function orderItemLabel(item: {
+  listing?: {
+    product?: { weapon?: string; skinName?: string; exterior?: string };
+  };
+}): string {
+  const product = item.listing?.product;
+  if (!product?.weapon || !product.skinName) return "Item";
+  const exterior = product.exterior ? ` (${product.exterior})` : "";
+  return `${product.weapon} | ${product.skinName}${exterior}`;
+}
+
+export function orderTotalAmount(
+  order: Pick<Order, "totalAmount" | "items">,
+): number {
+  if (order.totalAmount != null && Number(order.totalAmount) > 0) {
+    return Number(order.totalAmount);
+  }
+  return (
+    order.items?.reduce(
+      (sum, item) => sum + Number(item.priceSnapshot || 0),
+      0,
+    ) ?? 0
+  );
+}

--- a/src/lib/paypalCheckoutUrls.ts
+++ b/src/lib/paypalCheckoutUrls.ts
@@ -1,0 +1,27 @@
+const HTTP_PROTOCOLS = new Set(["http:", "https:"]);
+
+function absoluteHttpUrl(path: string, origin: string): string {
+  const url = new URL(path, origin);
+  if (!HTTP_PROTOCOLS.has(url.protocol)) {
+    throw new Error("PayPal return URLs must be absolute http(s) URLs");
+  }
+  return url.href;
+}
+
+/**
+ * Absolute PayPal return/cancel URLs for `POST /payments/create`.
+ * The backend DTO requires `z.string().url()` when these are sent.
+ */
+export function paypalCheckoutUrls(
+  orderId: string,
+  origin: string = window.location.origin,
+): { returnUrl: string; cancelUrl: string } {
+  if (!orderId) {
+    throw new Error("orderId is required");
+  }
+  const encodedId = encodeURIComponent(orderId);
+  return {
+    returnUrl: absoluteHttpUrl(`/orders/${encodedId}/return`, origin),
+    cancelUrl: absoluteHttpUrl(`/orders/${encodedId}/cancel`, origin),
+  };
+}

--- a/src/lib/redirect.ts
+++ b/src/lib/redirect.ts
@@ -1,0 +1,4 @@
+/** Full-page navigation to an external URL (PayPal approval). */
+export function redirectToExternal(url: string): void {
+  window.location.assign(url);
+}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -10,9 +10,10 @@ import {
   resolveCheckoutIdempotencyKey,
   type CheckoutIdempotencyState,
 } from "@/lib/checkoutIdempotency";
+import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
 
 export default function Checkout() {
-  const { items, totalPrice } = useCart();
+  const { items, totalPrice, removeItems } = useCart();
   const { isAuthenticated, user } = useAuth();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -22,7 +23,7 @@ export default function Checkout() {
   const serviceFee = totalPrice * 0.05;
   const total = totalPrice * 1.05;
 
-  if (items.length === 0) {
+  if (items.length === 0 && !loading) {
     return (
       <div className="container py-8">
         <h1 className="sr-only">Checkout</h1>
@@ -67,6 +68,8 @@ export default function Checkout() {
     inFlightRef.current = true;
     setError(null);
     setLoading(true);
+    let createdOrderId: string | null = null;
+    let leftCheckout = false;
     try {
       const listingIds = items.map(({ listing }) => listing.id);
       idempotencyRef.current = resolveCheckoutIdempotencyKey(
@@ -77,19 +80,29 @@ export default function Checkout() {
         { items: listingIds.map((listingId) => ({ listingId })) },
         { idempotencyKey: idempotencyRef.current.key },
       );
-      const payment = await createPaymentLink({ orderId: order.id });
+      createdOrderId = order.id;
+      removeItems(listingIds);
+      const payment = await createPaymentLink({
+        orderId: order.id,
+        ...paypalCheckoutUrls(order.id),
+      });
       if (payment.approvalUrl) {
-        window.location.href = payment.approvalUrl;
+        leftCheckout = true;
+        window.location.assign(payment.approvalUrl);
         return;
       }
-      setError(
-        "Não foi possível obter o link do PayPal. O pagamento ainda não foi confirmado.",
-      );
+      leftCheckout = true;
+      navigate(`/orders/${order.id}`);
     } catch (e) {
+      if (createdOrderId) {
+        leftCheckout = true;
+        navigate(`/orders/${createdOrderId}`);
+        return;
+      }
       setError(e instanceof Error ? e.message : "Falha ao criar pedido");
     } finally {
       inFlightRef.current = false;
-      setLoading(false);
+      if (!leftCheckout) setLoading(false);
     }
   };
 

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -11,6 +11,7 @@ import {
   type CheckoutIdempotencyState,
 } from "@/lib/checkoutIdempotency";
 import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
+import { redirectToExternal } from "@/lib/redirect";
 
 export default function Checkout() {
   const { items, totalPrice, removeItems } = useCart();
@@ -88,7 +89,7 @@ export default function Checkout() {
       });
       if (payment.approvalUrl) {
         leftCheckout = true;
-        window.location.assign(payment.approvalUrl);
+        redirectToExternal(payment.approvalUrl);
         return;
       }
       leftCheckout = true;

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -19,6 +19,7 @@ import {
   orderTotalAmount,
 } from "@/lib/orderPaymentView";
 import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
+import { redirectToExternal } from "@/lib/redirect";
 import type { Order } from "@/types/api";
 
 function OrderHeadline({
@@ -107,8 +108,7 @@ export default function OrderStatusPage() {
     queryKey: ["order", id],
     queryFn: () => getOrder(id!),
     enabled: Boolean(id),
-    retry: (failureCount, queryError) =>
-      !isOrderAccessError(queryError) && failureCount < 1,
+    retry: false,
     refetchInterval: (query) => orderPollIntervalMs(query.state.data, intent),
   });
 
@@ -190,7 +190,7 @@ export default function OrderStatusPage() {
         ...paypalCheckoutUrls(order.id),
       });
       if (payment.approvalUrl) {
-        window.location.assign(payment.approvalUrl);
+        redirectToExternal(payment.approvalUrl);
         return;
       }
       setRetryError(

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useState } from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getOrder } from "@/api/orders";
+import { createPaymentLink } from "@/api/payments";
+import { ErrorState, PageSkeleton } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  canRetryPayment,
+  earliestReservationExpiresAt,
+  formatReservationCountdown,
+  isOrderAccessError,
+  isPaymentConfirmed,
+  isReservationExpired,
+  orderItemLabel,
+  orderPageIntent,
+  orderPollIntervalMs,
+  orderTotalAmount,
+} from "@/lib/orderPaymentView";
+import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
+import type { Order } from "@/types/api";
+
+function OrderHeadline({
+  order,
+  intent,
+  countdown,
+}: {
+  order: Order;
+  intent: ReturnType<typeof orderPageIntent>;
+  countdown: string | null;
+}) {
+  if (isPaymentConfirmed(order)) {
+    return (
+      <>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Pagamento confirmado.
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          O PayPal confirmou este pagamento. A confirmação local veio do
+          webhook, não desta página.
+        </p>
+      </>
+    );
+  }
+
+  if (intent === "cancel") {
+    const expired = isReservationExpired(order);
+    return (
+      <>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Você cancelou o pagamento.
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {expired
+            ? "A reserva deste pedido já expirou. O pagamento continua pendente até o PayPal confirmar — esta tela não marca o pedido como pago."
+            : countdown
+              ? `Sua reserva expira em ${countdown}. O pedido ainda está pendente.`
+              : "O pedido ainda está pendente. A reserva pode expirar se o pagamento não for concluído."}
+        </p>
+      </>
+    );
+  }
+
+  if (isReservationExpired(order)) {
+    return (
+      <>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Reserva expirada.
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          O pagamento não foi confirmado pelo PayPal. Esta página não marca o
+          pedido como pago.
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Pedido criado. Aguardando confirmação do PayPal.
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        A confirmação real vem do PayPal (webhook/reconciliação). Nada nesta
+        tela afirma que o pagamento já foi confirmado.
+      </p>
+    </>
+  );
+}
+
+export default function OrderStatusPage() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const intent = orderPageIntent(location.pathname);
+  const [now, setNow] = useState(() => Date.now());
+  const [retrying, setRetrying] = useState(false);
+  const [retryError, setRetryError] = useState<string | null>(null);
+
+  const {
+    data: order,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["order", id],
+    queryFn: () => getOrder(id!),
+    enabled: Boolean(id),
+    retry: (failureCount, queryError) =>
+      !isOrderAccessError(queryError) && failureCount < 1,
+    refetchInterval: (query) => orderPollIntervalMs(query.state.data, intent),
+  });
+
+  const expiresAt = order ? earliestReservationExpiresAt(order) : null;
+
+  useEffect(() => {
+    if (expiresAt == null) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [expiresAt]);
+
+  if (!id) {
+    return (
+      <div className="container py-8">
+        <ErrorState
+          title="Pedido não encontrado"
+          description="O identificador do pedido é inválido."
+          action={
+            <Button asChild>
+              <Link to="/products">Ir ao Market</Link>
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <PageSkeleton label="Carregando pedido" />;
+  }
+
+  if (isError || !order) {
+    const accessError = isOrderAccessError(error);
+    return (
+      <div className="container py-8">
+        <ErrorState
+          title={
+            accessError ? "Pedido não encontrado" : "Erro ao carregar o pedido"
+          }
+          description={
+            accessError
+              ? "Este pedido não existe ou não pertence à sua conta."
+              : error instanceof Error
+                ? error.message
+                : "Falha de rede. Tente novamente."
+          }
+          action={
+            accessError ? (
+              <Button asChild>
+                <Link to="/products">Ir ao Market</Link>
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void refetch()}
+              >
+                Tentar novamente
+              </Button>
+            )
+          }
+        />
+      </div>
+    );
+  }
+
+  const paid = isPaymentConfirmed(order);
+  const retryEnabled = canRetryPayment(order, now);
+  const countdown = formatReservationCountdown(expiresAt, now);
+  const expired = isReservationExpired(order, now);
+
+  const handleRetry = async () => {
+    if (!retryEnabled || retrying) return;
+    setRetrying(true);
+    setRetryError(null);
+    try {
+      const payment = await createPaymentLink({
+        orderId: order.id,
+        ...paypalCheckoutUrls(order.id),
+      });
+      if (payment.approvalUrl) {
+        window.location.assign(payment.approvalUrl);
+        return;
+      }
+      setRetryError(
+        "Não foi possível obter o link do PayPal. O pedido existente não foi marcado como pago.",
+      );
+    } catch (e) {
+      setRetryError(
+        e instanceof Error
+          ? e.message
+          : "Não foi possível reutilizar este pedido para um novo pagamento.",
+      );
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  return (
+    <div className="container max-w-2xl py-8">
+      <div className="mb-8">
+        <OrderHeadline order={order} intent={intent} countdown={countdown} />
+      </div>
+
+      <section className="space-y-4 rounded-md border border-border bg-card p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="secondary">Pedido {order.status}</Badge>
+          <Badge variant={paid ? "default" : "outline"}>
+            Pagamento {order.paymentStatus}
+          </Badge>
+        </div>
+
+        <ul className="space-y-2">
+          {(order.items ?? []).map((item) => (
+            <li key={item.id} className="flex justify-between gap-4 text-sm">
+              <span className="min-w-0 truncate text-foreground">
+                {orderItemLabel(item)}
+              </span>
+              <span className="shrink-0 tabular-price text-muted-foreground">
+                ${Number(item.priceSnapshot).toFixed(2)}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <dl className="space-y-1 border-t border-border pt-3 text-sm">
+          <div className="flex justify-between pt-1 text-base font-medium text-foreground">
+            <dt>Total</dt>
+            <dd className="tabular-price">
+              ${orderTotalAmount(order).toFixed(2)}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <div className="mt-6 space-y-3">
+        {retryError ? (
+          <p className="text-sm text-destructive" role="alert">
+            {retryError}
+          </p>
+        ) : null}
+        {!paid && !retryEnabled ? (
+          <p className="text-sm text-muted-foreground">
+            {order.status === "CANCELLED"
+              ? "Este pedido foi cancelado. Não é possível reutilizar o mesmo pedido para pagar."
+              : expired
+                ? "A reserva expirou. Não é possível pagar novamente neste pedido."
+                : "Pagar novamente só fica disponível enquanto o pagamento estiver pendente."}
+          </p>
+        ) : null}
+        <div className="flex flex-col gap-3 sm:flex-row">
+          {intent !== "view" ? (
+            <Button asChild variant={paid ? "default" : "outline"}>
+              <Link to={`/orders/${order.id}`}>Ver pedido</Link>
+            </Button>
+          ) : null}
+          {retryEnabled ? (
+            <Button
+              type="button"
+              onClick={() => void handleRetry()}
+              disabled={retrying}
+            >
+              {retrying ? "Abrindo o PayPal..." : "Pagar novamente"}
+            </Button>
+          ) : null}
+          <Button asChild variant="outline">
+            <Link to="/products">Ir ao Market</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -6,6 +6,7 @@ import type { Listing, User } from "@/types/api";
 
 const createOrder = vi.fn();
 const createPaymentLink = vi.fn();
+const redirectToExternal = vi.fn();
 
 const cartState = {
   items: [] as { listing: Listing }[],
@@ -33,6 +34,10 @@ vi.mock("@/contexts/CartContext", () => ({
 
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
+}));
+
+vi.mock("@/lib/redirect", () => ({
+  redirectToExternal: (...args: unknown[]) => redirectToExternal(...args),
 }));
 
 function listing(price = 100, id = "listing-ak"): Listing {
@@ -120,11 +125,11 @@ describe("Checkout", () => {
     authState.isAuthenticated = false;
     createOrder.mockReset();
     createPaymentLink.mockReset();
+    redirectToExternal.mockReset();
     let uuidIndex = 0;
     vi.spyOn(crypto, "randomUUID").mockImplementation(
       () => uuidKeys[uuidIndex++] ?? "overflow-uuid",
     );
-    vi.spyOn(window.location, "assign").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -198,7 +203,7 @@ describe("Checkout", () => {
     expect(urls.cancelUrl.startsWith("http")).toBe(true);
     expect(cartState.removeItems).toHaveBeenCalledWith(["listing-ak"]);
     expect(cartState.clearCart).not.toHaveBeenCalled();
-    expect(window.location.assign).toHaveBeenCalledWith(
+    expect(redirectToExternal).toHaveBeenCalledWith(
       "https://www.paypal.com/checkoutnow?token=EC-1",
     );
     expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Checkout from "../Checkout";
 import type { Listing, User } from "@/types/api";
 
@@ -11,6 +11,7 @@ const cartState = {
   items: [] as { listing: Listing }[],
   totalPrice: 0,
   clearCart: vi.fn(),
+  removeItems: vi.fn(),
 };
 
 const authState = {
@@ -64,11 +65,22 @@ function listing(price = 100, id = "listing-ak"): Listing {
   } as Listing;
 }
 
+function expectedPaypalUrls(orderId: string) {
+  return {
+    returnUrl: `${window.location.origin}/orders/${orderId}/return`,
+    cancelUrl: `${window.location.origin}/orders/${orderId}/cancel`,
+  };
+}
+
 function CheckoutHarness({ nonce = 0 }: { nonce?: number }) {
   void nonce;
   return (
-    <MemoryRouter>
-      <Checkout />
+    <MemoryRouter initialEntries={["/checkout"]}>
+      <Routes>
+        <Route path="/checkout" element={<Checkout />} />
+        <Route path="/orders/:id" element={<div>Pedido destino</div>} />
+        <Route path="/login" element={<div>Login</div>} />
+      </Routes>
     </MemoryRouter>
   );
 }
@@ -103,6 +115,7 @@ describe("Checkout", () => {
     cartState.items = [];
     cartState.totalPrice = 0;
     cartState.clearCart.mockReset();
+    cartState.removeItems.mockReset();
     authState.user = null;
     authState.isAuthenticated = false;
     createOrder.mockReset();
@@ -111,6 +124,7 @@ describe("Checkout", () => {
     vi.spyOn(crypto, "randomUUID").mockImplementation(
       () => uuidKeys[uuidIndex++] ?? "overflow-uuid",
     );
+    vi.spyOn(window.location, "assign").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -151,12 +165,14 @@ describe("Checkout", () => {
     ).toBeTruthy();
   });
 
-  it("calls createOrder + createPaymentLink and errors without claiming success", async () => {
+  it("sends absolute returnUrl and cancelUrl and prunes ordered listings", async () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
     asCustomer();
     createOrder.mockResolvedValue({ id: "order-1" });
-    createPaymentLink.mockResolvedValue({});
+    createPaymentLink.mockResolvedValue({
+      approvalUrl: "https://www.paypal.com/checkoutnow?token=EC-1",
+    });
 
     renderCheckout();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
@@ -166,17 +182,66 @@ describe("Checkout", () => {
         { items: [{ listingId: "listing-ak" }] },
         { idempotencyKey: uuidKeys[0] },
       );
-      expect(createPaymentLink).toHaveBeenCalledWith({ orderId: "order-1" });
+      expect(createPaymentLink).toHaveBeenCalledWith({
+        orderId: "order-1",
+        ...expectedPaypalUrls("order-1"),
+      });
     });
 
-    expect(
-      screen.getByText(/pagamento ainda não foi confirmado/i),
-    ).toBeTruthy();
+    const urls = createPaymentLink.mock.calls[0][0] as {
+      returnUrl: string;
+      cancelUrl: string;
+    };
+    expect(() => new URL(urls.returnUrl)).not.toThrow();
+    expect(() => new URL(urls.cancelUrl)).not.toThrow();
+    expect(urls.returnUrl.startsWith("http")).toBe(true);
+    expect(urls.cancelUrl.startsWith("http")).toBe(true);
+    expect(cartState.removeItems).toHaveBeenCalledWith(["listing-ak"]);
     expect(cartState.clearCart).not.toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://www.paypal.com/checkoutnow?token=EC-1",
+    );
     expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Tentar novamente" }),
-    ).toBeTruthy();
+    expect(screen.queryByText(/Pagamento confirmado/i)).toBeNull();
+  });
+
+  it("removes only listings that entered the order, keeping others", async () => {
+    cartState.items = [
+      { listing: listing(80, "listing-ak") },
+      { listing: listing(20, "listing-awp") },
+    ];
+    cartState.totalPrice = 100;
+    asCustomer();
+    createOrder.mockResolvedValue({ id: "order-2" });
+    createPaymentLink.mockResolvedValue({});
+
+    renderCheckout();
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    await waitFor(() => {
+      expect(cartState.removeItems).toHaveBeenCalledWith([
+        "listing-ak",
+        "listing-awp",
+      ]);
+    });
+    expect(cartState.clearCart).not.toHaveBeenCalled();
+    expect(await screen.findByText("Pedido destino")).toBeTruthy();
+  });
+
+  it("does not prune the cart when createOrder fails", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    asCustomer();
+    createOrder.mockRejectedValue(new Error("Falha de rede"));
+
+    renderCheckout();
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
+    expect(cartState.removeItems).not.toHaveBeenCalled();
+    expect(cartState.clearCart).not.toHaveBeenCalled();
+    expect(createPaymentLink).not.toHaveBeenCalled();
+    expect(screen.getByText("Falha de rede")).toBeTruthy();
   });
 
   it("sends a non-empty Idempotency-Key of at most 128 characters", async () => {
@@ -277,5 +342,9 @@ describe("Checkout", () => {
 
     expect(createOrder).toHaveBeenCalledTimes(1);
     expect(idempotencyKeyOf(createOrder.mock.calls[0])).toBe(uuidKeys[0]);
+    expect(createPaymentLink.mock.calls[0][0]).toMatchObject({
+      orderId: "order-1",
+      ...expectedPaypalUrls("order-1"),
+    });
   });
 });

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import OrderStatusPage from "../OrderStatus";
+import type { Order } from "@/types/api";
+
+const getOrder = vi.fn();
+const createPaymentLink = vi.fn();
+const createOrder = vi.fn();
+
+vi.mock("@/api/orders", () => ({
+  getOrder: (...args: unknown[]) => getOrder(...args),
+  createOrder: (...args: unknown[]) => createOrder(...args),
+}));
+
+vi.mock("@/api/payments", () => ({
+  createPaymentLink: (...args: unknown[]) => createPaymentLink(...args),
+}));
+
+function pendingOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: "order-1",
+    totalAmount: 105,
+    status: "PENDING",
+    paymentStatus: "PENDING",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    items: [
+      {
+        id: "item-1",
+        listingId: "listing-ak",
+        sellerId: "seller-1",
+        priceSnapshot: 105,
+        listing: {
+          id: "listing-ak",
+          reservationExpiresAt: new Date(
+            Date.now() + 5 * 60 * 1000,
+          ).toISOString(),
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderPage(path: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/orders/:id" element={<OrderStatusPage />} />
+          <Route path="/orders/:id/return" element={<OrderStatusPage />} />
+          <Route path="/orders/:id/cancel" element={<OrderStatusPage />} />
+          <Route path="/products" element={<div>Market</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("OrderStatusPage", () => {
+  beforeEach(() => {
+    getOrder.mockReset();
+    createPaymentLink.mockReset();
+    createOrder.mockReset();
+    vi.spyOn(window.location, "assign").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a skeleton while the order loads", () => {
+    getOrder.mockImplementation(() => new Promise(() => {}));
+    renderPage("/orders/order-1/return");
+    expect(
+      screen.getByRole("status", { name: "Carregando pedido" }),
+    ).toBeTruthy();
+  });
+
+  it("does not claim payment is confirmed while paymentStatus is PENDING", async () => {
+    getOrder.mockResolvedValue(pendingOrder());
+    renderPage("/orders/order-1/return");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Pedido criado. Aguardando confirmação do PayPal.",
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    expect(screen.getByText("$105.00")).toBeTruthy();
+    expect(screen.getByText("Pedido PENDING")).toBeTruthy();
+    expect(screen.getByText("Pagamento PENDING")).toBeTruthy();
+    expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
+    expect(screen.getByText(/confirmação real vem do PayPal/i)).toBeTruthy();
+  });
+
+  it("says payment is confirmed only when paymentStatus is PAID", async () => {
+    getOrder.mockResolvedValue(
+      pendingOrder({ paymentStatus: "PAID", status: "CONFIRMED" }),
+    );
+    renderPage("/orders/order-1/return");
+
+    expect(
+      await screen.findByRole("heading", { name: "Pagamento confirmado." }),
+    ).toBeTruthy();
+    expect(screen.getByText("Pagamento PAID")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Pagar novamente" }),
+    ).toBeNull();
+  });
+
+  it("shows the cancel screen without claiming a local payment", async () => {
+    getOrder.mockResolvedValue(pendingOrder());
+    renderPage("/orders/order-1/cancel");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Você cancelou o pagamento.",
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText(/reserva expira em \d{2}:\d{2}/)).toBeTruthy();
+    expect(screen.getByText("Pedido PENDING")).toBeTruthy();
+    expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Pagar novamente" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Ir ao Market" })).toHaveAttribute(
+      "href",
+      "/products",
+    );
+  });
+
+  it("maps 403/404 to pedido não encontrado", async () => {
+    getOrder.mockRejectedValue(new Error("Not your order"));
+    renderPage("/orders/order-missing");
+
+    expect(await screen.findByText("Pedido não encontrado")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Ir ao Market" })).toBeTruthy();
+    expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
+  });
+
+  it("offers a network retry that does not invent a paid state", async () => {
+    getOrder.mockRejectedValue(new Error("Falha de rede"));
+    renderPage("/orders/order-1/return");
+
+    expect(await screen.findByText("Erro ao carregar o pedido")).toBeTruthy();
+    expect(screen.getByText("Falha de rede")).toBeTruthy();
+    getOrder.mockResolvedValue(pendingOrder());
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    expect(
+      await screen.findByText(
+        "Pedido criado. Aguardando confirmação do PayPal.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
+  });
+
+  it("retries payment on the existing order and does not create another", async () => {
+    getOrder.mockResolvedValue(pendingOrder());
+    createPaymentLink.mockResolvedValue({
+      approvalUrl: "https://www.paypal.com/checkoutnow?token=EC-retry",
+    });
+    renderPage("/orders/order-1/cancel");
+
+    const retry = await screen.findByRole("button", {
+      name: "Pagar novamente",
+    });
+    fireEvent.click(retry);
+
+    await waitFor(() => {
+      expect(createPaymentLink).toHaveBeenCalledWith({
+        orderId: "order-1",
+        returnUrl: `${window.location.origin}/orders/order-1/return`,
+        cancelUrl: `${window.location.origin}/orders/order-1/cancel`,
+      });
+    });
+    expect(createOrder).not.toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://www.paypal.com/checkoutnow?token=EC-retry",
+    );
+  });
+
+  it("explains why retry is unavailable when the reservation expired", async () => {
+    getOrder.mockResolvedValue(
+      pendingOrder({
+        items: [
+          {
+            id: "item-1",
+            listingId: "listing-ak",
+            sellerId: "seller-1",
+            priceSnapshot: 105,
+            listing: {
+              id: "listing-ak",
+              reservationExpiresAt: new Date(Date.now() - 1000).toISOString(),
+              product: {
+                id: "prod-1",
+                weapon: "AK-47",
+                skinName: "Redline",
+                exterior: "Field-Tested",
+              },
+            },
+          },
+        ],
+      }),
+    );
+    renderPage("/orders/order-1/cancel");
+
+    expect(
+      await screen.findByText(/reserva deste pedido já expirou/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Pagar novamente" }),
+    ).toBeNull();
+    expect(
+      screen.getByText(
+        "A reserva expirou. Não é possível pagar novamente neste pedido.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("surfaces a backend rejection instead of inventing a new order", async () => {
+    getOrder.mockResolvedValue(pendingOrder());
+    createPaymentLink.mockRejectedValue(new Error("Order is cancelled"));
+    renderPage("/orders/order-1");
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Pagar novamente" }),
+    );
+    expect(await screen.findByText("Order is cancelled")).toBeTruthy();
+    expect(createOrder).not.toHaveBeenCalled();
+    expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
+  });
+});

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -8,6 +8,7 @@ import type { Order } from "@/types/api";
 const getOrder = vi.fn();
 const createPaymentLink = vi.fn();
 const createOrder = vi.fn();
+const redirectToExternal = vi.fn();
 
 vi.mock("@/api/orders", () => ({
   getOrder: (...args: unknown[]) => getOrder(...args),
@@ -16,6 +17,10 @@ vi.mock("@/api/orders", () => ({
 
 vi.mock("@/api/payments", () => ({
   createPaymentLink: (...args: unknown[]) => createPaymentLink(...args),
+}));
+
+vi.mock("@/lib/redirect", () => ({
+  redirectToExternal: (...args: unknown[]) => redirectToExternal(...args),
 }));
 
 function pendingOrder(overrides: Partial<Order> = {}): Order {
@@ -73,7 +78,7 @@ describe("OrderStatusPage", () => {
     getOrder.mockReset();
     createPaymentLink.mockReset();
     createOrder.mockReset();
-    vi.spyOn(window.location, "assign").mockImplementation(() => {});
+    redirectToExternal.mockReset();
   });
 
   afterEach(() => {
@@ -98,7 +103,7 @@ describe("OrderStatusPage", () => {
       }),
     ).toBeTruthy();
     expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
-    expect(screen.getByText("$105.00")).toBeTruthy();
+    expect(screen.getAllByText("$105.00").length).toBeGreaterThan(0);
     expect(screen.getByText("Pedido PENDING")).toBeTruthy();
     expect(screen.getByText("Pagamento PENDING")).toBeTruthy();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
@@ -186,7 +191,7 @@ describe("OrderStatusPage", () => {
       });
     });
     expect(createOrder).not.toHaveBeenCalled();
-    expect(window.location.assign).toHaveBeenCalledWith(
+    expect(redirectToExternal).toHaveBeenCalledWith(
       "https://www.paypal.com/checkoutnow?token=EC-retry",
     );
   });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -107,6 +107,8 @@ export interface CreateOrderBody {
 
 export interface OrderItemListing {
   id: string;
+  status?: Listing["status"];
+  reservationExpiresAt?: string | null;
   product: {
     id: string;
     weapon: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objective

Land the buyer on Neon Arsenal after PayPal approve/cancel, showing order + `paymentStatus` without claiming local confirmation.

Implements GitHub issue #83. Webhook remains the source of PAID. Keeps Idempotency-Key from #82.

## Changes

- Checkout sends absolute `returnUrl` / `cancelUrl` and removes those listings from the cart after `createOrder` succeeds.
- Auth-gated `/orders/:id`, `/return`, `/cancel` with light poll while `PENDING`.
- UI never says payment is confirmed unless `paymentStatus === PAID`.
- Retry calls `createPaymentLink` on the existing order.

## Verification

```text
npm run typecheck → pass
npm run lint → 0 errors
npm test → 25 files / 102 passed
```

Does not edit `server/`.

**Known gap:** `POST /payments/create` accepts `returnUrl`/`cancelUrl`, but the current PayPal `OrdersCreate` path may not forward them to PayPal. The client still sends valid absolute URLs. A later backend issue is needed if PayPal does not redirect back.

Do not merge from the agent. Do not close the GitHub issue from this environment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

