### PR TITLE
#130 — P0 — Encaminhar returnUrl e cancelUrl do POST /payments para o PayPal OrdersCreate

### DIFF
--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -60,6 +60,7 @@ PENDING → CONFIRMED → SHIPPED → DELIVERED
 8. Only `PAYMENT.CAPTURE.COMPLETED` confirms local payment. `CHECKOUT.ORDER.APPROVED` is intermediate and must not sell listings or create seller transactions.
 9. External PayPal calls have an explicit timeout. Creating or capturing a PayPal order is not retried. Looking up PayPal order status, fetching an OAuth token, or downloading a webhook certificate may retry HTTP 5xx/429, timeouts and network errors (max 3 attempts, exponential backoff).
 10. `POST /payments` (create payment link) is idempotent per local order. A durable `PaymentLink` row claims the order before `OrdersCreate`. A retry that finds `paypalOrderId` or a completed `PaymentLink` must return the original PayPal order without calling `OrdersCreate` again. Concurrent identical requests have one `OrdersCreate`. An in-progress claim returns HTTP 409.
+11. Optional `returnUrl` and `cancelUrl` on `POST /payments/create` are forwarded to PayPal `OrdersCreate` as `application_context.return_url` / `cancel_url` when present, and omitted when absent. The server does not invent defaults or env-based URLs. Buyer return/cancel at PayPal does not mark the order `PAID`; confirmation remains webhook or reconciliation.
 
 ## Seller finances
 

--- a/server/src/modules/payments/__tests__/payments.service.test.ts
+++ b/server/src/modules/payments/__tests__/payments.service.test.ts
@@ -83,9 +83,35 @@ describe("paymentsService", () => {
 
       const result = await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
 
-      expect(createPayPalOrder).toHaveBeenCalledWith("150.00", "BRL", "order-1");
+      expect(createPayPalOrder).toHaveBeenCalledWith("150.00", "BRL", "order-1", undefined);
       expect(result.approvalUrl).toBe("https://paypal.com/approve/123");
       expect(result.orderId).toBe("order-1");
+    });
+
+    it("forwards validated returnUrl and cancelUrl to OrdersCreate", async () => {
+      setupCreateLink();
+      const returnUrl = "https://app.example/orders/order-1/return";
+      const cancelUrl = "https://app.example/orders/order-1/cancel";
+
+      await paymentsService.createPaymentLink("user-1", {
+        orderId: "order-1",
+        returnUrl,
+        cancelUrl,
+      });
+
+      expect(createPayPalOrder).toHaveBeenCalledWith("150.00", "BRL", "order-1", {
+        returnUrl,
+        cancelUrl,
+      });
+    });
+
+    it("does not invent PayPal checkout URLs when the request omits them", async () => {
+      setupCreateLink();
+
+      await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
+
+      const urls = vi.mocked(createPayPalOrder).mock.calls[0]?.[3];
+      expect(urls).toBeUndefined();
     });
 
     it("throws 404 when order not found", async () => {
@@ -151,7 +177,11 @@ describe("paymentsService", () => {
         }) as never
       );
 
-      const result = await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
+      const result = await paymentsService.createPaymentLink("user-1", {
+        orderId: "order-1",
+        returnUrl: "https://app.example/orders/order-1/return",
+        cancelUrl: "https://app.example/orders/order-1/cancel",
+      });
 
       expect(createPayPalOrder).not.toHaveBeenCalled();
       expect(prisma.paymentLink.create).not.toHaveBeenCalled();

--- a/server/src/modules/payments/payments.service.ts
+++ b/server/src/modules/payments/payments.service.ts
@@ -56,7 +56,11 @@ export const paymentsService = {
         const amount = order.totalAmount.toFixed(2);
         // OrdersCreate is not retried by the PayPal client. This call happens
         // only after a durable PaymentLink claim is inserted.
-        const paypalOrder = await createPayPalOrder(amount, "BRL", order.id);
+        const checkoutUrls =
+          input.returnUrl || input.cancelUrl
+            ? { returnUrl: input.returnUrl, cancelUrl: input.cancelUrl }
+            : undefined;
+        const paypalOrder = await createPayPalOrder(amount, "BRL", order.id, checkoutUrls);
         openedPaypalOrderId = (paypalOrder as { id?: string }).id;
         if (!openedPaypalOrderId) {
           throw new AppError(500, "Failed to create PayPal order");

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -395,7 +395,21 @@ export const openApiSpec = {
               schema: {
                 type: "object",
                 required: ["orderId"],
-                properties: { orderId: { type: "string" } },
+                properties: {
+                  orderId: { type: "string" },
+                  returnUrl: {
+                    type: "string",
+                    format: "uri",
+                    description:
+                      "Optional absolute URL forwarded to PayPal OrdersCreate as application_context.return_url. Omitted when absent. Does not confirm payment.",
+                  },
+                  cancelUrl: {
+                    type: "string",
+                    format: "uri",
+                    description:
+                      "Optional absolute URL forwarded to PayPal OrdersCreate as application_context.cancel_url. Omitted when absent. Does not confirm payment.",
+                  },
+                },
               },
             },
           },

--- a/server/src/shared/utils/__tests__/paypal.orders-create.test.ts
+++ b/server/src/shared/utils/__tests__/paypal.orders-create.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildPayPalOrdersCreateBody, PAYPAL_HTTP_POLICY } from "../paypal.js";
+
+describe("PayPal OrdersCreate body", () => {
+  it("includes application_context URLs when the client supplies both", () => {
+    const returnUrl = "https://app.example/orders/order-1/return";
+    const cancelUrl = "https://app.example/orders/order-1/cancel";
+
+    expect(buildPayPalOrdersCreateBody("150.00", "BRL", "order-1", { returnUrl, cancelUrl })).toEqual({
+      intent: "CAPTURE",
+      purchase_units: [
+        {
+          reference_id: "order-1",
+          amount: { currency_code: "BRL", value: "150.00" },
+        },
+      ],
+      application_context: {
+        return_url: returnUrl,
+        cancel_url: cancelUrl,
+      },
+    });
+  });
+
+  it("omits application_context when no checkout URLs are supplied", () => {
+    const body = buildPayPalOrdersCreateBody("10.00", "BRL", "order-2");
+    expect(body.application_context).toBeUndefined();
+    expect(body).toEqual({
+      intent: "CAPTURE",
+      purchase_units: [
+        {
+          reference_id: "order-2",
+          amount: { currency_code: "BRL", value: "10.00" },
+        },
+      ],
+    });
+  });
+
+  it("does not invent a missing return or cancel URL", () => {
+    const returnOnly = buildPayPalOrdersCreateBody("10.00", "BRL", "order-3", {
+      returnUrl: "https://app.example/orders/order-3/return",
+    });
+    expect(returnOnly.application_context).toEqual({
+      return_url: "https://app.example/orders/order-3/return",
+    });
+    expect(returnOnly.application_context).not.toHaveProperty("cancel_url");
+
+    const empty = buildPayPalOrdersCreateBody("10.00", "BRL", "order-4", {});
+    expect(empty.application_context).toBeUndefined();
+  });
+
+  it("still does not retry OrdersCreate", () => {
+    expect(PAYPAL_HTTP_POLICY.orders_create.retry).toBe(false);
+  });
+});

--- a/server/src/shared/utils/paypal.ts
+++ b/server/src/shared/utils/paypal.ts
@@ -42,10 +42,31 @@ async function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   }
 }
 
-export async function createPayPalOrder(amount: string, currency = "BRL", orderId: string) {
-  const request = new paypal.orders.OrdersCreateRequest();
-  request.prefer("return=representation");
-  request.requestBody({
+export type PayPalCheckoutUrls = {
+  returnUrl?: string;
+  cancelUrl?: string;
+};
+
+type PayPalOrdersCreateBody = {
+  intent: "CAPTURE";
+  purchase_units: Array<{
+    reference_id: string;
+    amount: { currency_code: string; value: string };
+  }>;
+  application_context?: {
+    return_url?: string;
+    cancel_url?: string;
+  };
+};
+
+/** PayPal Orders v2 body. Omits application_context unless client URLs were supplied. */
+export function buildPayPalOrdersCreateBody(
+  amount: string,
+  currency: string,
+  orderId: string,
+  urls?: PayPalCheckoutUrls
+): PayPalOrdersCreateBody {
+  const body: PayPalOrdersCreateBody = {
     intent: "CAPTURE",
     purchase_units: [
       {
@@ -56,7 +77,25 @@ export async function createPayPalOrder(amount: string, currency = "BRL", orderI
         },
       },
     ],
-  });
+  };
+  const application_context: { return_url?: string; cancel_url?: string } = {};
+  if (urls?.returnUrl) application_context.return_url = urls.returnUrl;
+  if (urls?.cancelUrl) application_context.cancel_url = urls.cancelUrl;
+  if (application_context.return_url || application_context.cancel_url) {
+    body.application_context = application_context;
+  }
+  return body;
+}
+
+export async function createPayPalOrder(
+  amount: string,
+  currency = "BRL",
+  orderId: string,
+  urls?: PayPalCheckoutUrls
+) {
+  const request = new paypal.orders.OrdersCreateRequest();
+  request.prefer("return=representation");
+  request.requestBody(buildPayPalOrdersCreateBody(amount, currency, orderId, urls));
   return withPaypalOperation("orders_create", async () => {
     // OrdersCreate is not retried: a retry can create a second PayPal order.
     const response = await withTimeout(client.execute(request), "PayPal OrdersCreate");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fecha o gap entre o DTO de `POST /payments/create` (que já aceita `returnUrl`/`cancelUrl`) e o PayPal `OrdersCreate`, que não enviava `application_context`. Sem isso, as páginas de retorno/cancelamento do #83 não são alcançáveis pelo fluxo real.

## O que muda

- `createPaymentLink` encaminha URLs já validadas pelo DTO para `createPayPalOrder`.
- `OrdersCreate` inclui `application_context.return_url` / `cancel_url` só quando o cliente envia as URLs.
- Sem URLs no request, `application_context` é omitido — o servidor não inventa defaults nem env vars.
- Replay do payment link (#39/R1) continua sem segundo `OrdersCreate`, mesmo se o retry vier com URLs novas.
- Return/cancel **não** marcam o pedido como `PAID`. Confirmação permanece webhook / reconciliação.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/130

## Critérios de aceite

- [x] URLs válidas no `POST /payments/create` aparecem no body do PayPal `OrdersCreate`
- [x] Sem esses campos, o PayPal não recebe URLs inventadas
- [x] Replay de payment link válido não chama `OrdersCreate` de novo
- [x] Return/cancel não confirmam pagamento
- [x] Diff em `server/` (+ uma linha de invariante); sem `src/`

## Verificação

- `npx vitest run src/modules/payments/__tests__/payments.service.test.ts src/shared/utils/__tests__/paypal.orders-create.test.ts src/shared/utils/__tests__/paypal.policy.test.ts` → 32 passed
- `cd server && npm run typecheck` → pass
- `cd server && npm run test:integration` → 60 passed (inclui `payment.link.idempotency.integration.test.ts`)

## Invariantes

- `OrdersCreate` continua sem retry
- Idempotência do payment link preservada
- Nova invariante 11 em `docs/architecture/domain-invariants.md`

## Risco conhecido

Se o primeiro `OrdersCreate` omitiu URLs, um replay posterior com URLs devolve o pedido PayPal original (sem segundo create). Isso é a idempotência de #39, não um bug desta issue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

