### PR TITLE
#84 — [UX] Expor reserva, TTL e countdown de reservationExpiresAt

### DIFF
--- a/src/components/ReservationHold.tsx
+++ b/src/components/ReservationHold.tsx
@@ -1,0 +1,71 @@
+import {
+  EXPIRED_HOLD_COPY,
+  PRE_ORDER_HOLD_COPY,
+  VERIFYING_RESERVATION_COPY,
+  formatReservationCountdown,
+  reservationLiveAnnouncement,
+} from "@/lib/orderPaymentView";
+
+export type ReservationHoldPhase = "pre-order" | "order";
+
+export function ReservationHold({
+  phase,
+  expiresAt = null,
+  now = Date.now(),
+  isLoading = false,
+}: {
+  phase: ReservationHoldPhase;
+  expiresAt?: number | null;
+  now?: number;
+  isLoading?: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-md border border-border bg-card p-4"
+        role="status"
+      >
+        <p className="text-sm text-muted-foreground">
+          {VERIFYING_RESERVATION_COPY}
+        </p>
+      </div>
+    );
+  }
+
+  if (phase === "pre-order") {
+    return (
+      <div className="rounded-md border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">{PRE_ORDER_HOLD_COPY}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Cada listing é único. Adicionar ao carrinho não segura o item.
+        </p>
+      </div>
+    );
+  }
+
+  if (expiresAt == null) {
+    return null;
+  }
+
+  const expired = expiresAt <= now;
+  const countdown = formatReservationCountdown(expiresAt, now);
+  const liveText = reservationLiveAnnouncement(expiresAt, now);
+
+  return (
+    <div className="rounded-md border border-border bg-card p-4">
+      {expired ? (
+        <p className="text-sm text-foreground">{EXPIRED_HOLD_COPY}</p>
+      ) : (
+        <p className="text-sm text-foreground">
+          Reservado para você ·{" "}
+          <span className="tabular-nums">{countdown}</span> restantes
+        </p>
+      )}
+      {liveText ? (
+        <p className="sr-only" aria-live="polite" aria-atomic="true">
+          {liveText}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/__tests__/ReservationHold.test.tsx
+++ b/src/components/__tests__/ReservationHold.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReservationHold } from "../ReservationHold";
+import {
+  EXPIRED_HOLD_COPY,
+  PRE_ORDER_HOLD_COPY,
+  VERIFYING_RESERVATION_COPY,
+} from "@/lib/orderPaymentView";
+
+const NOW = Date.parse("2026-09-05T12:00:00.000Z");
+
+describe("ReservationHold", () => {
+  it("does not claim a hold before the order exists", () => {
+    render(<ReservationHold phase="pre-order" now={NOW} />);
+    expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
+    expect(screen.getByText(/não segura o item/i)).toBeTruthy();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
+    expect(screen.queryByText(/\d{2}:\d{2}/)).toBeNull();
+  });
+
+  it("shows a verifying placeholder while the order loads", () => {
+    render(<ReservationHold phase="order" isLoading now={NOW} />);
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText(VERIFYING_RESERVATION_COPY)).toBeTruthy();
+    expect(screen.queryByText(/15:00/)).toBeNull();
+  });
+
+  it("renders no countdown when there is no server expiry", () => {
+    const { container } = render(
+      <ReservationHold phase="order" expiresAt={null} now={NOW} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
+  });
+
+  it("counts down from reservationExpiresAt instead of a local 15-minute timer", () => {
+    const expiresAt = Date.parse("2026-09-05T12:01:32.000Z");
+    render(<ReservationHold phase="order" expiresAt={expiresAt} now={NOW} />);
+    expect(screen.getAllByText(/Reservado para você/).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText("01:32")).toBeTruthy();
+    expect(screen.queryByText("15:00")).toBeNull();
+    expect(
+      screen.getByText("Reservado para você. 1 minuto restante."),
+    ).toBeTruthy();
+  });
+
+  it("announces remaining minutes politely, not the ticking seconds", () => {
+    const expiresAt = Date.parse("2026-09-05T12:14:32.000Z");
+    render(<ReservationHold phase="order" expiresAt={expiresAt} now={NOW} />);
+    const live = screen.getByText("Reservado para você. 14 minutos restantes.");
+    expect(live.getAttribute("aria-live")).toBe("polite");
+    expect(screen.getByText("14:32")).toBeTruthy();
+  });
+
+  it("uses expired-hold copy that is not a payment refusal", () => {
+    const expiresAt = Date.parse("2026-09-05T11:59:00.000Z");
+    render(<ReservationHold phase="order" expiresAt={expiresAt} now={NOW} />);
+    expect(screen.getAllByText(EXPIRED_HOLD_COPY).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/pagamento recusado/i)).toBeNull();
+    expect(screen.queryByText(/PayPal recusou/i)).toBeNull();
+    expect(screen.queryByText(/Reservado para você ·/)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/orderPaymentView.test.ts
+++ b/src/lib/__tests__/orderPaymentView.test.ts
@@ -5,9 +5,13 @@ import {
   formatReservationCountdown,
   isOrderAccessError,
   isPaymentConfirmed,
+  earliestReservationExpiresAt,
+  isReservationExpired,
   orderPageIntent,
   orderPollIntervalMs,
   ORDER_POLL_INTERVAL_MS,
+  reservationLiveAnnouncement,
+  EXPIRED_HOLD_COPY,
 } from "../orderPaymentView";
 
 function order(overrides: Partial<Order> = {}): Order {
@@ -109,6 +113,84 @@ describe("orderPaymentView", () => {
     expect(
       formatReservationCountdown(Date.parse("2026-09-05T11:59:00.000Z"), now),
     ).toBe("00:00");
+    expect(formatReservationCountdown(null, now)).toBeNull();
+  });
+
+  it("picks the earliest listing reservationExpiresAt on the order", () => {
+    const later = order();
+    const mixed = {
+      ...later,
+      items: [
+        {
+          ...later.items![0],
+          listing: {
+            ...later.items![0].listing!,
+            reservationExpiresAt: "2026-09-05T12:14:00.000Z",
+          },
+        },
+        {
+          id: "item-2",
+          listingId: "listing-awp",
+          sellerId: "seller-1",
+          priceSnapshot: 50,
+          listing: {
+            id: "listing-awp",
+            reservedAt: "2026-09-05T12:00:00.000Z",
+            reservationExpiresAt: "2026-09-05T12:03:00.000Z",
+            reservedByOrderId: "order-1",
+            product: {
+              id: "prod-2",
+              weapon: "AWP",
+              skinName: "Asiimov",
+              exterior: "Field-Tested",
+            },
+          },
+        },
+      ],
+    };
+    expect(earliestReservationExpiresAt(mixed)).toBe(
+      Date.parse("2026-09-05T12:03:00.000Z"),
+    );
+  });
+
+  it("does not invent expiry when the server omitted reservationExpiresAt", () => {
+    const now = Date.parse("2026-09-05T12:00:00.000Z");
+    const bare = order({
+      items: [
+        {
+          id: "item-1",
+          listingId: "listing-ak",
+          sellerId: "seller-1",
+          priceSnapshot: 100,
+          listing: {
+            id: "listing-ak",
+            product: {
+              id: "prod-1",
+              weapon: "AK-47",
+              skinName: "Redline",
+              exterior: "Field-Tested",
+            },
+          },
+        },
+      ],
+    });
+    expect(earliestReservationExpiresAt(bare)).toBeNull();
+    expect(isReservationExpired(bare, now)).toBe(false);
+    expect(canRetryPayment(bare, now)).toBe(true);
+  });
+
+  it("announces remaining minutes, not ticking seconds", () => {
+    const now = Date.parse("2026-09-05T12:00:00.000Z");
+    expect(
+      reservationLiveAnnouncement(Date.parse("2026-09-05T12:14:32.000Z"), now),
+    ).toBe("Reservado para você. 14 minutos restantes.");
+    expect(
+      reservationLiveAnnouncement(Date.parse("2026-09-05T12:00:40.000Z"), now),
+    ).toBe("Reservado para você. Menos de um minuto restante.");
+    expect(
+      reservationLiveAnnouncement(Date.parse("2026-09-05T11:59:00.000Z"), now),
+    ).toBe(EXPIRED_HOLD_COPY);
+    expect(reservationLiveAnnouncement(null, now)).toBeNull();
   });
 
   it("polls only pending unpaid return/view orders", () => {

--- a/src/lib/orderPaymentView.ts
+++ b/src/lib/orderPaymentView.ts
@@ -4,6 +4,14 @@ export type OrderPageIntent = "return" | "cancel" | "view";
 
 export const ORDER_POLL_INTERVAL_MS = 4000;
 
+export const PRE_ORDER_HOLD_COPY =
+  "O item só é reservado quando você inicia o pagamento.";
+
+export const EXPIRED_HOLD_COPY =
+  "A reserva expirou. O item pode ter voltado ao Market.";
+
+export const VERIFYING_RESERVATION_COPY = "verificando reserva…";
+
 export function orderPageIntent(pathname: string): OrderPageIntent {
   if (pathname.endsWith("/cancel")) return "cancel";
   if (pathname.endsWith("/return")) return "return";
@@ -48,15 +56,40 @@ export function canRetryPayment(
   return !isReservationExpired(order, now);
 }
 
+export function remainingReservationSeconds(
+  expiresAt: number | null,
+  now = Date.now(),
+): number | null {
+  if (expiresAt == null) return null;
+  return Math.max(0, Math.floor((expiresAt - now) / 1000));
+}
+
 export function formatReservationCountdown(
   expiresAt: number | null,
   now = Date.now(),
 ): string | null {
-  if (expiresAt == null) return null;
-  const totalSec = Math.max(0, Math.floor((expiresAt - now) / 1000));
+  const totalSec = remainingReservationSeconds(expiresAt, now);
+  if (totalSec == null) return null;
   const minutes = Math.floor(totalSec / 60);
   const seconds = totalSec % 60;
   return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+/** Minute-granularity copy for aria-live="polite". Does not change every second. */
+export function reservationLiveAnnouncement(
+  expiresAt: number | null,
+  now = Date.now(),
+): string | null {
+  const totalSec = remainingReservationSeconds(expiresAt, now);
+  if (totalSec == null) return null;
+  if (totalSec <= 0) return EXPIRED_HOLD_COPY;
+  const minutes = Math.floor(totalSec / 60);
+  if (minutes <= 0) {
+    return "Reservado para você. Menos de um minuto restante.";
+  }
+  return `Reservado para você. ${minutes} ${
+    minutes === 1 ? "minuto restante" : "minutos restantes"
+  }.`;
 }
 
 export function orderPollIntervalMs(

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Trash2 } from "lucide-react";
 import { useCart } from "@/contexts/CartContext";
 import { EmptyState } from "@/components/page-state";
+import { ReservationHold } from "@/components/ReservationHold";
 import { Button } from "@/components/ui/button";
 
 function listingLabel(listing: {
@@ -98,6 +99,7 @@ export default function CartPage() {
               <dd className="tabular-price">${total.toFixed(2)}</dd>
             </div>
           </dl>
+          <ReservationHold phase="pre-order" />
           <Button asChild className="w-full" size="lg">
             <Link to="/checkout">Finalizar compra</Link>
           </Button>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,17 +1,23 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useCart } from "@/contexts/CartContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { createOrder } from "@/api/orders";
 import { createPaymentLink } from "@/api/payments";
 import { EmptyState } from "@/components/page-state";
+import { ReservationHold } from "@/components/ReservationHold";
 import { Button } from "@/components/ui/button";
 import {
   resolveCheckoutIdempotencyKey,
   type CheckoutIdempotencyState,
 } from "@/lib/checkoutIdempotency";
+import {
+  earliestReservationExpiresAt,
+  isReservationExpired,
+} from "@/lib/orderPaymentView";
 import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
 import { redirectToExternal } from "@/lib/redirect";
+import type { Order } from "@/types/api";
 
 export default function Checkout() {
   const { items, totalPrice, removeItems } = useCart();
@@ -19,12 +25,26 @@ export default function Checkout() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [createdOrder, setCreatedOrder] = useState<Order | null>(null);
+  const [now, setNow] = useState(() => Date.now());
   const inFlightRef = useRef(false);
   const idempotencyRef = useRef<CheckoutIdempotencyState | null>(null);
   const serviceFee = totalPrice * 0.05;
   const total = totalPrice * 1.05;
+  const expiresAt = createdOrder
+    ? earliestReservationExpiresAt(createdOrder)
+    : null;
+  const reservationExpired = createdOrder
+    ? isReservationExpired(createdOrder, now)
+    : false;
 
-  if (items.length === 0 && !loading) {
+  useEffect(() => {
+    if (expiresAt == null) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [expiresAt]);
+
+  if (items.length === 0 && !loading && !createdOrder) {
     return (
       <div className="container py-8">
         <h1 className="sr-only">Checkout</h1>
@@ -82,6 +102,7 @@ export default function Checkout() {
         { idempotencyKey: idempotencyRef.current.key },
       );
       createdOrderId = order.id;
+      setCreatedOrder(order);
       removeItems(listingIds);
       const payment = await createPaymentLink({
         orderId: order.id,
@@ -114,6 +135,14 @@ export default function Checkout() {
         <p className="mt-1 text-sm text-muted-foreground">
           Revise os itens e pague no PayPal. Nada é confirmado nesta tela.
         </p>
+      </div>
+
+      <div className="mb-6">
+        <ReservationHold
+          phase={createdOrder ? "order" : "pre-order"}
+          expiresAt={expiresAt}
+          now={now}
+        />
       </div>
 
       <div className="space-y-6">
@@ -171,7 +200,12 @@ export default function Checkout() {
             className="w-full"
             size="lg"
             onClick={handlePay}
-            disabled={loading}
+            disabled={loading || reservationExpired}
+            title={
+              reservationExpired
+                ? "A reserva expirou. O item pode ter voltado ao Market."
+                : undefined
+            }
           >
             {loading
               ? "Abrindo o PayPal..."

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -4,12 +4,14 @@ import { useQuery } from "@tanstack/react-query";
 import { getOrder } from "@/api/orders";
 import { createPaymentLink } from "@/api/payments";
 import { ErrorState, PageSkeleton } from "@/components/page-state";
+import { ReservationHold } from "@/components/ReservationHold";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  EXPIRED_HOLD_COPY,
+  VERIFYING_RESERVATION_COPY,
   canRetryPayment,
   earliestReservationExpiresAt,
-  formatReservationCountdown,
   isOrderAccessError,
   isPaymentConfirmed,
   isReservationExpired,
@@ -25,11 +27,11 @@ import type { Order } from "@/types/api";
 function OrderHeadline({
   order,
   intent,
-  countdown,
+  expired,
 }: {
   order: Order;
   intent: ReturnType<typeof orderPageIntent>;
-  countdown: string | null;
+  expired: boolean;
 }) {
   if (isPaymentConfirmed(order)) {
     return (
@@ -45,33 +47,28 @@ function OrderHeadline({
     );
   }
 
-  if (intent === "cancel") {
-    const expired = isReservationExpired(order);
-    return (
-      <>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Você cancelou o pagamento.
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {expired
-            ? "A reserva deste pedido já expirou. O pagamento continua pendente até o PayPal confirmar — esta tela não marca o pedido como pago."
-            : countdown
-              ? `Sua reserva expira em ${countdown}. O pedido ainda está pendente.`
-              : "O pedido ainda está pendente. A reserva pode expirar se o pagamento não for concluído."}
-        </p>
-      </>
-    );
-  }
-
-  if (isReservationExpired(order)) {
+  if (expired) {
     return (
       <>
         <h1 className="text-2xl font-semibold tracking-tight">
           Reserva expirada.
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          O pagamento não foi confirmado pelo PayPal. Esta página não marca o
-          pedido como pago.
+          Não conclua o pagamento neste pedido. Esta tela não marca o pedido
+          como pago.
+        </p>
+      </>
+    );
+  }
+
+  if (intent === "cancel") {
+    return (
+      <>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Você cancelou o pagamento.
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          O pedido ainda está pendente. Esta tela não marca o pedido como pago.
         </p>
       </>
     );
@@ -137,7 +134,7 @@ export default function OrderStatusPage() {
   }
 
   if (isLoading) {
-    return <PageSkeleton label="Carregando pedido" />;
+    return <PageSkeleton label={VERIFYING_RESERVATION_COPY} />;
   }
 
   if (isError || !order) {
@@ -177,8 +174,9 @@ export default function OrderStatusPage() {
 
   const paid = isPaymentConfirmed(order);
   const retryEnabled = canRetryPayment(order, now);
-  const countdown = formatReservationCountdown(expiresAt, now);
   const expired = isReservationExpired(order, now);
+  const showPayButton =
+    !paid && order.status !== "CANCELLED" && order.paymentStatus === "PENDING";
 
   const handleRetry = async () => {
     if (!retryEnabled || retrying) return;
@@ -209,8 +207,11 @@ export default function OrderStatusPage() {
 
   return (
     <div className="container max-w-2xl py-8">
-      <div className="mb-8">
-        <OrderHeadline order={order} intent={intent} countdown={countdown} />
+      <div className="mb-8 space-y-4">
+        <OrderHeadline order={order} intent={intent} expired={expired} />
+        {!paid ? (
+          <ReservationHold phase="order" expiresAt={expiresAt} now={now} />
+        ) : null}
       </div>
 
       <section className="space-y-4 rounded-md border border-border bg-card p-4">
@@ -255,7 +256,7 @@ export default function OrderStatusPage() {
             {order.status === "CANCELLED"
               ? "Este pedido foi cancelado. Não é possível reutilizar o mesmo pedido para pagar."
               : expired
-                ? "A reserva expirou. Não é possível pagar novamente neste pedido."
+                ? "O pagamento não deve ser concluído neste pedido."
                 : "Pagar novamente só fica disponível enquanto o pagamento estiver pendente."}
           </p>
         ) : null}
@@ -265,11 +266,12 @@ export default function OrderStatusPage() {
               <Link to={`/orders/${order.id}`}>Ver pedido</Link>
             </Button>
           ) : null}
-          {retryEnabled ? (
+          {showPayButton ? (
             <Button
               type="button"
               onClick={() => void handleRetry()}
-              disabled={retrying}
+              disabled={!retryEnabled || retrying}
+              title={expired ? EXPIRED_HOLD_COPY : undefined}
             >
               {retrying ? "Abrindo o PayPal..." : "Pagar novamente"}
             </Button>

--- a/src/pages/__tests__/CartPage.test.tsx
+++ b/src/pages/__tests__/CartPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import CartPage from "../CartPage";
 import type { Listing } from "@/types/api";
+import { PRE_ORDER_HOLD_COPY } from "@/lib/orderPaymentView";
 
 const cartState = {
   items: [] as { listing: Listing }[],
@@ -78,6 +79,20 @@ describe("CartPage", () => {
     expect(screen.getByText("$5.00")).toBeTruthy();
     expect(screen.getByText("$105.00")).toBeTruthy();
     expect(screen.getByText("Finalizar compra")).toBeTruthy();
+    expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
+    expect(screen.queryByText(/15:00/)).toBeNull();
     expect(screen.queryByText("SKINMARKET")).toBeNull();
+  });
+
+  it("does not claim the listing is held in the cart", () => {
+    cartState.items = [{ listing: listing("listing-ak", 100) }];
+    cartState.totalPrice = 100;
+    cartState.totalItems = 1;
+    renderCart();
+    expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
+    expect(screen.getByText(/não segura o item/i)).toBeTruthy();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
+    expect(screen.queryByRole("timer")).toBeNull();
   });
 });

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Checkout from "../Checkout";
-import type { Listing, User } from "@/types/api";
+import type { Listing, Order, User } from "@/types/api";
+import { PRE_ORDER_HOLD_COPY } from "@/lib/orderPaymentView";
 
 const createOrder = vi.fn();
 const createPaymentLink = vi.fn();
 const redirectToExternal = vi.fn();
+const reserveListing = vi.fn();
 
 const cartState = {
   items: [] as { listing: Listing }[],
@@ -40,6 +42,10 @@ vi.mock("@/lib/redirect", () => ({
   redirectToExternal: (...args: unknown[]) => redirectToExternal(...args),
 }));
 
+vi.mock("@/api/listings", () => ({
+  reserveListing: (...args: unknown[]) => reserveListing(...args),
+}));
+
 function listing(price = 100, id = "listing-ak"): Listing {
   return {
     id,
@@ -68,6 +74,37 @@ function listing(price = 100, id = "listing-ak"): Listing {
     },
     seller: { id: "seller-1", storeName: "Store Alpha" },
   } as Listing;
+}
+
+function pendingCreatedOrder(expiresAt: string, id = "order-1"): Order {
+  return {
+    id,
+    totalAmount: 105,
+    status: "PENDING",
+    paymentStatus: "PENDING",
+    createdAt: "2026-09-05T12:00:00.000Z",
+    updatedAt: "2026-09-05T12:00:00.000Z",
+    items: [
+      {
+        id: "item-1",
+        listingId: "listing-ak",
+        sellerId: "seller-1",
+        priceSnapshot: 100,
+        listing: {
+          id: "listing-ak",
+          reservedAt: "2026-09-05T12:00:00.000Z",
+          reservationExpiresAt: expiresAt,
+          reservedByOrderId: id,
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+      },
+    ],
+  };
 }
 
 function expectedPaypalUrls(orderId: string) {
@@ -126,6 +163,7 @@ describe("Checkout", () => {
     createOrder.mockReset();
     createPaymentLink.mockReset();
     redirectToExternal.mockReset();
+    reserveListing.mockReset();
     let uuidIndex = 0;
     vi.spyOn(crypto, "randomUUID").mockImplementation(
       () => uuidKeys[uuidIndex++] ?? "overflow-uuid",
@@ -163,6 +201,8 @@ describe("Checkout", () => {
     expect(screen.getByText("$5.00")).toBeTruthy();
     expect(screen.getByText("$105.00")).toBeTruthy();
     expect(screen.getByText(/Pagar com PayPal — \$105\.00/)).toBeTruthy();
+    expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();
     expect(screen.queryByText(/processado com sucesso/i)).toBeNull();
     expect(
@@ -350,6 +390,45 @@ describe("Checkout", () => {
     expect(createPaymentLink.mock.calls[0][0]).toMatchObject({
       orderId: "order-1",
       ...expectedPaypalUrls("order-1"),
+    });
+  });
+
+  it("does not reserve on checkout start and shows a server countdown after createOrder", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    asCustomer();
+    const now = Date.parse("2026-09-05T12:00:00.000Z");
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    createOrder.mockResolvedValue(
+      pendingCreatedOrder("2026-09-05T12:01:32.000Z"),
+    );
+    let releasePayment: (value: { approvalUrl: string }) => void = () => {};
+    createPaymentLink.mockImplementation(
+      () =>
+        new Promise<{ approvalUrl: string }>((resolve) => {
+          releasePayment = resolve;
+        }),
+    );
+
+    renderCheckout();
+    expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    expect(await screen.findAllByText(/Reservado para você/)).toHaveLength(2);
+    expect(screen.getByText("01:32")).toBeTruthy();
+    expect(screen.queryByText("15:00")).toBeNull();
+    expect(reserveListing).not.toHaveBeenCalled();
+    expect(createPaymentLink).toHaveBeenCalledTimes(1);
+
+    releasePayment({
+      approvalUrl: "https://www.paypal.com/checkoutnow?token=EC-1",
+    });
+    await waitFor(() => {
+      expect(redirectToExternal).toHaveBeenCalledWith(
+        "https://www.paypal.com/checkoutnow?token=EC-1",
+      );
     });
   });
 });

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -9,10 +9,12 @@ const getListing = vi.fn();
 const listListings = vi.fn();
 const getPriceHistory = vi.fn();
 const addItem = vi.fn();
+const reserveListing = vi.fn();
 
 vi.mock("@/api/listings", () => ({
   getListing: (...args: unknown[]) => getListing(...args),
   listListings: (...args: unknown[]) => listListings(...args),
+  reserveListing: (...args: unknown[]) => reserveListing(...args),
 }));
 
 vi.mock("@/api/price-history", () => ({
@@ -94,6 +96,7 @@ describe("ListingDetail", () => {
     listListings.mockReset();
     getPriceHistory.mockReset();
     addItem.mockReset();
+    reserveListing.mockReset();
     listListings.mockResolvedValue({ items: [], total: 0, page: 1, limit: 4 });
     getPriceHistory.mockResolvedValue([]);
   });
@@ -135,6 +138,9 @@ describe("ListingDetail", () => {
     expect(addButton).not.toHaveProperty("disabled", true);
     addButton.click();
     expect(addItem).toHaveBeenCalledTimes(1);
+    expect(reserveListing).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
+    expect(screen.queryByText(/15:00/)).toBeNull();
   });
 
   it("disables purchase when the listing is not ACTIVE", async () => {

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -4,6 +4,10 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import OrderStatusPage from "../OrderStatus";
 import type { Order } from "@/types/api";
+import {
+  EXPIRED_HOLD_COPY,
+  VERIFYING_RESERVATION_COPY,
+} from "@/lib/orderPaymentView";
 
 const getOrder = vi.fn();
 const createPaymentLink = vi.fn();
@@ -89,8 +93,9 @@ describe("OrderStatusPage", () => {
     getOrder.mockImplementation(() => new Promise(() => {}));
     renderPage("/orders/order-1/return");
     expect(
-      screen.getByRole("status", { name: "Carregando pedido" }),
+      screen.getByRole("status", { name: VERIFYING_RESERVATION_COPY }),
     ).toBeTruthy();
+    expect(screen.queryByText(/15:00/)).toBeNull();
   });
 
   it("does not claim payment is confirmed while paymentStatus is PENDING", async () => {
@@ -108,6 +113,10 @@ describe("OrderStatusPage", () => {
     expect(screen.getByText("Pagamento PENDING")).toBeTruthy();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
     expect(screen.getByText(/confirmação real vem do PayPal/i)).toBeTruthy();
+    expect(screen.getAllByText(/Reservado para você/).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText("15:00")).toBeNull();
   });
 
   it("says payment is confirmed only when paymentStatus is PAID", async () => {
@@ -120,6 +129,7 @@ describe("OrderStatusPage", () => {
       await screen.findByRole("heading", { name: "Pagamento confirmado." }),
     ).toBeTruthy();
     expect(screen.getByText("Pagamento PAID")).toBeTruthy();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Pagar novamente" }),
     ).toBeNull();
@@ -134,7 +144,11 @@ describe("OrderStatusPage", () => {
         name: "Você cancelou o pagamento.",
       }),
     ).toBeTruthy();
-    expect(screen.getByText(/reserva expira em \d{2}:\d{2}/)).toBeTruthy();
+    expect(screen.getAllByText(/Reservado para você/).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText(/\d{2}:\d{2}/)).toBeTruthy();
+    expect(screen.queryByText("15:00")).toBeNull();
     expect(screen.getByText("Pedido PENDING")).toBeTruthy();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
     expect(
@@ -161,6 +175,8 @@ describe("OrderStatusPage", () => {
 
     expect(await screen.findByText("Erro ao carregar o pedido")).toBeTruthy();
     expect(screen.getByText("Falha de rede")).toBeTruthy();
+    expect(screen.queryByText(/15:00/)).toBeNull();
+    expect(screen.queryByText(/Reservado para você/)).toBeNull();
     getOrder.mockResolvedValue(pendingOrder());
     fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
     expect(
@@ -222,16 +238,54 @@ describe("OrderStatusPage", () => {
     renderPage("/orders/order-1/cancel");
 
     expect(
-      await screen.findByText(/reserva deste pedido já expirou/i),
+      await screen.findByRole("heading", { name: "Reserva expirada." }),
     ).toBeTruthy();
+    expect(screen.getAllByText(EXPIRED_HOLD_COPY).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/pagamento recusado/i)).toBeNull();
+    expect(screen.queryByText(/PayPal recusou/i)).toBeNull();
     expect(
-      screen.queryByRole("button", { name: "Pagar novamente" }),
+      screen.queryByRole("heading", { name: "Você cancelou o pagamento." }),
     ).toBeNull();
+    const pay = screen.getByRole("button", { name: "Pagar novamente" });
+    expect(pay).toBeDisabled();
+    expect(pay).toHaveAttribute("title", EXPIRED_HOLD_COPY);
+  });
+
+  it("counts down from the server reservationExpiresAt, not a local 15-minute timer", async () => {
+    const now = Date.parse("2026-09-05T12:00:00.000Z");
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    getOrder.mockResolvedValue(
+      pendingOrder({
+        items: [
+          {
+            id: "item-1",
+            listingId: "listing-ak",
+            sellerId: "seller-1",
+            priceSnapshot: 105,
+            listing: {
+              id: "listing-ak",
+              reservedAt: "2026-09-05T12:00:00.000Z",
+              reservationExpiresAt: "2026-09-05T12:04:05.000Z",
+              reservedByOrderId: "order-1",
+              product: {
+                id: "prod-1",
+                weapon: "AK-47",
+                skinName: "Redline",
+                exterior: "Field-Tested",
+              },
+            },
+          },
+        ],
+      }),
+    );
+    renderPage("/orders/order-1");
+
+    expect(await screen.findAllByText(/Reservado para você/)).toHaveLength(2);
+    expect(screen.getByText("04:05")).toBeTruthy();
+    expect(screen.queryByText("15:00")).toBeNull();
     expect(
-      screen.getByText(
-        "A reserva expirou. Não é possível pagar novamente neste pedido.",
-      ),
-    ).toBeTruthy();
+      screen.getByText("Reservado para você. 4 minutos restantes."),
+    ).toHaveAttribute("aria-live", "polite");
   });
 
   it("surfaces a backend rejection instead of inventing a new order", async () => {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -67,6 +67,9 @@ export interface Listing {
   currency: string;
   status: "ACTIVE" | "SOLD" | "RESERVED" | "CANCELED";
   tradeLockUntil?: string | null;
+  reservedAt?: string | null;
+  reservationExpiresAt?: string | null;
+  reservedByOrderId?: string | null;
   steamAssetId?: string | null;
   createdAt: string;
   soldAt?: string | null;
@@ -108,7 +111,9 @@ export interface CreateOrderBody {
 export interface OrderItemListing {
   id: string;
   status?: Listing["status"];
+  reservedAt?: string | null;
   reservationExpiresAt?: string | null;
+  reservedByOrderId?: string | null;
   product: {
     id: string;
     weapon: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Expõe a reserva de listing único no cliente usando `reservationExpiresAt` do servidor — no carrinho (sem hold), no checkout depois de `createOrder`, e nas páginas de pedido pendente / retorno PayPal.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/84

## O que muda

- Tipos `Listing` / listing aninhado no pedido passam a incluir `reservedAt`, `reservationExpiresAt`, `reservedByOrderId` (campos já no contrato da API; não inventados no root do Order).
- Carrinho e checkout pré-pedido: copy honesta de que o item só é reservado ao iniciar o pagamento. Sem `POST /listings/:id/reserve` no add-to-cart.
- Depois de `createOrder`: countdown a partir de `reservationExpiresAt` dos items.
- Pedido pendente / return / cancel: o mesmo countdown. Expirado é distinto de pagamento recusado/cancelado no PayPal. Pagar fica desabilitado na UI quando o hold daquele pedido expirou.
- `aria-live="polite"` anuncia minutos (ou expiração), não cada segundo. O mm:ss visível atualiza localmente sem refetch.

## Critérios de aceite

- [x] Countdown usa `reservationExpiresAt` do servidor, não um timer local de 15 min
- [x] A UI não afirma hold no add-to-cart
- [x] Estado expirado é distinto de pagamento recusado
- [x] Tempo também em texto (aria-live no minuto)

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 26 files, 114 tests passed

## Invariantes

- Reserva continua começando só em `POST /orders`
- Cliente nunca marca `PAID`
- Cliente nunca inventa TTL
- Pay desabilitado é só UX; o backend ainda recusa capture expirado

## Riscos

- Se `createOrder` omitir `listing.reservationExpiresAt`, o countdown não aparece (pay permanece habilitado; o TTL continua no servidor).
- No happy path o countdown no checkout é breve (redirect PayPal); a superfície durável é `/orders/:id`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

