### PR TITLE
#85 — [UX] Revalidar disponibilidade e preço dos listings do carrinho antes do checkout

### DIFF
--- a/src/components/CartListingAlerts.tsx
+++ b/src/components/CartListingAlerts.tsx
@@ -1,0 +1,35 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatCartMoney, type CartLineView } from "@/lib/cartListingStatus";
+
+export function CartListingAlerts({ line }: { line: CartLineView }) {
+  if (line.kind === "error") {
+    return (
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <Badge variant="destructive">Erro ao atualizar</Badge>
+        <Button type="button" variant="ghost" size="sm" onClick={line.retry}>
+          Tentar novamente
+        </Button>
+      </div>
+    );
+  }
+
+  if (line.kind === "unavailable") {
+    return (
+      <p className="mt-2 text-sm text-destructive" role="status">
+        {line.name} não está mais disponível
+      </p>
+    );
+  }
+
+  if (line.kind === "price-changed") {
+    return (
+      <p className="mt-2 text-sm text-muted-foreground" role="status">
+        Preço atualizado: {formatCartMoney(line.previousPrice)} →{" "}
+        {formatCartMoney(line.currentPrice)}
+      </p>
+    );
+  }
+
+  return null;
+}

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,13 +1,22 @@
-import { createContext, useContext, useState, ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  ReactNode,
+} from "react";
 import type { Listing } from "@/types/api";
+import { cartSnapshotNeedsUpdate } from "@/lib/cartListingStatus";
 
 export interface CartItem {
   listing: Listing;
+  priceWhenAdded: Listing["price"];
 }
 
 interface CartContextType {
   items: CartItem[];
   addItem: (listing: Listing) => void;
+  updateListing: (listing: Listing) => void;
   removeItem: (listingId: string) => void;
   removeItems: (listingIds: string[]) => void;
   clearCart: () => void;
@@ -29,8 +38,20 @@ export function CartProvider({ children }: { children: ReactNode }) {
     if (listing.status !== "ACTIVE") {
       return; // Cannot add non-active listings
     }
-    setItems((prev) => [...prev, { listing }]);
+    setItems((prev) => [...prev, { listing, priceWhenAdded: listing.price }]);
   };
+
+  const updateListing = useCallback((listing: Listing) => {
+    setItems((prev) => {
+      const index = prev.findIndex((item) => item.listing.id === listing.id);
+      if (index === -1) return prev;
+      const current = prev[index].listing;
+      if (!cartSnapshotNeedsUpdate(current, listing)) return prev;
+      const next = [...prev];
+      next[index] = { ...next[index], listing };
+      return next;
+    });
+  }, []);
 
   const removeItem = (listingId: string) =>
     setItems((prev) => prev.filter((i) => i.listing.id !== listingId));
@@ -49,6 +70,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
       value={{
         items,
         addItem,
+        updateListing,
         removeItem,
         removeItems,
         clearCart,

--- a/src/contexts/__tests__/CartContext.test.tsx
+++ b/src/contexts/__tests__/CartContext.test.tsx
@@ -39,6 +39,7 @@ function CartConsumer() {
   const {
     items,
     addItem,
+    updateListing,
     removeItem,
     removeItems,
     clearCart,
@@ -147,6 +148,16 @@ function CartConsumer() {
       </button>
       <button data-testid="clear" onClick={clearCart}>
         Clear
+      </button>
+      <button
+        data-testid="update-ak-price"
+        onClick={() =>
+          updateListing(
+            makeListing({ id: "listing-ak", price: 230, status: "ACTIVE" }),
+          )
+        }
+      >
+        Update AK price
       </button>
     </div>
   );
@@ -295,6 +306,15 @@ describe("CartContext", () => {
     it("returns 0 when cart is empty", () => {
       renderCart();
       expect(screen.getByTestId("price").textContent).toBe("0.00");
+    });
+
+    it("updates an existing snapshot price without adding a new row", () => {
+      renderCart();
+      fireEvent.click(screen.getByTestId("add-ak"));
+      fireEvent.click(screen.getByTestId("update-ak-price"));
+
+      expect(screen.getByTestId("count").textContent).toBe("1");
+      expect(screen.getByTestId("price").textContent).toBe("230.00");
     });
   });
 

--- a/src/hooks/useCartListingsRevalidation.ts
+++ b/src/hooks/useCartListingsRevalidation.ts
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { getListing } from "@/api/listings";
+import {
+  assessCartLine,
+  cartLinesArePayable,
+  cartSnapshotNeedsUpdate,
+  firstCartBlockage,
+  type CartLineView,
+  type CartSnapshotItem,
+} from "@/lib/cartListingStatus";
+import type { Listing } from "@/types/api";
+
+export function useCartListingsRevalidation(
+  items: CartSnapshotItem[],
+  updateListing: (listing: Listing) => void,
+): {
+  lines: CartLineView[];
+  blockage: string | null;
+  canCheckout: boolean;
+} {
+  const queries = useQueries({
+    queries: items.map((item) => ({
+      queryKey: ["listing", item.listing.id] as const,
+      queryFn: () => getListing(item.listing.id),
+      staleTime: 0,
+      refetchOnMount: "always" as const,
+      retry: false,
+    })),
+  });
+
+  useEffect(() => {
+    for (let index = 0; index < items.length; index += 1) {
+      const fresh = queries[index]?.data;
+      const current = items[index]?.listing;
+      if (!fresh || !current || fresh.id !== current.id) continue;
+      if (fresh.status !== "ACTIVE") continue;
+      if (!cartSnapshotNeedsUpdate(current, fresh)) continue;
+      updateListing(fresh);
+    }
+  }, [items, queries, updateListing]);
+
+  const lines = items.map((item, index) =>
+    assessCartLine(item, {
+      isPending: queries[index]?.isPending ?? true,
+      isError: queries[index]?.isError ?? false,
+      data: queries[index]?.data,
+      refetch: () => {
+        void queries[index]?.refetch();
+      },
+    }),
+  );
+
+  return {
+    lines,
+    blockage: firstCartBlockage(lines),
+    canCheckout: cartLinesArePayable(lines),
+  };
+}

--- a/src/lib/__tests__/cartListingStatus.test.ts
+++ b/src/lib/__tests__/cartListingStatus.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { Listing } from "@/types/api";
+import {
+  assessCartLine,
+  cartLinesArePayable,
+  cartListingName,
+  cartSnapshotNeedsUpdate,
+  firstCartBlockage,
+  formatCartMoney,
+  isListingPurchasable,
+} from "../cartListingStatus";
+
+function listing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: "listing-1",
+    productId: "prod-1",
+    sellerId: "seller-1",
+    price: 210,
+    currency: "USD",
+    status: "ACTIVE",
+    floatValue: 0.15,
+    pattern: null,
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Neon Rider",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      imageUrl: null,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
+    seller: { id: "seller-1", storeName: "Store Alpha" },
+    ...overrides,
+  };
+}
+
+const idleQuery = {
+  isPending: false,
+  isError: false,
+  data: undefined as Listing | undefined,
+  refetch: () => {},
+};
+
+describe("cartListingStatus", () => {
+  it("formats names and money with Number()", () => {
+    expect(cartListingName(listing())).toBe("AK-47 | Neon Rider");
+    expect(formatCartMoney("210.5" as unknown as number)).toBe("$210.50");
+  });
+
+  it("treats SOLD, RESERVED, CANCELED and trade lock as not purchasable", () => {
+    expect(isListingPurchasable(listing({ status: "SOLD" }))).toBe(false);
+    expect(isListingPurchasable(listing({ status: "RESERVED" }))).toBe(false);
+    expect(isListingPurchasable(listing({ status: "CANCELED" }))).toBe(false);
+    expect(
+      isListingPurchasable(
+        listing({
+          tradeLockUntil: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      ),
+    ).toBe(false);
+    expect(isListingPurchasable(listing({ status: "ACTIVE" }))).toBe(true);
+  });
+
+  it("detects snapshot price and status drift", () => {
+    expect(
+      cartSnapshotNeedsUpdate(listing({ price: 210 }), listing({ price: 230 })),
+    ).toBe(true);
+    expect(
+      cartSnapshotNeedsUpdate(listing(), listing({ status: "SOLD" })),
+    ).toBe(true);
+    expect(cartSnapshotNeedsUpdate(listing(), listing())).toBe(false);
+  });
+
+  it("marks a SOLD refetch as unavailable and not payable", () => {
+    const line = assessCartLine(
+      { listing: listing(), priceWhenAdded: 210 },
+      { ...idleQuery, data: listing({ status: "SOLD" }) },
+    );
+
+    expect(line.kind).toBe("unavailable");
+    expect(line.purchasable).toBe(false);
+    expect(line.blockage).toBe("AK-47 | Neon Rider não está mais disponível");
+    expect(cartLinesArePayable([line])).toBe(false);
+    expect(firstCartBlockage([line])).toBe(
+      "AK-47 | Neon Rider não está mais disponível",
+    );
+  });
+
+  it("surfaces a price change without blocking checkout", () => {
+    const line = assessCartLine(
+      { listing: listing({ price: 210 }), priceWhenAdded: 210 },
+      { ...idleQuery, data: listing({ price: 230 }) },
+    );
+
+    expect(line.kind).toBe("price-changed");
+    expect(line.purchasable).toBe(true);
+    expect(line.blockage).toBeNull();
+    expect(formatCartMoney(line.previousPrice)).toBe("$210.00");
+    expect(formatCartMoney(line.currentPrice)).toBe("$230.00");
+    expect(cartLinesArePayable([line])).toBe(true);
+  });
+
+  it("keeps other lines payable when one row is still loading or failed", () => {
+    const ok = assessCartLine(
+      { listing: listing({ id: "ok", price: 100 }), priceWhenAdded: 100 },
+      { ...idleQuery, data: listing({ id: "ok", price: 100 }) },
+    );
+    const failed = assessCartLine(
+      { listing: listing({ id: "bad", price: 50 }), priceWhenAdded: 50 },
+      { ...idleQuery, isError: true },
+    );
+
+    expect(ok.kind).toBe("available");
+    expect(failed.kind).toBe("error");
+    expect(failed.blockage).toBe(
+      "Não foi possível atualizar AK-47 | Neon Rider.",
+    );
+    expect(firstCartBlockage([ok, failed])).toBe(
+      "Não foi possível atualizar AK-47 | Neon Rider.",
+    );
+    expect(cartLinesArePayable([ok, failed])).toBe(false);
+  });
+});

--- a/src/lib/cartListingStatus.ts
+++ b/src/lib/cartListingStatus.ts
@@ -1,0 +1,159 @@
+import type { Listing } from "@/types/api";
+
+export interface CartSnapshotItem {
+  listing: Listing;
+  priceWhenAdded?: Listing["price"];
+}
+
+export function cartListingName(listing: {
+  product: { weapon: string; skinName: string };
+}): string {
+  return `${listing.product.weapon} | ${listing.product.skinName}`;
+}
+
+export function formatCartMoney(value: Listing["price"] | number): string {
+  return `$${Number(value).toFixed(2)}`;
+}
+
+export function isListingTradeLocked(
+  listing: Pick<Listing, "tradeLockUntil">,
+  now = Date.now(),
+): boolean {
+  if (!listing.tradeLockUntil) return false;
+  return new Date(listing.tradeLockUntil).getTime() > now;
+}
+
+export function isListingPurchasable(
+  listing: Pick<Listing, "status" | "tradeLockUntil">,
+  now = Date.now(),
+): boolean {
+  return listing.status === "ACTIVE" && !isListingTradeLocked(listing, now);
+}
+
+export function cartSnapshotNeedsUpdate(
+  current: Pick<Listing, "price" | "status" | "tradeLockUntil">,
+  fresh: Pick<Listing, "price" | "status" | "tradeLockUntil">,
+): boolean {
+  return (
+    Number(current.price) !== Number(fresh.price) ||
+    current.status !== fresh.status ||
+    current.tradeLockUntil !== fresh.tradeLockUntil
+  );
+}
+
+export type CartLineKind =
+  | "loading"
+  | "error"
+  | "unavailable"
+  | "price-changed"
+  | "available";
+
+export interface CartLineView {
+  listingId: string;
+  kind: CartLineKind;
+  snapshot: Listing;
+  display: Listing;
+  name: string;
+  purchasable: boolean;
+  priceChanged: boolean;
+  previousPrice: Listing["price"];
+  currentPrice: Listing["price"];
+  blockage: string | null;
+  retry: () => void;
+}
+
+export function assessCartLine(
+  item: CartSnapshotItem,
+  query: {
+    isPending: boolean;
+    isError: boolean;
+    data: Listing | undefined;
+    refetch: () => void;
+  },
+  now = Date.now(),
+): CartLineView {
+  const snapshot = item.listing;
+  const previousPrice = item.priceWhenAdded ?? snapshot.price;
+  const fresh = query.data;
+  const display = fresh ?? snapshot;
+  const name = cartListingName(display);
+  const retry = () => {
+    void query.refetch();
+  };
+
+  if (query.isPending && !fresh) {
+    return {
+      listingId: snapshot.id,
+      kind: "loading",
+      snapshot,
+      display,
+      name,
+      purchasable: false,
+      priceChanged: false,
+      previousPrice,
+      currentPrice: display.price,
+      blockage: "Verificando disponibilidade dos itens.",
+      retry,
+    };
+  }
+
+  if (query.isError && !fresh) {
+    return {
+      listingId: snapshot.id,
+      kind: "error",
+      snapshot,
+      display,
+      name,
+      purchasable: false,
+      priceChanged: false,
+      previousPrice,
+      currentPrice: display.price,
+      blockage: `Não foi possível atualizar ${name}.`,
+      retry,
+    };
+  }
+
+  const current = fresh ?? snapshot;
+  const purchasable = isListingPurchasable(current, now);
+  if (!purchasable) {
+    return {
+      listingId: snapshot.id,
+      kind: "unavailable",
+      snapshot,
+      display: current,
+      name,
+      purchasable: false,
+      priceChanged: false,
+      previousPrice,
+      currentPrice: current.price,
+      blockage: `${name} não está mais disponível`,
+      retry,
+    };
+  }
+
+  const priceChanged = Number(current.price) !== Number(previousPrice);
+  return {
+    listingId: snapshot.id,
+    kind: priceChanged ? "price-changed" : "available",
+    snapshot,
+    display: current,
+    name,
+    purchasable: true,
+    priceChanged,
+    previousPrice,
+    currentPrice: current.price,
+    blockage: null,
+    retry,
+  };
+}
+
+export function firstCartBlockage(lines: CartLineView[]): string | null {
+  for (const line of lines) {
+    if (line.blockage) return line.blockage;
+  }
+  return null;
+}
+
+export function cartLinesArePayable(lines: CartLineView[]): boolean {
+  return lines.length > 0 && lines.every((line) => line.purchasable);
+}

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -1,9 +1,12 @@
 import { Link } from "react-router-dom";
 import { Trash2 } from "lucide-react";
 import { useCart } from "@/contexts/CartContext";
+import { useCartListingsRevalidation } from "@/hooks/useCartListingsRevalidation";
+import { CartListingAlerts } from "@/components/CartListingAlerts";
 import { EmptyState } from "@/components/page-state";
 import { ReservationHold } from "@/components/ReservationHold";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 
 function listingLabel(listing: {
   product: { weapon: string; skinName: string; exterior: string };
@@ -12,7 +15,12 @@ function listingLabel(listing: {
 }
 
 export default function CartPage() {
-  const { items, removeItem, totalPrice, totalItems } = useCart();
+  const { items, removeItem, updateListing, totalPrice, totalItems } =
+    useCart();
+  const { lines, blockage, canCheckout } = useCartListingsRevalidation(
+    items,
+    updateListing,
+  );
   const serviceFee = totalPrice * 0.05;
   const total = totalPrice * 1.05;
 
@@ -44,7 +52,20 @@ export default function CartPage() {
 
       <div className="grid gap-8 lg:grid-cols-3">
         <ul className="space-y-3 lg:col-span-2">
-          {items.map(({ listing }) => {
+          {lines.map((line) => {
+            if (line.kind === "loading") {
+              return (
+                <li key={line.listingId}>
+                  <Skeleton
+                    className="h-24 w-full"
+                    role="status"
+                    aria-label="Carregando"
+                  />
+                </li>
+              );
+            }
+
+            const listing = line.display;
             const name = listingLabel(listing);
             return (
               <li
@@ -68,6 +89,7 @@ export default function CartPage() {
                   <p className="mt-1 text-sm tabular-price text-foreground">
                     ${Number(listing.price).toFixed(2)}
                   </p>
+                  <CartListingAlerts line={line} />
                 </div>
                 <Button
                   variant="ghost"
@@ -100,9 +122,20 @@ export default function CartPage() {
             </div>
           </dl>
           <ReservationHold phase="pre-order" />
-          <Button asChild className="w-full" size="lg">
-            <Link to="/checkout">Finalizar compra</Link>
-          </Button>
+          {canCheckout ? (
+            <Button asChild className="w-full" size="lg">
+              <Link to="/checkout">Finalizar compra</Link>
+            </Button>
+          ) : (
+            <Button className="w-full" size="lg" disabled>
+              Finalizar compra
+            </Button>
+          )}
+          {blockage ? (
+            <p className="text-sm text-destructive" role="status">
+              {blockage}
+            </p>
+          ) : null}
           <p className="text-xs text-muted-foreground">
             O pagamento é confirmado só depois do retorno do PayPal.
           </p>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { Trash2 } from "lucide-react";
 import { useCart } from "@/contexts/CartContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { createOrder } from "@/api/orders";
 import { createPaymentLink } from "@/api/payments";
+import { CartListingAlerts } from "@/components/CartListingAlerts";
 import { EmptyState } from "@/components/page-state";
 import { ReservationHold } from "@/components/ReservationHold";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCartListingsRevalidation } from "@/hooks/useCartListingsRevalidation";
 import {
   resolveCheckoutIdempotencyKey,
   type CheckoutIdempotencyState,
@@ -20,7 +24,12 @@ import { redirectToExternal } from "@/lib/redirect";
 import type { Order } from "@/types/api";
 
 export default function Checkout() {
-  const { items, totalPrice, removeItems } = useCart();
+  const { items, totalPrice, removeItem, removeItems, updateListing } =
+    useCart();
+  const { lines, blockage, canCheckout } = useCartListingsRevalidation(
+    items,
+    updateListing,
+  );
   const { isAuthenticated, user } = useAuth();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -85,7 +94,7 @@ export default function Checkout() {
   }
 
   const handlePay = async () => {
-    if (inFlightRef.current) return;
+    if (inFlightRef.current || !canCheckout) return;
     inFlightRef.current = true;
     setError(null);
     setLoading(true);
@@ -151,19 +160,44 @@ export default function Checkout() {
             Itens ({items.length})
           </h2>
           <ul className="space-y-2">
-            {items.map(({ listing }) => {
+            {lines.map((line) => {
+              if (line.kind === "loading") {
+                return (
+                  <li key={line.listingId}>
+                    <Skeleton
+                      className="h-10 w-full"
+                      role="status"
+                      aria-label="Carregando"
+                    />
+                  </li>
+                );
+              }
+
+              const listing = line.display;
               const name = `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
               return (
-                <li
-                  key={listing.id}
-                  className="flex justify-between gap-4 text-sm"
-                >
-                  <span className="min-w-0 truncate text-foreground">
-                    {name}
-                  </span>
-                  <span className="shrink-0 tabular-price text-muted-foreground">
-                    ${Number(listing.price).toFixed(2)}
-                  </span>
+                <li key={listing.id} className="space-y-1 text-sm">
+                  <div className="flex items-start justify-between gap-4">
+                    <span className="min-w-0 truncate text-foreground">
+                      {name}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      <span className="tabular-price text-muted-foreground">
+                        ${Number(listing.price).toFixed(2)}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 min-h-8 min-w-8 text-muted-foreground hover:text-destructive"
+                        onClick={() => removeItem(listing.id)}
+                        aria-label={`Remover ${name}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </span>
+                  </div>
+                  <CartListingAlerts line={line} />
                 </li>
               );
             })}
@@ -200,11 +234,13 @@ export default function Checkout() {
             className="w-full"
             size="lg"
             onClick={handlePay}
-            disabled={loading || reservationExpired}
+            disabled={loading || reservationExpired || !canCheckout}
             title={
               reservationExpired
                 ? "A reserva expirou. O item pode ter voltado ao Market."
-                : undefined
+                : blockage && !canCheckout
+                  ? blockage
+                  : undefined
             }
           >
             {loading
@@ -213,6 +249,11 @@ export default function Checkout() {
                 ? "Tentar novamente"
                 : `Pagar com PayPal — $${total.toFixed(2)}`}
           </Button>
+          {!canCheckout && blockage ? (
+            <p className="text-sm text-destructive" role="status">
+              {blockage}
+            </p>
+          ) : null}
           <p className="text-center text-xs text-muted-foreground">
             Sem confirmação local até o retorno do PayPal.
           </p>

--- a/src/pages/__tests__/CartPage.test.tsx
+++ b/src/pages/__tests__/CartPage.test.tsx
@@ -143,8 +143,12 @@ describe("CartPage", () => {
     renderCart();
 
     expect(
-      await screen.findByText("AK-47 | Neon Rider não está mais disponível"),
-    ).toBeTruthy();
+      (
+        await screen.findAllByText(
+          "AK-47 | Neon Rider não está mais disponível",
+        )
+      ).length,
+    ).toBeGreaterThan(0);
     expect(
       screen.getByRole("button", { name: "Finalizar compra" }),
     ).toBeDisabled();

--- a/src/pages/__tests__/CartPage.test.tsx
+++ b/src/pages/__tests__/CartPage.test.tsx
@@ -1,22 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import CartPage from "../CartPage";
 import type { Listing } from "@/types/api";
 import { PRE_ORDER_HOLD_COPY } from "@/lib/orderPaymentView";
 
+const getListing = vi.fn();
+const reserveListing = vi.fn();
+
 const cartState = {
-  items: [] as { listing: Listing }[],
+  items: [] as { listing: Listing; priceWhenAdded?: Listing["price"] }[],
   totalPrice: 0,
   totalItems: 0,
   removeItem: vi.fn(),
+  updateListing: vi.fn(),
 };
 
 vi.mock("@/contexts/CartContext", () => ({
   useCart: () => cartState,
 }));
 
-function listing(id: string, price: number): Listing {
+vi.mock("@/api/listings", () => ({
+  getListing: (...args: unknown[]) => getListing(...args),
+  reserveListing: (...args: unknown[]) => reserveListing(...args),
+}));
+
+function listing(
+  id: string,
+  price: number,
+  overrides: Partial<Listing> = {},
+): Listing {
   return {
     id,
     productId: "prod-1",
@@ -33,7 +47,7 @@ function listing(id: string, price: number): Listing {
       id: "prod-1",
       game: "CS2",
       weapon: "AK-47",
-      skinName: "Redline",
+      skinName: "Neon Rider",
       rarity: "Classified",
       exterior: "Field-Tested",
       imageUrl: null,
@@ -44,14 +58,20 @@ function listing(id: string, price: number): Listing {
     },
     seller: { id: "seller-1", storeName: "Store Alpha" },
     pattern: 123,
+    ...overrides,
   } as Listing;
 }
 
 function renderCart() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter>
-      <CartPage />
-    </MemoryRouter>,
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CartPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -61,6 +81,14 @@ describe("CartPage", () => {
     cartState.totalPrice = 0;
     cartState.totalItems = 0;
     cartState.removeItem.mockReset();
+    cartState.updateListing.mockReset();
+    getListing.mockReset();
+    reserveListing.mockReset();
+    getListing.mockImplementation(async (id: string) => {
+      const found = cartState.items.find((item) => item.listing.id === id);
+      if (!found) throw new Error("Listing not found");
+      return found.listing;
+    });
   });
 
   it("shows empty cart and a Market link", () => {
@@ -70,29 +98,131 @@ describe("CartPage", () => {
     expect(screen.queryByText("Finalizar compra")).toBeNull();
   });
 
-  it("keeps 5% service fee display math", () => {
-    cartState.items = [{ listing: listing("listing-ak", 100) }];
+  it("keeps 5% service fee display math", async () => {
+    cartState.items = [
+      { listing: listing("listing-ak", 100), priceWhenAdded: 100 },
+    ];
     cartState.totalPrice = 100;
     cartState.totalItems = 1;
     renderCart();
+    expect(await screen.findByText("Finalizar compra")).toBeTruthy();
     expect(screen.getAllByText("$100.00").length).toBe(2);
     expect(screen.getByText("$5.00")).toBeTruthy();
     expect(screen.getByText("$105.00")).toBeTruthy();
-    expect(screen.getByText("Finalizar compra")).toBeTruthy();
     expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(screen.queryByText(/15:00/)).toBeNull();
     expect(screen.queryByText("SKINMARKET")).toBeNull();
+    expect(reserveListing).not.toHaveBeenCalled();
   });
 
-  it("does not claim the listing is held in the cart", () => {
-    cartState.items = [{ listing: listing("listing-ak", 100) }];
+  it("does not claim the listing is held in the cart", async () => {
+    cartState.items = [
+      { listing: listing("listing-ak", 100), priceWhenAdded: 100 },
+    ];
     cartState.totalPrice = 100;
     cartState.totalItems = 1;
     renderCart();
+    expect(await screen.findByText("Finalizar compra")).toBeTruthy();
     expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
     expect(screen.getByText(/não segura o item/i)).toBeTruthy();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(screen.queryByRole("timer")).toBeNull();
+  });
+
+  it("blocks checkout when the listing is SOLD on the server", async () => {
+    cartState.items = [
+      { listing: listing("listing-ak", 100), priceWhenAdded: 100 },
+    ];
+    cartState.totalPrice = 100;
+    cartState.totalItems = 1;
+    getListing.mockResolvedValue(
+      listing("listing-ak", 100, { status: "SOLD" }),
+    );
+
+    renderCart();
+
+    expect(
+      await screen.findByText("AK-47 | Neon Rider não está mais disponível"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Finalizar compra" }),
+    ).toBeDisabled();
+    expect(reserveListing).not.toHaveBeenCalled();
+  });
+
+  it("shows a price change before checkout", async () => {
+    cartState.items = [
+      { listing: listing("listing-ak", 210), priceWhenAdded: 210 },
+    ];
+    cartState.totalPrice = 210;
+    cartState.totalItems = 1;
+    getListing.mockResolvedValue(listing("listing-ak", 230));
+
+    renderCart();
+
+    expect(
+      await screen.findByText("Preço atualizado: $210.00 → $230.00"),
+    ).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Finalizar compra" })).toBeTruthy();
+    expect(cartState.updateListing).toHaveBeenCalled();
+  });
+
+  it("keeps a successful line visible when another listing fetch fails", async () => {
+    cartState.items = [
+      { listing: listing("listing-ak", 100), priceWhenAdded: 100 },
+      {
+        listing: listing("listing-awp", 50, {
+          product: {
+            ...listing("listing-awp", 50).product,
+            weapon: "AWP",
+            skinName: "Asiimov",
+          },
+        }),
+        priceWhenAdded: 50,
+      },
+    ];
+    cartState.totalPrice = 150;
+    cartState.totalItems = 2;
+    getListing.mockImplementation(async (id: string) => {
+      if (id === "listing-ak") throw new Error("network");
+      return listing("listing-awp", 50, {
+        product: {
+          ...listing("listing-awp", 50).product,
+          weapon: "AWP",
+          skinName: "Asiimov",
+        },
+      });
+    });
+
+    renderCart();
+
+    expect(await screen.findByText(/AWP \| Asiimov/)).toBeTruthy();
+    expect(screen.getByText("Erro ao atualizar")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Tentar novamente" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Finalizar compra" }),
+    ).toBeDisabled();
+
+    getListing.mockImplementation(async (id: string) => {
+      if (id === "listing-ak") return listing("listing-ak", 100);
+      return listing("listing-awp", 50, {
+        product: {
+          ...listing("listing-awp", 50).product,
+          weapon: "AWP",
+          skinName: "Asiimov",
+        },
+      });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "Finalizar compra" }),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText("Erro ao atualizar")).toBeNull();
   });
 });

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -492,8 +492,9 @@ describe("Checkout", () => {
     renderCheckout();
 
     expect(
-      await screen.findByText("AK-47 | Redline não está mais disponível"),
-    ).toBeTruthy();
+      (await screen.findAllByText("AK-47 | Redline não está mais disponível"))
+        .length,
+    ).toBeGreaterThan(0);
     expect(
       screen.getByRole("button", { name: /Pagar com PayPal/ }),
     ).toBeDisabled();

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Checkout from "../Checkout";
 import type { Listing, Order, User } from "@/types/api";
 import { PRE_ORDER_HOLD_COPY } from "@/lib/orderPaymentView";
@@ -9,12 +10,15 @@ const createOrder = vi.fn();
 const createPaymentLink = vi.fn();
 const redirectToExternal = vi.fn();
 const reserveListing = vi.fn();
+const getListing = vi.fn();
 
 const cartState = {
-  items: [] as { listing: Listing }[],
+  items: [] as { listing: Listing; priceWhenAdded?: Listing["price"] }[],
   totalPrice: 0,
   clearCart: vi.fn(),
   removeItems: vi.fn(),
+  removeItem: vi.fn(),
+  updateListing: vi.fn(),
 };
 
 const authState = {
@@ -44,6 +48,7 @@ vi.mock("@/lib/redirect", () => ({
 
 vi.mock("@/api/listings", () => ({
   reserveListing: (...args: unknown[]) => reserveListing(...args),
+  getListing: (...args: unknown[]) => getListing(...args),
 }));
 
 function listing(price = 100, id = "listing-ak"): Listing {
@@ -114,17 +119,31 @@ function expectedPaypalUrls(orderId: string) {
   };
 }
 
+let queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
 function CheckoutHarness({ nonce = 0 }: { nonce?: number }) {
   void nonce;
   return (
-    <MemoryRouter initialEntries={["/checkout"]}>
-      <Routes>
-        <Route path="/checkout" element={<Checkout />} />
-        <Route path="/orders/:id" element={<div>Pedido destino</div>} />
-        <Route path="/login" element={<div>Login</div>} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/checkout"]}>
+        <Routes>
+          <Route path="/checkout" element={<Checkout />} />
+          <Route path="/orders/:id" element={<div>Pedido destino</div>} />
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
+}
+
+async function waitForPayable() {
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: /Pagar com PayPal/ }),
+    ).not.toBeDisabled();
+  });
 }
 
 function renderCheckout(nonce = 0) {
@@ -154,16 +173,27 @@ describe("Checkout", () => {
   ];
 
   beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     cartState.items = [];
     cartState.totalPrice = 0;
     cartState.clearCart.mockReset();
     cartState.removeItems.mockReset();
+    cartState.removeItem.mockReset();
+    cartState.updateListing.mockReset();
     authState.user = null;
     authState.isAuthenticated = false;
     createOrder.mockReset();
     createPaymentLink.mockReset();
     redirectToExternal.mockReset();
     reserveListing.mockReset();
+    getListing.mockReset();
+    getListing.mockImplementation(async (id: string) => {
+      const found = cartState.items.find((item) => item.listing.id === id);
+      if (!found) throw new Error("Listing not found");
+      return found.listing;
+    });
     let uuidIndex = 0;
     vi.spyOn(crypto, "randomUUID").mockImplementation(
       () => uuidKeys[uuidIndex++] ?? "overflow-uuid",
@@ -190,12 +220,13 @@ describe("Checkout", () => {
     expect(screen.queryByText(/Pagar com PayPal/)).toBeNull();
   });
 
-  it("shows 5% fee and does not claim payment succeeded", () => {
+  it("shows 5% fee and does not claim payment succeeded", async () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
     asCustomer();
 
     renderCheckout();
+    await waitForPayable();
 
     expect(screen.getAllByText("$100.00").length).toBe(2);
     expect(screen.getByText("$5.00")).toBeTruthy();
@@ -208,6 +239,7 @@ describe("Checkout", () => {
     expect(
       screen.getByText(/só é confirmado depois que o provedor retornar/i),
     ).toBeTruthy();
+    expect(reserveListing).not.toHaveBeenCalled();
   });
 
   it("sends absolute returnUrl and cancelUrl and prunes ordered listings", async () => {
@@ -220,6 +252,7 @@ describe("Checkout", () => {
     });
 
     renderCheckout();
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => {
@@ -261,6 +294,7 @@ describe("Checkout", () => {
     createPaymentLink.mockResolvedValue({});
 
     renderCheckout();
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => {
@@ -280,6 +314,7 @@ describe("Checkout", () => {
     createOrder.mockRejectedValue(new Error("Falha de rede"));
 
     renderCheckout();
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
@@ -296,6 +331,7 @@ describe("Checkout", () => {
     createOrder.mockRejectedValue(new Error("Falha de rede"));
 
     renderCheckout();
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
@@ -313,6 +349,7 @@ describe("Checkout", () => {
     createOrder.mockRejectedValue(new Error("Falha de rede"));
 
     renderCheckout();
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => {
@@ -338,6 +375,7 @@ describe("Checkout", () => {
     createOrder.mockRejectedValue(new Error("Falha de rede"));
 
     const view = renderCheckout(0);
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
     await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
 
@@ -348,7 +386,18 @@ describe("Checkout", () => {
     cartState.totalPrice = 100;
     view.rerender(<CheckoutHarness nonce={1} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    await waitFor(() => {
+      const retry = screen.queryByRole("button", { name: "Tentar novamente" });
+      const pay = screen.queryByRole("button", { name: /Pagar com PayPal/ });
+      const cta = retry ?? pay;
+      expect(cta).toBeTruthy();
+      expect(cta).not.toBeDisabled();
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Tentar novamente|Pagar com PayPal/,
+      }),
+    );
     await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(2));
 
     expect(idempotencyKeyOf(createOrder.mock.calls[0])).toBe(uuidKeys[0]);
@@ -373,6 +422,7 @@ describe("Checkout", () => {
     createPaymentLink.mockResolvedValue({});
 
     renderCheckout();
+    await waitForPayable();
     const button = screen.getByRole("button", { name: /Pagar com PayPal/ });
     fireEvent.click(button);
     fireEvent.click(button);
@@ -414,6 +464,7 @@ describe("Checkout", () => {
     expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
 
+    await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     expect(await screen.findAllByText(/Reservado para você/)).toHaveLength(2);
@@ -430,5 +481,73 @@ describe("Checkout", () => {
         "https://www.paypal.com/checkoutnow?token=EC-1",
       );
     });
+  });
+
+  it("does not let a SOLD listing stay payable", async () => {
+    cartState.items = [{ listing: listing(100) }];
+    cartState.totalPrice = 100;
+    asCustomer();
+    getListing.mockResolvedValue({ ...listing(100), status: "SOLD" });
+
+    renderCheckout();
+
+    expect(
+      await screen.findByText("AK-47 | Redline não está mais disponível"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Pagar com PayPal/ }),
+    ).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+    expect(createOrder).not.toHaveBeenCalled();
+    expect(reserveListing).not.toHaveBeenCalled();
+  });
+
+  it("shows a price change before createOrder", async () => {
+    cartState.items = [{ listing: listing(210), priceWhenAdded: 210 }];
+    cartState.totalPrice = 210;
+    asCustomer();
+    getListing.mockResolvedValue(listing(230));
+    createOrder.mockResolvedValue({ id: "order-1" });
+    createPaymentLink.mockResolvedValue({});
+
+    renderCheckout();
+
+    expect(
+      await screen.findByText("Preço atualizado: $210.00 → $230.00"),
+    ).toBeTruthy();
+    await waitForPayable();
+    fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
+
+    await waitFor(() => expect(createOrder).toHaveBeenCalledTimes(1));
+    expect(cartState.updateListing).toHaveBeenCalled();
+  });
+
+  it("keeps a successful line when another listing fetch fails", async () => {
+    const awp = listing(20, "listing-awp");
+    awp.product = {
+      ...awp.product,
+      weapon: "AWP",
+      skinName: "Asiimov",
+    };
+    cartState.items = [
+      { listing: listing(80, "listing-ak") },
+      { listing: awp },
+    ];
+    cartState.totalPrice = 100;
+    asCustomer();
+    getListing.mockImplementation(async (id: string) => {
+      if (id === "listing-ak") throw new Error("network");
+      return awp;
+    });
+
+    renderCheckout();
+
+    expect(await screen.findByText(/AWP \| Asiimov/)).toBeTruthy();
+    expect(screen.getByText("Erro ao atualizar")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /Pagar com PayPal/ }),
+    ).toBeDisabled();
+    expect(createOrder).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Carrinho e checkout passam a refetch `GET /listings/:id` por linha antes de pagar, para o resumo não mentir se o item único foi vendido, reservado, cancelado, ficou em trade lock, ou teve preço alterado.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/85

## O que muda

- Ao abrir `/cart` e `/checkout`, cada item é revalidado via `GET /listings/:id` (React Query, `refetchOnMount`).
- Indisponível (SOLD / RESERVED / CANCELED / trade lock): alerta + remover; CTA bloqueado.
- Preço alterado: mostra antigo → novo; não bloqueia o pagamento.
- Snapshot do carrinho só atualiza quando o listing continua ACTIVE.
- Erro de rede em uma linha: badge + retry nessa linha; as outras permanecem; CTA desabilitado até o retry.

## Critérios de aceite

- [x] Listing SOLD no servidor não permanece pagável no checkout
- [x] Mudança de preço é visível antes de `createOrder`
- [x] Falha de rede em um item não esconde os outros
- [x] Testes de Cart/Checkout cobrem SOLD e price change

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 27 files, 127 tests passed

## Invariantes

- Reserva continua começando em `createOrder` (sem `POST /listings/:id/reserve` no carrinho)
- Cliente nunca marca `PAID`
- Taxa 5% continua `totalPrice * 0.05` a partir dos preços atuais

## Riscos

- O gate no cliente é UX; `createOrder` ainda pode 400 se o listing vender depois do refetch
- Trade lock usa o relógio do browser

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

