### PR TITLE
#86 — [UX] Corrigir destino pós-login por papel e impedir ADMIN de cair no painel seller

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -12,7 +12,7 @@ import type { User } from "@/types/api";
 interface AuthContextType {
   user: User | null;
   isLoading: boolean;
-  login: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<User>;
   /** Step 1: send verification code to email. Returns message and optional code (dev). */
   startRegistration: (params: {
     name: string;
@@ -62,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const data = await authApi.login({ email, password });
       setUser(data.user);
+      return data.user;
     } catch (e) {
       const message = e instanceof Error ? e.message : "Login failed";
       setError(message);
@@ -86,20 +87,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw e;
       }
     },
-    []
+    [],
   );
 
-  const confirmRegistration = useCallback(async (email: string, code: string) => {
-    setError(null);
-    try {
-      const data = await authApi.verifyEmail({ email, code });
-      setUser(data.user);
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Invalid or expired code";
-      setError(message);
-      throw e;
-    }
-  }, []);
+  const confirmRegistration = useCallback(
+    async (email: string, code: string) => {
+      setError(null);
+      try {
+        const data = await authApi.verifyEmail({ email, code });
+        setUser(data.user);
+      } catch (e) {
+        const message =
+          e instanceof Error ? e.message : "Invalid or expired code";
+        setError(message);
+        throw e;
+      }
+    },
+    [],
+  );
 
   const logout = useCallback(() => {
     authApi.logout();

--- a/src/lib/__tests__/postLoginPath.test.ts
+++ b/src/lib/__tests__/postLoginPath.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHECKOUT_BUYER_ONLY_COPY,
+  fromPathFromState,
+  homePathForRole,
+  normalizeInternalPath,
+  postLoginPath,
+} from "../postLoginPath";
+
+describe("homePathForRole", () => {
+  it("maps each role to its home surface", () => {
+    expect(homePathForRole("CUSTOMER")).toBe("/");
+    expect(homePathForRole("SELLER")).toBe("/seller");
+    expect(homePathForRole("ADMIN")).toBe("/admin");
+  });
+});
+
+describe("fromPathFromState", () => {
+  it("reads pathname from a Location-like from object", () => {
+    expect(fromPathFromState({ from: { pathname: "/seller/listings" } })).toBe(
+      "/seller/listings",
+    );
+  });
+
+  it("accepts a bare from string", () => {
+    expect(fromPathFromState({ from: "/checkout" })).toBe("/checkout");
+  });
+
+  it("returns undefined when from is missing", () => {
+    expect(fromPathFromState(undefined)).toBeUndefined();
+    expect(fromPathFromState({})).toBeUndefined();
+  });
+});
+
+describe("normalizeInternalPath", () => {
+  it("treats empty, login and external values as home", () => {
+    expect(normalizeInternalPath(undefined)).toBe("/");
+    expect(normalizeInternalPath("")).toBe("/");
+    expect(normalizeInternalPath("/login")).toBe("/");
+    expect(normalizeInternalPath("/register")).toBe("/");
+    expect(normalizeInternalPath("//evil.example")).toBe("/");
+    expect(normalizeInternalPath("https://evil.example")).toBe("/");
+  });
+
+  it("strips query, hash and trailing slashes", () => {
+    expect(normalizeInternalPath("/seller/listings/?x=1#top")).toBe(
+      "/seller/listings",
+    );
+  });
+});
+
+describe("postLoginPath", () => {
+  it("sends admin without from to /admin", () => {
+    expect(postLoginPath("ADMIN").path).toBe("/admin");
+    expect(postLoginPath("ADMIN", "/").path).toBe("/admin");
+    expect(postLoginPath("ADMIN", "").path).toBe("/admin");
+  });
+
+  it("sends admin away from seller routes to /admin", () => {
+    expect(postLoginPath("ADMIN", "/seller").path).toBe("/admin");
+    expect(postLoginPath("ADMIN", "/seller/listings").path).toBe("/admin");
+  });
+
+  it("sends seller without from to /seller", () => {
+    expect(postLoginPath("SELLER").path).toBe("/seller");
+    expect(postLoginPath("SELLER", "/").path).toBe("/seller");
+  });
+
+  it("keeps a seller on a seller from path", () => {
+    expect(postLoginPath("SELLER", "/seller/listings").path).toBe(
+      "/seller/listings",
+    );
+  });
+
+  it("sends customer with from=/checkout to /checkout", () => {
+    expect(postLoginPath("CUSTOMER", "/checkout")).toEqual({
+      path: "/checkout",
+    });
+  });
+
+  it("sends customer without from to home", () => {
+    expect(postLoginPath("CUSTOMER").path).toBe("/");
+  });
+
+  it("blocks checkout for non-customers and explains why", () => {
+    expect(postLoginPath("SELLER", "/checkout")).toEqual({
+      path: "/seller",
+      notice: CHECKOUT_BUYER_ONLY_COPY,
+    });
+    expect(postLoginPath("ADMIN", "/checkout")).toEqual({
+      path: "/admin",
+      notice: CHECKOUT_BUYER_ONLY_COPY,
+    });
+  });
+
+  it("does not treat ADMIN as a seller home", () => {
+    expect(postLoginPath("ADMIN", "/seller/products").path).not.toMatch(
+      /^\/seller/,
+    );
+  });
+});

--- a/src/lib/postLoginPath.ts
+++ b/src/lib/postLoginPath.ts
@@ -1,0 +1,87 @@
+import type { Role } from "@/types/api";
+
+export const CHECKOUT_BUYER_ONLY_COPY =
+  "Checkout é exclusivo para contas de comprador.";
+
+export interface PostLoginDestination {
+  path: string;
+  notice?: string;
+}
+
+const AUTH_PAGES = new Set(["/login", "/register"]);
+
+export function homePathForRole(role: Role): string {
+  if (role === "ADMIN") return "/admin";
+  if (role === "SELLER") return "/seller";
+  return "/";
+}
+
+export function fromPathFromState(state: unknown): string | undefined {
+  if (!state || typeof state !== "object") return undefined;
+  const from = (state as { from?: unknown }).from;
+  if (typeof from === "string") return from;
+  if (from && typeof from === "object" && "pathname" in from) {
+    const pathname = (from as { pathname?: unknown }).pathname;
+    if (typeof pathname === "string") return pathname;
+  }
+  return undefined;
+}
+
+export function normalizeInternalPath(from?: string | null): string {
+  if (from == null) return "/";
+  const trimmed = from.trim();
+  if (trimmed === "") return "/";
+  if (
+    !trimmed.startsWith("/") ||
+    trimmed.startsWith("//") ||
+    trimmed.includes("://")
+  ) {
+    return "/";
+  }
+
+  const pathOnly = trimmed.split(/[?#]/, 1)[0] ?? "/";
+  const collapsed =
+    pathOnly.length > 1 ? pathOnly.replace(/\/+$/, "") : pathOnly;
+  if (collapsed === "" || AUTH_PAGES.has(collapsed)) return "/";
+  return collapsed;
+}
+
+function isSellerPath(path: string): boolean {
+  return path === "/seller" || path.startsWith("/seller/");
+}
+
+function isAdminPath(path: string): boolean {
+  return path === "/admin" || path.startsWith("/admin/");
+}
+
+function isCheckoutPath(path: string): boolean {
+  return path === "/checkout";
+}
+
+export function postLoginPath(
+  role: Role,
+  from?: string | null,
+): PostLoginDestination {
+  const path = normalizeInternalPath(from);
+
+  if (path === "/") {
+    return { path: homePathForRole(role) };
+  }
+
+  if (isSellerPath(path) && role !== "SELLER") {
+    return { path: homePathForRole(role) };
+  }
+
+  if (isAdminPath(path) && role !== "ADMIN") {
+    return { path: homePathForRole(role) };
+  }
+
+  if (isCheckoutPath(path) && role !== "CUSTOMER") {
+    return {
+      path: homePathForRole(role),
+      notice: CHECKOUT_BUYER_ONLY_COPY,
+    };
+  }
+
+  return { path };
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,8 +32,6 @@ export default function Login() {
       }
       navigate(destination.path, { replace: true });
     } catch {
-      // error shown via context
-    } finally {
       setLoading(false);
     }
   };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,16 +2,18 @@ import { useState } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useToast } from "@/hooks/use-toast";
+import { fromPathFromState, postLoginPath } from "@/lib/postLoginPath";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 export default function Login() {
   const { login, error, clearError } = useAuth();
+  const { toast } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
-  const from =
-    (location.state as { from?: { pathname: string } })?.from?.pathname ?? "/";
+  const from = fromPathFromState(location.state);
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -23,8 +25,12 @@ export default function Login() {
     clearError();
     setLoading(true);
     try {
-      await login(email, password);
-      navigate(from, { replace: true });
+      const user = await login(email, password);
+      const destination = postLoginPath(user.role, from);
+      if (destination.notice) {
+        toast({ description: destination.notice });
+      }
+      navigate(destination.path, { replace: true });
     } catch {
       // error shown via context
     } finally {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { homePathForRole } from "@/lib/postLoginPath";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -50,7 +51,7 @@ export default function Register() {
     setLoading(true);
     try {
       await confirmRegistration(email, code);
-      navigate("/", { replace: true });
+      navigate(homePathForRole(role), { replace: true });
     } catch {
       // error shown via context
     } finally {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -53,8 +53,6 @@ export default function Register() {
       await confirmRegistration(email, code);
       navigate(homePathForRole(role), { replace: true });
     } catch {
-      // error shown via context
-    } finally {
       setLoading(false);
     }
   };

--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -1,8 +1,9 @@
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Package, ShoppingBag, DollarSign } from "lucide-react";
 import { listOrders } from "@/api/orders";
 import { getSellerListings } from "@/api/listings";
+import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -36,13 +37,18 @@ function orderSummary(order: Order): string {
 }
 
 export default function SellerDashboard() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "ADMIN";
+
   const listingsQuery = useQuery({
     queryKey: ["sellerListings"],
     queryFn: () => getSellerListings(),
+    enabled: !isAdmin,
   });
   const ordersQuery = useQuery({
     queryKey: ["orders"],
     queryFn: () => listOrders(),
+    enabled: !isAdmin,
   });
 
   const listings = listingsQuery.data?.items ?? [];
@@ -50,6 +56,10 @@ export default function SellerDashboard() {
   const isLoading = listingsQuery.isLoading || ordersQuery.isLoading;
   const isError = listingsQuery.isError || ordersQuery.isError;
   const error = listingsQuery.error ?? ordersQuery.error;
+
+  if (isAdmin) {
+    return <Navigate to="/admin" replace />;
+  }
 
   const activeListings = listings.filter(
     (listing) => listing.status === "ACTIVE",

--- a/src/pages/__tests__/Login.test.tsx
+++ b/src/pages/__tests__/Login.test.tsx
@@ -1,23 +1,73 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Login from "../Login";
+import type { Role, User } from "@/types/api";
+import { CHECKOUT_BUYER_ONLY_COPY } from "@/lib/postLoginPath";
+
+const login = vi.fn();
+const toast = vi.fn();
 
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => ({
-    login: vi.fn(),
+    login,
     error: null,
     clearError: vi.fn(),
   }),
 }));
 
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
+
+function authedUser(role: Role): User {
+  return {
+    id: `${role}-1`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
+}
+
+function renderLogin(from?: string) {
+  const entry =
+    from === undefined
+      ? "/login"
+      : { pathname: "/login", state: { from: { pathname: from } } };
+
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/" element={<div>landed-home</div>} />
+        <Route path="/seller" element={<div>landed-seller</div>} />
+        <Route path="/admin" element={<div>landed-admin</div>} />
+        <Route path="/checkout" element={<div>landed-checkout</div>} />
+        <Route path="/seller/listings" element={<div>landed-listings</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function submitAs(role: Role) {
+  login.mockResolvedValue(authedUser(role));
+  fireEvent.change(screen.getByLabelText("E-mail"), {
+    target: { value: "user@test.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Senha"), {
+    target: { value: "secret1" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+}
+
 describe("Login", () => {
+  beforeEach(() => {
+    login.mockReset();
+    toast.mockReset();
+  });
+
   it("labels fields and keeps the submit control disabled-ready", () => {
-    render(
-      <MemoryRouter>
-        <Login />
-      </MemoryRouter>,
-    );
+    renderLogin();
 
     expect(screen.getByLabelText("E-mail")).toBeTruthy();
     expect(screen.getByLabelText("Senha")).toBeTruthy();
@@ -29,5 +79,41 @@ describe("Login", () => {
     expect(screen.queryByText(/CS2 Skin Marketplace/i)).toBeNull();
     expect(document.querySelector(".scan-lines")).toBeNull();
     expect(document.querySelector(".neon-text")).toBeNull();
+  });
+
+  it("sends admin without from to /admin", async () => {
+    renderLogin();
+    await submitAs("ADMIN");
+    expect(await screen.findByText("landed-admin")).toBeTruthy();
+  });
+
+  it("sends admin with from=/seller/listings to /admin", async () => {
+    renderLogin("/seller/listings");
+    await submitAs("ADMIN");
+    expect(await screen.findByText("landed-admin")).toBeTruthy();
+    expect(screen.queryByText("landed-listings")).toBeNull();
+  });
+
+  it("sends seller without from to /seller", async () => {
+    renderLogin();
+    await submitAs("SELLER");
+    expect(await screen.findByText("landed-seller")).toBeTruthy();
+  });
+
+  it("sends customer with from=/checkout to /checkout", async () => {
+    renderLogin("/checkout");
+    await submitAs("CUSTOMER");
+    expect(await screen.findByText("landed-checkout")).toBeTruthy();
+  });
+
+  it("sends seller away from checkout with buyer-only copy", async () => {
+    renderLogin("/checkout");
+    await submitAs("SELLER");
+    expect(await screen.findByText("landed-seller")).toBeTruthy();
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        description: CHECKOUT_BUYER_ONLY_COPY,
+      });
+    });
   });
 });

--- a/src/pages/__tests__/Register.test.tsx
+++ b/src/pages/__tests__/Register.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import Register from "../Register";
+
+const startRegistration = vi.fn();
+const confirmRegistration = vi.fn();
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    startRegistration,
+    confirmRegistration,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+function renderRegister() {
+  return render(
+    <MemoryRouter initialEntries={["/register"]}>
+      <Routes>
+        <Route path="/register" element={<Register />} />
+        <Route path="/" element={<div>landed-home</div>} />
+        <Route path="/seller" element={<div>landed-seller</div>} />
+        <Route path="/admin" element={<div>landed-admin</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("Register", () => {
+  beforeEach(() => {
+    startRegistration.mockReset();
+    confirmRegistration.mockReset();
+    startRegistration.mockResolvedValue({ message: "ok", code: "123456" });
+    confirmRegistration.mockResolvedValue(undefined);
+  });
+
+  it("does not offer ADMIN as a public registration role", () => {
+    renderRegister();
+    expect(screen.getByText("Comprador")).toBeTruthy();
+    expect(screen.getByText("Vendedor")).toBeTruthy();
+    expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.queryByText("ADMIN")).toBeNull();
+  });
+
+  it("sends a customer to home after email verify", async () => {
+    renderRegister();
+    fireEvent.change(screen.getByLabelText("Nome"), {
+      target: { value: "Ana" },
+    });
+    fireEvent.change(screen.getByLabelText("E-mail"), {
+      target: { value: "ana@test.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "secret1" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enviar código por e-mail" }),
+    );
+
+    expect(await screen.findByLabelText("Código")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Código"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
+
+    expect(await screen.findByText("landed-home")).toBeTruthy();
+    expect(screen.queryByText("landed-seller")).toBeNull();
+  });
+
+  it("sends a seller to /seller after email verify", async () => {
+    renderRegister();
+    fireEvent.click(screen.getByText("Vendedor"));
+    fireEvent.change(screen.getByLabelText("Nome"), {
+      target: { value: "Loja" },
+    });
+    fireEvent.change(screen.getByLabelText("E-mail"), {
+      target: { value: "loja@test.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "secret1" },
+    });
+    fireEvent.change(screen.getByLabelText("Nome da loja"), {
+      target: { value: "Neon Trader" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enviar código por e-mail" }),
+    );
+
+    expect(await screen.findByLabelText("Código")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Código"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
+
+    expect(await screen.findByText("landed-seller")).toBeTruthy();
+    expect(screen.queryByText("landed-home")).toBeNull();
+    expect(screen.queryByText("landed-admin")).toBeNull();
+  });
+});

--- a/src/pages/__tests__/SellerDashboard.test.tsx
+++ b/src/pages/__tests__/SellerDashboard.test.tsx
@@ -1,12 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SellerDashboard from "../SellerDashboard";
-import type { Listing, Order } from "@/types/api";
+import type { Listing, Order, Role, User } from "@/types/api";
 
 const getSellerListings = vi.fn();
 const listOrders = vi.fn();
+const authState = {
+  user: {
+    id: "seller-user",
+    name: "Seller",
+    email: "seller@test.com",
+    role: "SELLER",
+  } as User,
+};
 
 vi.mock("@/api/listings", () => ({
   getSellerListings: (...args: unknown[]) => getSellerListings(...args),
@@ -14,6 +22,10 @@ vi.mock("@/api/listings", () => ({
 
 vi.mock("@/api/orders", () => ({
   listOrders: (...args: unknown[]) => listOrders(...args),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
 }));
 
 function listing(status: Listing["status"] = "ACTIVE"): Listing {
@@ -71,14 +83,23 @@ function order(id: string, amount: number): Order {
   };
 }
 
-function renderDashboard() {
+function renderDashboard(role: Role = "SELLER") {
+  authState.user = {
+    id: `${role}-user`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <MemoryRouter>
-        <SellerDashboard />
+      <MemoryRouter initialEntries={["/seller"]}>
+        <Routes>
+          <Route path="/seller" element={<SellerDashboard />} />
+          <Route path="/admin" element={<div>admin-home</div>} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -97,7 +118,7 @@ describe("SellerDashboard", () => {
     });
     listOrders.mockResolvedValue([order("ord-1", 42)]);
 
-    renderDashboard();
+    renderDashboard("SELLER");
 
     expect(await screen.findByText("Visão geral")).toBeTruthy();
     expect(screen.getByText("Listings ativos")).toBeTruthy();
@@ -106,5 +127,18 @@ describe("SellerDashboard", () => {
     expect(screen.getByText("AK-47 | Redline")).toBeTruthy();
     expect(screen.queryByText(/SKINMARKET/i)).toBeNull();
     expect(screen.queryByText(/CS2 Skin Marketplace/i)).toBeNull();
+  });
+
+  it("redirects ADMIN to /admin instead of showing Seller not found", async () => {
+    getSellerListings.mockRejectedValue(new Error("Seller not found"));
+    listOrders.mockRejectedValue(new Error("Seller not found"));
+
+    renderDashboard("ADMIN");
+
+    expect(await screen.findByText("admin-home")).toBeTruthy();
+    expect(screen.queryByText("Erro ao carregar o painel")).toBeNull();
+    expect(screen.queryByText("Seller not found")).toBeNull();
+    expect(getSellerListings).not.toHaveBeenCalled();
+    expect(listOrders).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
 import {
   Package,
   Pencil,
@@ -47,6 +48,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { EmptyState, ErrorState } from "@/components/page-state";
+import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import {
   Select,
@@ -67,6 +69,8 @@ const emptyForm = {
 };
 
 export default function SellerListings() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "ADMIN";
   const [seller, setSeller] = useState<Seller | null>(null);
   const [listings, setListings] = useState<Listing[]>([]);
   const [products, setProducts] = useState<Product[]>([]);
@@ -128,10 +132,15 @@ export default function SellerListings() {
   };
 
   useEffect(() => {
+    if (isAdmin) return;
     void reload();
     // Mount + explicit retry via reload(); load helpers close over setters only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isAdmin]);
+
+  if (isAdmin) {
+    return <Navigate to="/admin" replace />;
+  }
 
   const openCreate = () => {
     setEditingListing(null);

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -1,12 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import SellerListings from "../SellerListings";
-import type { Listing, Seller } from "@/types/api";
+import type { Listing, Seller, User } from "@/types/api";
 
 const getSellerMe = vi.fn();
 const getSellerListings = vi.fn();
 const listProducts = vi.fn();
+const authState = {
+  user: {
+    id: "seller-user",
+    name: "Seller",
+    email: "seller@test.com",
+    role: "SELLER",
+  } as User,
+};
 
 vi.mock("@/api", () => ({
   getSellerMe: (...args: unknown[]) => getSellerMe(...args),
@@ -23,6 +31,10 @@ vi.mock("@/api/products", () => ({
 
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
 }));
 
 function seller(): Seller {
@@ -77,6 +89,12 @@ describe("SellerListings", () => {
       page: 1,
       limit: 100,
     });
+    authState.user = {
+      id: "seller-user",
+      name: "Seller",
+      email: "seller@test.com",
+      role: "SELLER",
+    };
   });
 
   it("keeps unique-item listing CRUD on /seller/listings", async () => {
@@ -125,5 +143,30 @@ describe("SellerListings", () => {
     expect(
       screen.getByRole("button", { name: "Tentar novamente" }),
     ).toBeTruthy();
+  });
+
+  it("redirects ADMIN to /admin instead of showing Seller not found", async () => {
+    authState.user = {
+      id: "admin-user",
+      name: "Admin",
+      email: "admin@test.com",
+      role: "ADMIN",
+    };
+    getSellerMe.mockRejectedValue(new Error("Seller not found"));
+
+    render(
+      <MemoryRouter initialEntries={["/seller/listings"]}>
+        <Routes>
+          <Route path="/seller/listings" element={<SellerListings />} />
+          <Route path="/admin" element={<div>admin-home</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("admin-home")).toBeTruthy();
+    expect(screen.queryByText("Erro ao carregar listings")).toBeNull();
+    expect(screen.queryByText("Seller not found")).toBeNull();
+    expect(getSellerMe).not.toHaveBeenCalled();
+    expect(getSellerListings).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Depois do login/registro, cada papel aterra na superfície certa. ADMIN com `from` de rota seller vai para `/admin` em vez de cair em “Seller not found”.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/86

## O que muda

- Helper `postLoginPath(role, from)`: CUSTOMER → `/`, SELLER → `/seller`, ADMIN → `/admin` quando `from` é vazio ou `/`.
- ADMIN + `from=/seller/listings` → `/admin`.
- CUSTOMER + `from=/checkout` → `/checkout`; outros papéis no checkout vão ao dashboard com toast de que checkout é de comprador.
- Register pós-verify: SELLER → `/seller`, CUSTOMER → `/`.
- Dashboard e listings do seller: ADMIN redireciona para `/admin` antes de chamar APIs de seller.
- `from` sanitizado (paths internos; `//`, `://`, `/login`, `/register` caem no home do papel).

## Critérios de aceite

- [x] Login admin sem `from` abre `/admin`
- [x] Login admin com `from=/seller/listings` abre `/admin`
- [x] Login seller sem `from` abre `/seller`
- [x] Login customer com `from=/checkout` abre `/checkout`
- [x] Testes de Login cobrem os três papéis

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → pass
- `npm test` → 29 files / 151 tests passed

## Riscos

- `/seller/orders` e `/seller/products` ainda permitem ADMIN na rota; só dashboard e listings redirecionam.
- SELLER não aprovado ainda cai em `/seller` (sem tela de onboarding pendente).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

