### PR TITLE
#137 — [UX] Redirecionar ADMIN para /admin em todas as rotas /seller/*

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ const App = () => (
                   <Route
                     path="/seller"
                     element={
-                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                      <ProtectedRoute allowedRoles={["SELLER"]}>
                         <SellerDashboard />
                       </ProtectedRoute>
                     }
@@ -88,7 +88,7 @@ const App = () => (
                   <Route
                     path="/seller/products"
                     element={
-                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                      <ProtectedRoute allowedRoles={["SELLER"]}>
                         <SellerProducts />
                       </ProtectedRoute>
                     }
@@ -96,7 +96,7 @@ const App = () => (
                   <Route
                     path="/seller/listings"
                     element={
-                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                      <ProtectedRoute allowedRoles={["SELLER"]}>
                         <SellerListings />
                       </ProtectedRoute>
                     }
@@ -104,7 +104,7 @@ const App = () => (
                   <Route
                     path="/seller/orders"
                     element={
-                      <ProtectedRoute allowedRoles={["SELLER", "ADMIN"]}>
+                      <ProtectedRoute allowedRoles={["SELLER"]}>
                         <SellerOrders />
                       </ProtectedRoute>
                     }

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { ErrorState, PageSkeleton } from "@/components/page-state";
+import { homePathForRole, isSellerPath } from "@/lib/postLoginPath";
 import type { Role } from "@/types/api";
 
 interface ProtectedRouteProps {
@@ -21,6 +22,10 @@ export function ProtectedRoute({
 
   if (!isAuthenticated || !user) {
     return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (isSellerPath(location.pathname) && user.role === "ADMIN") {
+    return <Navigate to={homePathForRole("ADMIN")} replace />;
   }
 
   if (

--- a/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ProtectedRoute } from "../ProtectedRoute";
+import type { Role, User } from "@/types/api";
+
+const authState = {
+  user: null as User | null,
+  isAuthenticated: false,
+  isLoading: false,
+};
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+const SELLER_ROUTES = [
+  "/seller",
+  "/seller/listings",
+  "/seller/products",
+  "/seller/orders",
+] as const;
+
+function userFor(role: Role): User {
+  return {
+    id: `${role.toLowerCase()}-user`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
+}
+
+function renderSellerGate(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          element={
+            <ProtectedRoute>
+              <div>
+                <nav aria-label="Painel">seller-chrome</nav>
+                <ProtectedRoute allowedRoles={["SELLER"]}>
+                  <div>seller-page</div>
+                </ProtectedRoute>
+              </div>
+            </ProtectedRoute>
+          }
+        >
+          <Route path="/seller" element={null} />
+          <Route path="/seller/listings" element={null} />
+          <Route path="/seller/products" element={null} />
+          <Route path="/seller/orders" element={null} />
+        </Route>
+        <Route path="/admin" element={<div>admin-home</div>} />
+        <Route path="/login" element={<div>login</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ProtectedRoute seller surface", () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
+  });
+
+  it.each(SELLER_ROUTES)(
+    "redirects ADMIN from %s to /admin without seller chrome or Acesso negado",
+    (path) => {
+      authState.user = userFor("ADMIN");
+      authState.isAuthenticated = true;
+
+      renderSellerGate(path);
+
+      expect(screen.getByText("admin-home")).toBeTruthy();
+      expect(screen.queryByText("seller-chrome")).toBeNull();
+      expect(screen.queryByText("seller-page")).toBeNull();
+      expect(screen.queryByText("Acesso negado")).toBeNull();
+    },
+  );
+
+  it.each(SELLER_ROUTES)("keeps SELLER on %s", (path) => {
+    authState.user = userFor("SELLER");
+    authState.isAuthenticated = true;
+
+    renderSellerGate(path);
+
+    expect(screen.getByText("seller-page")).toBeTruthy();
+    expect(screen.getByText("seller-chrome")).toBeTruthy();
+    expect(screen.queryByText("admin-home")).toBeNull();
+  });
+
+  it("still denies CUSTOMER on /seller with Acesso negado", () => {
+    authState.user = userFor("CUSTOMER");
+    authState.isAuthenticated = true;
+
+    renderSellerGate("/seller");
+
+    expect(screen.getByText("Acesso negado")).toBeTruthy();
+    expect(screen.queryByText("admin-home")).toBeNull();
+    expect(screen.queryByText("seller-page")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/isSellerPath.test.ts
+++ b/src/lib/__tests__/isSellerPath.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isSellerPath } from "../postLoginPath";
+
+describe("isSellerPath", () => {
+  it("covers every seller dashboard route", () => {
+    expect(isSellerPath("/seller")).toBe(true);
+    expect(isSellerPath("/seller/listings")).toBe(true);
+    expect(isSellerPath("/seller/products")).toBe(true);
+    expect(isSellerPath("/seller/orders")).toBe(true);
+  });
+
+  it("does not treat admin or storefront paths as seller", () => {
+    expect(isSellerPath("/admin")).toBe(false);
+    expect(isSellerPath("/admin/orders")).toBe(false);
+    expect(isSellerPath("/products")).toBe(false);
+    expect(isSellerPath("/")).toBe(false);
+  });
+});

--- a/src/lib/__tests__/postLoginPath.test.ts
+++ b/src/lib/__tests__/postLoginPath.test.ts
@@ -59,6 +59,8 @@ describe("postLoginPath", () => {
   it("sends admin away from seller routes to /admin", () => {
     expect(postLoginPath("ADMIN", "/seller").path).toBe("/admin");
     expect(postLoginPath("ADMIN", "/seller/listings").path).toBe("/admin");
+    expect(postLoginPath("ADMIN", "/seller/products").path).toBe("/admin");
+    expect(postLoginPath("ADMIN", "/seller/orders").path).toBe("/admin");
   });
 
   it("sends seller without from to /seller", () => {

--- a/src/lib/postLoginPath.ts
+++ b/src/lib/postLoginPath.ts
@@ -46,7 +46,7 @@ export function normalizeInternalPath(from?: string | null): string {
   return collapsed;
 }
 
-function isSellerPath(path: string): boolean {
+export function isSellerPath(path: string): boolean {
   return path === "/seller" || path.startsWith("/seller/");
 }
 

--- a/src/pages/seller/SellerOrders.tsx
+++ b/src/pages/seller/SellerOrders.tsx
@@ -1,5 +1,7 @@
+import { Navigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { listOrders } from "@/api/orders";
+import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -19,6 +21,8 @@ function orderTotal(order: Order): number {
 }
 
 export default function SellerOrdersPage() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "ADMIN";
   const {
     data: orders = [],
     isLoading,
@@ -28,7 +32,12 @@ export default function SellerOrdersPage() {
   } = useQuery({
     queryKey: ["sellerOrders"],
     queryFn: () => listOrders(),
+    enabled: user?.role === "SELLER",
   });
+
+  if (isAdmin) {
+    return <Navigate to="/admin" replace />;
+  }
 
   if (isLoading) {
     return (

--- a/src/pages/seller/SellerProducts.tsx
+++ b/src/pages/seller/SellerProducts.tsx
@@ -1,7 +1,8 @@
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { listProducts } from "@/api/products";
+import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -17,15 +18,22 @@ import {
 const PAGE_SIZE = 20;
 
 export default function SellerProductsPage() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "ADMIN";
   const [page, setPage] = useState(1);
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["products", { page, limit: PAGE_SIZE }],
     queryFn: () => listProducts({ page, limit: PAGE_SIZE }),
+    enabled: user?.role === "SELLER",
   });
 
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  if (isAdmin) {
+    return <Navigate to="/admin" replace />;
+  }
 
   if (isLoading) {
     return (

--- a/src/pages/seller/__tests__/SellerOrders.test.tsx
+++ b/src/pages/seller/__tests__/SellerOrders.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SellerOrdersPage from "../SellerOrders";
+import type { Order, Role, User } from "@/types/api";
+
+const listOrders = vi.fn();
+const authState = {
+  user: {
+    id: "seller-user",
+    name: "Seller",
+    email: "seller@test.com",
+    role: "SELLER",
+  } as User,
+};
+
+vi.mock("@/api/orders", () => ({
+  listOrders: (...args: unknown[]) => listOrders(...args),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+function order(): Order {
+  return {
+    id: "ord-1",
+    totalAmount: 42,
+    status: "CONFIRMED",
+    paymentStatus: "PAID",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    items: [
+      {
+        id: "item-1",
+        listingId: "listing-1",
+        sellerId: "seller-1",
+        priceSnapshot: 42,
+        listing: {
+          id: "listing-1",
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+      },
+    ],
+  };
+}
+
+function setRole(role: Role) {
+  authState.user = {
+    id: `${role.toLowerCase()}-user`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
+}
+
+function renderOrders() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/seller/orders"]}>
+        <Routes>
+          <Route path="/seller/orders" element={<SellerOrdersPage />} />
+          <Route path="/admin" element={<div>admin-home</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SellerOrders", () => {
+  beforeEach(() => {
+    listOrders.mockReset();
+    setRole("SELLER");
+  });
+
+  it("renders the seller order list", async () => {
+    listOrders.mockResolvedValue([order()]);
+
+    renderOrders();
+
+    expect(await screen.findByText("Pedidos")).toBeTruthy();
+    expect(
+      screen.getByText("Pedidos que incluem um listing da sua loja."),
+    ).toBeTruthy();
+    expect(screen.getByText("Pedido ord-1")).toBeTruthy();
+    expect(screen.getByText("AK-47 | Redline")).toBeTruthy();
+    expect(listOrders).toHaveBeenCalled();
+  });
+
+  it("redirects ADMIN to /admin without rendering seller orders or calling listOrders", async () => {
+    setRole("ADMIN");
+    listOrders.mockResolvedValue([order()]);
+
+    renderOrders();
+
+    expect(await screen.findByText("admin-home")).toBeTruthy();
+    expect(screen.queryByText("Pedidos")).toBeNull();
+    expect(screen.queryByText("Pedido ord-1")).toBeNull();
+    expect(
+      screen.queryByText("Pedidos que incluem um listing da sua loja."),
+    ).toBeNull();
+    expect(listOrders).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/seller/__tests__/SellerProducts.test.tsx
+++ b/src/pages/seller/__tests__/SellerProducts.test.tsx
@@ -1,14 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SellerProductsPage from "../SellerProducts";
-import type { Product } from "@/types/api";
+import type { Product, Role, User } from "@/types/api";
 
 const listProducts = vi.fn();
+const authState = {
+  user: {
+    id: "seller-user",
+    name: "Seller",
+    email: "seller@test.com",
+    role: "SELLER",
+  } as User,
+};
 
 vi.mock("@/api/products", () => ({
   listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
 }));
 
 function product(): Product {
@@ -28,14 +40,26 @@ function product(): Product {
   };
 }
 
-function renderProducts() {
+function setRole(role: Role) {
+  authState.user = {
+    id: `${role.toLowerCase()}-user`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
+}
+
+function renderProducts(path = "/seller/products") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <MemoryRouter>
-        <SellerProductsPage />
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/seller/products" element={<SellerProductsPage />} />
+          <Route path="/admin" element={<div>admin-home</div>} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -44,6 +68,7 @@ function renderProducts() {
 describe("SellerProducts", () => {
   beforeEach(() => {
     listProducts.mockReset();
+    setRole("SELLER");
   });
 
   it("renders a read-only product catalog from listProducts", async () => {
@@ -84,5 +109,22 @@ describe("SellerProducts", () => {
     expect(
       screen.queryByRole("button", { name: /criar|salvar|excluir/i }),
     ).toBeNull();
+  });
+
+  it("redirects ADMIN to /admin without calling listProducts", async () => {
+    setRole("ADMIN");
+    listProducts.mockResolvedValue({
+      items: [product()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderProducts();
+
+    expect(await screen.findByText("admin-home")).toBeTruthy();
+    expect(screen.queryByText("Produtos")).toBeNull();
+    expect(screen.queryByText("AK-47 | Redline")).toBeNull();
+    expect(listProducts).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fecha o residual do #86: ADMIN que acessa `/seller/products` ou `/seller/orders` (URL direta) deixa de ficar no chrome de vendedor.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/137

## O que muda

- Rotas `/seller/*` passam a `allowedRoles={["SELLER"]}`.
- `ProtectedRoute` redireciona ADMIN nesses paths para `/admin` antes do `DashboardLayout`.
- `SellerProducts` / `SellerOrders`: `Navigate` para ADMIN e queries só com `enabled: role === "SELLER"`.
- SELLER inalterado. CUSTOMER continua vendo “Acesso negado” (não vai para home).

## Critérios de aceite

- [x] ADMIN em `/seller/products` vai para `/admin`; sem chamada de API de seller
- [x] ADMIN em `/seller/orders` vai para `/admin`
- [x] SELLER nas mesmas rotas permanece
- [x] Testes cobrem as quatro rotas `/seller`, `/seller/listings`, `/seller/products`, `/seller/orders`

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 32 files, 165 tests passed

## Riscos

- Só roteamento de superfície; chamada de API com token ADMIN continua sendo preocupação de backend (fora de escopo).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

