### PR TITLE
#140 — P1 — Alinhar seed e GET /commissions/balance ao ledger SellerTransaction

### DIFF
--- a/docs/adr/0011-seller-ledger.md
+++ b/docs/adr/0011-seller-ledger.md
@@ -28,5 +28,5 @@ Drop the two CHECK constraints. Unique `(sellerId, orderId)` and the confirm-pat
 ## Consequences
 
 - Duplicate payment confirmation remains a no-op after the order claim (`paymentStatus = PENDING AND status = PENDING`); the unique constraint is defense in depth.
-- Demo seed may set `Seller.balance` without matching ledger rows. That display data is not a production invariant. Reconciliation (#45) would flag it.
+- Demo seed sets `Seller.balance` to `"0.00"` with no `SellerTransaction` rows so the projection matches an empty PAID `SUM(netAmount)`. Non-zero credits are written only by `confirmPayment`. `GET /commissions/balance` returns the Decimal projection without `Number()`. Periodic SUM-vs-projection reconciliation remains #45.
 - Capture after reservation expiry still creates no ledger row (ADR 0002).

--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -91,6 +91,7 @@ Rules:
 3. Confirmation writes `status = PAID`. `REFUNDED` is not an application path.
 4. `Seller.balance` is a materialized projection of PAID net amounts, updated in the same local database transaction as the ledger insert. If they disagree, the ledger wins.
 5. Duplicate confirm, webhook replay, and concurrent confirmation must not insert a second row or double-credit the projection.
+6. `GET /commissions/balance` exposes that projection as Prisma Decimal JSON (string), not a JavaScript `number`. Demo seed writes `"0.00"` with no ledger rows so display data cannot diverge from an empty SUM.
 
 ## Authorization
 

--- a/docs/domain/invariants.md
+++ b/docs/domain/invariants.md
@@ -131,7 +131,9 @@ Related IDs below keep this catalog aligned with the architecture narrative. Cit
 
 - Schema: unique `(sellerId, orderId)`; CHECK net identity and non-negative amounts. `Seller.balance` documented as projection (ADR 0011).
 - Service: `confirmPayment` claim (`paymentStatus = PENDING AND status = PENDING`) plus ledger insert. Duplicate claims are no-ops.
-- Tests: `seller.ledger.integration.test.ts` (sequential and concurrent confirm, net identity, Decimal vs float); `reservation.lifecycle.integration.test.ts`; `paypal.webhook.integration.test.ts`.
+- HTTP: `GET /commissions/balance` returns the Prisma Decimal projection (JSON string via Decimal#toJSON). No `Number()`.
+- Seed: demo `Seller.balance` is `"0.00"` with no ledger rows so the projection matches empty PAID SUM. Confirm remains the only non-zero writer.
+- Tests: `seller.ledger.integration.test.ts` (sequential and concurrent confirm, net identity, Decimal vs float); `reservation.lifecycle.integration.test.ts`; `paypal.webhook.integration.test.ts`; `commissions.service.test.ts`; `demoCatalog.test.ts`; `seed.ledger.integration.test.ts`.
 
 **Related:** `INV-SELLER-COMMISSION-DECIMAL`, `INV-SELLER-TXN-UNIQUE`. Issue #45 (not implemented) can reconcile projection vs `SUM(netAmount) WHERE status = 'PAID'`.
 

--- a/server/src/__tests__/seed.ledger.integration.test.ts
+++ b/server/src/__tests__/seed.ledger.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import { DomainInvariant } from "../shared/domain/invariants.js";
+import { prisma } from "../shared/database/index.js";
+import { commissionsService } from "../modules/commissions/commissions.service.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import { seedDemoData } from "../scripts/seedDemoData.js";
+import { DEMO_USERS } from "../scripts/demoCatalog.js";
+import { createCheckoutGraph, createOrder, orderKey } from "./helpers/index.js";
+
+describe(`${DomainInvariant.SELLER_LEDGER_SOURCE} demo seed and GET balance`, () => {
+  it("seeds seller balances that match PAID ledger SUM(netAmount)", async () => {
+    await seedDemoData();
+
+    const sellers = await prisma.seller.findMany({
+      include: { user: { select: { email: true } } },
+    });
+    expect(sellers.length).toBe(DEMO_USERS.filter((user) => user.seller).length);
+
+    for (const seller of sellers) {
+      const paid = await prisma.sellerTransaction.aggregate({
+        where: { sellerId: seller.id, status: "PAID" },
+        _sum: { netAmount: true },
+      });
+      const ledgerSum = paid._sum.netAmount ?? new Prisma.Decimal(0);
+      expect(seller.balance.equals(ledgerSum)).toBe(true);
+      expect(seller.balance.isZero()).toBe(true);
+    }
+
+    const ledgerRows = await prisma.sellerTransaction.count();
+    expect(ledgerRows).toBe(0);
+  });
+
+  it("GET balance JSON is a Decimal string equal to the PAID ledger net", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(
+      fixture.customer.id,
+      [fixture.listings[0].id],
+      orderKey("balance-json-ledger")
+    );
+
+    await paymentsService.confirmPayment(created.id);
+
+    const result = await commissionsService.getBalance(fixture.sellerUser.id);
+    const json = JSON.parse(JSON.stringify(result)) as { balance: unknown };
+    const txn = await prisma.sellerTransaction.findFirst({
+      where: { sellerId: fixture.seller.id, status: "PAID" },
+    });
+    const seller = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+
+    expect(typeof json.balance).toBe("string");
+    expect(typeof result.balance).not.toBe("number");
+    expect(result.balance.equals(new Prisma.Decimal("90"))).toBe(true);
+    expect(new Prisma.Decimal(json.balance as string).equals(seller!.balance)).toBe(true);
+    expect(new Prisma.Decimal(json.balance as string).equals(txn!.netAmount)).toBe(true);
+  });
+});

--- a/server/src/modules/commissions/__tests__/commissions.service.test.ts
+++ b/server/src/modules/commissions/__tests__/commissions.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Prisma } from "@prisma/client";
 
 vi.mock("../../../shared/database/index.js", () => ({
   prisma: {
@@ -19,6 +20,7 @@ vi.mock("../commissions.repository.js", () => ({
 import { prisma } from "../../../shared/database/index.js";
 import { commissionsRepository } from "../commissions.repository.js";
 import { commissionsService } from "../commissions.service.js";
+import { openApiSpec } from "../../../shared/docs/openapi.js";
 
 const mockSeller = (overrides = {}) => ({
   id: "seller-1",
@@ -70,14 +72,42 @@ describe("commissionsService", () => {
   });
 
   describe("getBalance()", () => {
-    it("returns seller balance as a number", async () => {
-      vi.mocked(prisma.seller.findUnique).mockResolvedValue(mockSeller({ balance: 375.5 }) as any);
-      vi.mocked(commissionsRepository.getBalance).mockResolvedValue(375.5 as any);
+    it("returns seller balance as Prisma Decimal, not a JavaScript number", async () => {
+      const stored = new Prisma.Decimal("1250.75");
+      vi.mocked(prisma.seller.findUnique).mockResolvedValue(mockSeller({ balance: stored }) as any);
+      vi.mocked(commissionsRepository.getBalance).mockResolvedValue(stored);
 
       const result = await commissionsService.getBalance("user-1");
 
-      expect(result).toEqual({ balance: 375.5 });
-      expect(typeof result.balance).toBe("number");
+      expect(result.balance).toBeInstanceOf(Prisma.Decimal);
+      expect(result.balance.equals(stored)).toBe(true);
+      expect(typeof result.balance).not.toBe("number");
+    });
+
+    it("JSON-serializes balance as a Decimal string that keeps scale", async () => {
+      const stored = new Prisma.Decimal("1250.75");
+      vi.mocked(prisma.seller.findUnique).mockResolvedValue(mockSeller({ balance: stored }) as any);
+      vi.mocked(commissionsRepository.getBalance).mockResolvedValue(stored);
+
+      const result = await commissionsService.getBalance("user-1");
+      const json = JSON.parse(JSON.stringify(result)) as { balance: unknown };
+
+      expect(typeof json.balance).toBe("string");
+      expect(json.balance).toBe("1250.75");
+      expect(new Prisma.Decimal(json.balance as string).equals(stored)).toBe(true);
+    });
+
+    it("does not coerce 0.10 + 0.20 through JavaScript number on the HTTP JSON path", async () => {
+      const stored = new Prisma.Decimal("0.10").plus(new Prisma.Decimal("0.20"));
+      vi.mocked(prisma.seller.findUnique).mockResolvedValue(mockSeller({ balance: stored }) as any);
+      vi.mocked(commissionsRepository.getBalance).mockResolvedValue(stored);
+
+      const result = await commissionsService.getBalance("user-1");
+      const json = JSON.parse(JSON.stringify(result)) as { balance: unknown };
+
+      expect(typeof json.balance).toBe("string");
+      expect(new Prisma.Decimal(json.balance as string).equals(new Prisma.Decimal("0.30"))).toBe(true);
+      expect(json.balance).not.toBe(0.1 + 0.2);
     });
 
     it("throws 404 when seller not found", async () => {
@@ -87,5 +117,15 @@ describe("commissionsService", () => {
         statusCode: 404,
       });
     });
+  });
+});
+
+describe("OpenAPI GET /commissions/balance", () => {
+  it("documents balance as a Decimal string, not a JSON number", () => {
+    const schema = openApiSpec.paths["/commissions/balance"].get.responses[200].content[
+      "application/json"
+    ].schema;
+    expect(schema.properties.balance.type).toBe("string");
+    expect(schema.properties.balance.type).not.toBe("number");
   });
 });

--- a/server/src/modules/commissions/commissions.service.ts
+++ b/server/src/modules/commissions/commissions.service.ts
@@ -20,6 +20,8 @@ export const commissionsService = {
     });
     if (!seller) throw new AppError(404, "Seller not found");
     const balance = await commissionsRepository.getBalance(seller.id);
-    return { balance: Number(balance) };
+    // Projection only (ADR 0011). Pass Prisma Decimal through so JSON.stringify
+    // uses Decimal#toJSON (a string), matching listing price / order totalAmount.
+    return { balance };
   },
 };

--- a/server/src/scripts/__tests__/demoCatalog.test.ts
+++ b/server/src/scripts/__tests__/demoCatalog.test.ts
@@ -46,4 +46,13 @@ describe("demoCatalog", () => {
     expect(listing).toBeDefined();
     expect(listingPrice(product!, listing!)).toBe("22.00");
   });
+
+  it("seeds seller balances at zero so the empty ledger is the source of truth", () => {
+    const sellers = DEMO_USERS.filter((user) => user.seller);
+    expect(sellers.length).toBeGreaterThan(0);
+
+    for (const user of sellers) {
+      expect(["0", "0.00"]).toContain(user.seller!.balance);
+    }
+  });
 });

--- a/server/src/scripts/demoCatalog.ts
+++ b/server/src/scripts/demoCatalog.ts
@@ -52,21 +52,21 @@ export const DEMO_USERS: DemoUser[] = [
     password: "seller123",
     name: "NeonTrader",
     role: "SELLER",
-    seller: { storeName: "NeonTrader Store", commissionRate: "0.10", balance: "1250.75", isApproved: true },
+    seller: { storeName: "NeonTrader Store", commissionRate: "0.10", balance: "0.00", isApproved: true },
   },
   {
     email: "pro_trader@skinmarket.gg",
     password: "seller456",
     name: "ProTrader",
     role: "SELLER",
-    seller: { storeName: "ProTrader CS2", commissionRate: "0.08", balance: "580.00", isApproved: true },
+    seller: { storeName: "ProTrader CS2", commissionRate: "0.08", balance: "0.00", isApproved: true },
   },
   {
     email: "rustking@skinmarket.gg",
     password: "seller123",
     name: "RustKing",
     role: "SELLER",
-    seller: { storeName: "RustKing Trades", commissionRate: "0.10", balance: "210.40", isApproved: true },
+    seller: { storeName: "RustKing Trades", commissionRate: "0.10", balance: "0.00", isApproved: true },
   },
   {
     email: "pending_seller@skinmarket.gg",
@@ -261,6 +261,11 @@ export function assertDemoCatalog(): void {
     emails.add(user.email);
     if (user.role === "SELLER" && !user.seller) {
       throw new Error(`Seller ${user.email} is missing a store profile`);
+    }
+    if (user.seller && user.seller.balance !== "0" && user.seller.balance !== "0.00") {
+      throw new Error(
+        `Demo seller ${user.email} must seed balance "0" or "0.00"; confirm/ledger is the only balance writer`
+      );
     }
   }
 

--- a/server/src/scripts/seedDemoData.ts
+++ b/server/src/scripts/seedDemoData.ts
@@ -91,6 +91,8 @@ export async function seedDemoData(client: PrismaClient = prisma): Promise<SeedS
           userId: user.id,
           storeName: account.seller.storeName,
           commissionRate: account.seller.commissionRate,
+          // Zero projection: no SellerTransaction rows are seeded. confirmPayment
+          // is the only writer of non-zero Seller.balance (ADR 0011 / #140).
           balance: account.seller.balance,
           isApproved: account.seller.isApproved,
         },

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -509,7 +509,14 @@ export const openApiSpec = {
               "application/json": {
                 schema: {
                   type: "object",
-                  properties: { balance: { type: "number", example: 135.0 } },
+                  properties: {
+                    balance: {
+                      type: "string",
+                      example: "135.00",
+                      description:
+                        "Seller.balance projection as a Prisma Decimal JSON string (same wire format as listing price and order totalAmount). Not a JSON number.",
+                    },
+                  },
                 },
               },
             },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Alinha o GET de saldo e o seed de demo ao ledger do #44: sem `Number()` no caminho de dinheiro, e sem saldo seedado sem lançamentos PAID.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/140

## O que muda

- `GET /commissions/balance` devolve Prisma `Decimal` (JSON string, como `price` / `totalAmount`). OpenAPI: `type: string`.
- Seed de demo: `Seller.balance` é `"0.00"`; o único writer de saldo ≠ 0 continua sendo a confirmação/ledger.
- Testes de serialização, catálogo zerado e consistência seed × `SUM(net)` PAID.

Não implementa o worker de reconciliação (#45) nem política monetária/refund (#52).

## Verificação

- `cd server && npm run typecheck` → pass
- commissions + demoCatalog unit → 12 passed
- `cd server && npm run test:integration` → 75 passed

## Riscos

- Upsert de seller no seed não reescreve um banco já seedado com `1250.75` até um reset.
- GET ainda lê a projeção, não `SUM(net)` (#45).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

