### PR TITLE
#88 — [Accessibility] Mapear erros e status da API para português sem vazar URL ou detalhe técnico

### DIFF
--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -59,4 +59,17 @@ describe("api extra headers", () => {
       Authorization: "Bearer access-token",
     });
   });
+
+  it("keeps the API URL on the Error object and does not swallow the failure", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(api.get("/listings")).rejects.toMatchObject({
+      name: "ApiClientError",
+      code: "NETWORK",
+      message: expect.stringMatching(
+        /Could not reach API at .+Failed to fetch/,
+      ),
+    });
+  });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,3 +1,4 @@
+import { ApiClientError, logTechnicalError } from "@/lib/userFacingApiError";
 import { resolveApiBaseUrl } from "./apiBaseUrl";
 
 const API_BASE = resolveApiBaseUrl({
@@ -27,7 +28,7 @@ const tokenStorage: TokenStorage = {
 
 async function refreshAccessToken(): Promise<string> {
   const refresh = tokenStorage.getRefreshToken();
-  if (!refresh) throw new Error("No refresh token");
+  if (!refresh) throw new ApiClientError("No refresh token", { status: 401 });
   const res = await fetch(`${API_BASE}/auth/refresh`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -36,7 +37,9 @@ async function refreshAccessToken(): Promise<string> {
   if (!res.ok) {
     tokenStorage.clear();
     const data = await res.json().catch(() => ({}));
-    throw new Error(data.error ?? "Session expired");
+    throw new ApiClientError(data.error ?? "Session expired", {
+      status: res.status,
+    });
   }
   const data = await res.json();
   tokenStorage.setTokens(data.accessToken, data.refreshToken);
@@ -88,7 +91,14 @@ async function request<T>(
     res = await doFetch(access);
   } catch (err) {
     const reason = err instanceof Error ? err.message : "Failed to fetch";
-    throw new Error(`Could not reach API at ${url}: ${reason}`);
+    const error = new ApiClientError(
+      `Could not reach API at ${url}: ${reason}`,
+      {
+        code: "NETWORK",
+      },
+    );
+    logTechnicalError(error);
+    throw error;
   }
 
   if (res.status === 401 && !skipAuth && access) {
@@ -98,13 +108,22 @@ async function request<T>(
     } catch {
       tokenStorage.clear();
       const data = await res.json().catch(() => ({}));
-      throw new Error(data.error ?? "Unauthorized");
+      const error = new ApiClientError(data.error ?? "Unauthorized", {
+        status: 401,
+      });
+      logTechnicalError(error);
+      throw error;
     }
   }
 
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
-    throw new Error(data.error ?? `Request failed: ${res.status}`);
+    const error = new ApiClientError(
+      data.error ?? `Request failed: ${res.status}`,
+      { status: res.status },
+    );
+    logTechnicalError(error);
+    throw error;
   }
   return data as T;
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -30,7 +30,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="container py-20">
           <ErrorState
             title="Algo deu errado"
-            description={this.state.error.message}
+            error={this.state.error}
             action={
               <Button
                 type="button"

--- a/src/components/__tests__/page-state.test.tsx
+++ b/src/components/__tests__/page-state.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { EmptyState, ErrorState } from "../page-state";
+import { ApiClientError, USER_FACING_NETWORK } from "@/lib/userFacingApiError";
 
 describe("page-state", () => {
   it("exposes empty content as a status region", () => {
@@ -15,5 +16,17 @@ describe("page-state", () => {
     );
     expect(screen.getByRole("alert")).toBeTruthy();
     expect(screen.getByText("Erro ao carregar")).toBeTruthy();
+  });
+
+  it("maps API errors to Portuguese without leaking the host", () => {
+    const error = new ApiClientError(
+      "Could not reach API at http://localhost:3001/listings: Failed to fetch",
+      { code: "NETWORK" },
+    );
+    render(<ErrorState title="Erro ao carregar listings" error={error} />);
+    expect(screen.getByText(USER_FACING_NETWORK)).toBeTruthy();
+    expect(screen.queryByText(/localhost/i)).toBeNull();
+    expect(screen.queryByText(/Failed to fetch/i)).toBeNull();
+    expect(error.message).toContain("http://localhost:3001");
   });
 });

--- a/src/components/page-state.tsx
+++ b/src/components/page-state.tsx
@@ -1,5 +1,9 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  logTechnicalError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
 
 type Action = ReactNode;
 
@@ -42,19 +46,29 @@ export function EmptyState({
 export function ErrorState({
   title = "Algo deu errado",
   description,
+  error,
   action,
 }: {
   title?: string;
   description?: string;
+  error?: unknown;
   action?: Action;
 }) {
+  useEffect(() => {
+    if (error !== undefined) logTechnicalError(error);
+  }, [error]);
+
+  const text =
+    description ??
+    (error !== undefined ? userFacingApiError(error) : undefined);
+
   return (
     <div className="mx-auto max-w-md py-16 text-center" role="alert">
       <h2 className="text-lg font-semibold tracking-tight text-foreground">
         {title}
       </h2>
-      {description ? (
-        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+      {text ? (
+        <p className="mt-2 text-sm text-muted-foreground">{text}</p>
       ) : null}
       {action ? <div className="mt-6">{action}</div> : null}
     </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,6 +7,10 @@ import {
   ReactNode,
 } from "react";
 import * as authApi from "@/api/auth";
+import {
+  logTechnicalError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
 import type { User } from "@/types/api";
 
 interface AuthContextType {
@@ -64,7 +68,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(data.user);
       return data.user;
     } catch (e) {
-      const message = e instanceof Error ? e.message : "Login failed";
+      const message = userFacingApiError(e);
+      logTechnicalError(e);
       setError(message);
       throw e;
     }
@@ -82,7 +87,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       try {
         return await authApi.register(params);
       } catch (e) {
-        const message = e instanceof Error ? e.message : "Registration failed";
+        const message = userFacingApiError(e);
+        logTechnicalError(e);
         setError(message);
         throw e;
       }
@@ -97,8 +103,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const data = await authApi.verifyEmail({ email, code });
         setUser(data.user);
       } catch (e) {
-        const message =
-          e instanceof Error ? e.message : "Invalid or expired code";
+        const message = userFacingApiError(e);
+        logTechnicalError(e);
         setError(message);
         throw e;
       }

--- a/src/lib/__tests__/userFacingApiError.test.ts
+++ b/src/lib/__tests__/userFacingApiError.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  ApiClientError,
+  USER_FACING_CONFLICT,
+  USER_FACING_CREDENTIALS,
+  USER_FACING_EMAIL_TAKEN,
+  USER_FACING_FORBIDDEN,
+  USER_FACING_GENERIC,
+  USER_FACING_LISTING_CONFLICT,
+  USER_FACING_NETWORK,
+  USER_FACING_NOT_FOUND,
+  USER_FACING_RATE_LIMIT,
+  USER_FACING_SERVER,
+  USER_FACING_UNAUTHORIZED,
+  USER_FACING_VALIDATION,
+  USER_FACING_VERIFICATION_CODE,
+  listingStatusLabel,
+  orderStatusLabel,
+  paymentStatusLabel,
+  userFacingApiError,
+} from "../userFacingApiError";
+
+describe("userFacingApiError", () => {
+  it("maps network failures without leaking the API URL", () => {
+    const error = new ApiClientError(
+      "Could not reach API at http://localhost:3001/listings: Failed to fetch",
+      { code: "NETWORK" },
+    );
+
+    expect(userFacingApiError(error)).toBe(USER_FACING_NETWORK);
+    expect(error.message).toContain("http://localhost:3001");
+    expect(error.message).toContain("Failed to fetch");
+    expect(userFacingApiError(error)).not.toMatch(
+      /localhost|Failed to fetch|http:\/\//i,
+    );
+  });
+
+  it("maps Failed to fetch and TypeError fetch failures to the network copy", () => {
+    expect(userFacingApiError(new Error("Failed to fetch"))).toBe(
+      USER_FACING_NETWORK,
+    );
+    expect(userFacingApiError(new TypeError("Failed to fetch"))).toBe(
+      USER_FACING_NETWORK,
+    );
+  });
+
+  it("maps 401 session and credential errors", () => {
+    expect(
+      userFacingApiError(new ApiClientError("Unauthorized", { status: 401 })),
+    ).toBe(USER_FACING_UNAUTHORIZED);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Invalid email or password", { status: 401 }),
+      ),
+    ).toBe(USER_FACING_CREDENTIALS);
+  });
+
+  it("maps 403 and 404", () => {
+    expect(
+      userFacingApiError(new ApiClientError("Forbidden", { status: 403 })),
+    ).toBe(USER_FACING_FORBIDDEN);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Listing not found", { status: 404 }),
+      ),
+    ).toBe(USER_FACING_NOT_FOUND);
+    expect(userFacingApiError(new Error("Listing not found"))).toBe(
+      USER_FACING_NOT_FOUND,
+    );
+    expect(userFacingApiError(new Error("Listing not found"))).not.toBe(
+      "Listing not found",
+    );
+  });
+
+  it("maps 409 listing reservation to the buyer conflict copy", () => {
+    expect(
+      userFacingApiError(
+        new ApiClientError("Listing is already reserved", { status: 409 }),
+      ),
+    ).toBe(USER_FACING_LISTING_CONFLICT);
+    expect(
+      userFacingApiError(
+        new ApiClientError(
+          "Listing listing-1 is not available (status: RESERVED)",
+          {
+            status: 400,
+          },
+        ),
+      ),
+    ).toBe(USER_FACING_LISTING_CONFLICT);
+  });
+
+  it("maps other 409s, 429, 5xx and validation", () => {
+    expect(
+      userFacingApiError(
+        new ApiClientError("Order status changed concurrently", {
+          status: 409,
+        }),
+      ),
+    ).toBe(USER_FACING_CONFLICT);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Email already registered", { status: 409 }),
+      ),
+    ).toBe(USER_FACING_EMAIL_TAKEN);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Too many requests", { status: 429 }),
+      ),
+    ).toBe(USER_FACING_RATE_LIMIT);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Internal server error.", { status: 500 }),
+      ),
+    ).toBe(USER_FACING_SERVER);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Invalid verification code", { status: 400 }),
+      ),
+    ).toBe(USER_FACING_VERIFICATION_CODE);
+    expect(
+      userFacingApiError(
+        new ApiClientError("Float must be between 0 and 1", { status: 400 }),
+      ),
+    ).toBe(USER_FACING_VALIDATION);
+  });
+
+  it("never returns localhost, Failed to fetch, or an API URL", () => {
+    const cases: unknown[] = [
+      new Error(
+        "Could not reach API at http://localhost:3001/auth/login: Failed to fetch",
+      ),
+      new Error("Failed to fetch"),
+      new ApiClientError("Request failed: 502", { status: 502 }),
+      "Could not reach API at https://api.example.com/v1",
+      { status: 0, message: "Failed to fetch" },
+    ];
+
+    for (const error of cases) {
+      const copy = userFacingApiError(error);
+      expect(copy).not.toMatch(/localhost/i);
+      expect(copy).not.toMatch(/Failed to fetch/i);
+      expect(copy).not.toMatch(/https?:\/\//i);
+      expect(copy.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps a generic Portuguese fallback without echoing unknown English", () => {
+    expect(userFacingApiError(new Error("ECONNRESET boom"))).toBe(
+      USER_FACING_NETWORK,
+    );
+    expect(userFacingApiError(new Error("weird upstream stack"))).toBe(
+      USER_FACING_GENERIC,
+    );
+    expect(userFacingApiError(new Error("weird upstream stack"))).not.toBe(
+      "weird upstream stack",
+    );
+  });
+});
+
+describe("status labels", () => {
+  it("translates listing statuses visible to the user", () => {
+    expect(listingStatusLabel("ACTIVE")).toBe("Disponível");
+    expect(listingStatusLabel("RESERVED")).toBe("Reservado");
+    expect(listingStatusLabel("SOLD")).toBe("Vendido");
+    expect(listingStatusLabel("CANCELED")).toBe("Cancelado");
+  });
+
+  it("translates order and payment statuses", () => {
+    expect(orderStatusLabel("PENDING")).toBe("Pendente");
+    expect(orderStatusLabel("CONFIRMED")).toBe("Confirmado");
+    expect(orderStatusLabel("SHIPPED")).toBe("Enviado");
+    expect(orderStatusLabel("DELIVERED")).toBe("Entregue");
+    expect(orderStatusLabel("CANCELLED")).toBe("Cancelado");
+    expect(paymentStatusLabel("PENDING")).toBe("Pendente");
+    expect(paymentStatusLabel("PAID")).toBe("Pago");
+    expect(paymentStatusLabel("REFUNDED")).toBe("Reembolsado");
+  });
+});

--- a/src/lib/orderPaymentView.ts
+++ b/src/lib/orderPaymentView.ts
@@ -1,4 +1,8 @@
 import type { Order } from "@/types/api";
+import {
+  isForbiddenApiError,
+  isNotFoundApiError,
+} from "@/lib/userFacingApiError";
 
 export type OrderPageIntent = "return" | "cancel" | "view";
 
@@ -106,6 +110,7 @@ export function orderPollIntervalMs(
 }
 
 export function isOrderAccessError(error: unknown): boolean {
+  if (isForbiddenApiError(error) || isNotFoundApiError(error)) return true;
   const message = error instanceof Error ? error.message : String(error ?? "");
   return (
     /order not found/i.test(message) ||

--- a/src/lib/userFacingApiError.ts
+++ b/src/lib/userFacingApiError.ts
@@ -1,0 +1,236 @@
+/**
+ * Single storefront mapper: API status/code/known message → Portuguese copy.
+ * Technical detail stays on the Error object (and optional DEV logs), never in UI.
+ */
+
+export const USER_FACING_NETWORK =
+  "Não foi possível conectar. Verifique sua conexão e tente de novo.";
+
+export const USER_FACING_LISTING_CONFLICT =
+  "Este item acabou de ser reservado por outro comprador.";
+
+export const USER_FACING_UNAUTHORIZED =
+  "Sua sessão expirou. Entre novamente para continuar.";
+
+export const USER_FACING_CREDENTIALS =
+  "E-mail ou senha incorretos. Verifique os dados e tente de novo.";
+
+export const USER_FACING_FORBIDDEN =
+  "Você não tem permissão para acessar isto.";
+
+export const USER_FACING_NOT_FOUND =
+  "Não encontramos o que você procura. Volte ao Market e tente de novo.";
+
+export const USER_FACING_CONFLICT =
+  "Este recurso mudou. Recarregue a página e tente de novo.";
+
+export const USER_FACING_RATE_LIMIT =
+  "Muitas tentativas. Espere um momento e tente de novo.";
+
+export const USER_FACING_SERVER =
+  "O serviço está indisponível. Tente de novo em instantes.";
+
+export const USER_FACING_VALIDATION =
+  "Alguns dados estão inválidos. Confira os campos e tente de novo.";
+
+export const USER_FACING_EMAIL_TAKEN =
+  "Este e-mail já está em uso. Entre ou use outro e-mail.";
+
+export const USER_FACING_VERIFICATION_CODE =
+  "Código inválido ou expirado. Volte e solicite um novo código.";
+
+export const USER_FACING_GENERIC =
+  "Algo deu errado. Tente de novo em instantes.";
+
+export const USER_FACING_ORDER_CANCELLED =
+  "Este pedido foi cancelado. Não é possível continuar o pagamento.";
+
+export class ApiClientError extends Error {
+  readonly status: number | undefined;
+  readonly code: string | undefined;
+
+  constructor(message: string, options?: { status?: number; code?: string }) {
+    super(message);
+    this.name = "ApiClientError";
+    this.status = options?.status;
+    this.code = options?.code;
+  }
+}
+
+const LISTING_STATUS_LABELS: Record<string, string> = {
+  ACTIVE: "Disponível",
+  RESERVED: "Reservado",
+  SOLD: "Vendido",
+  CANCELED: "Cancelado",
+};
+
+const ORDER_STATUS_LABELS: Record<string, string> = {
+  PENDING: "Pendente",
+  CONFIRMED: "Confirmado",
+  SHIPPED: "Enviado",
+  DELIVERED: "Entregue",
+  CANCELLED: "Cancelado",
+  CANCELED: "Cancelado",
+};
+
+const PAYMENT_STATUS_LABELS: Record<string, string> = {
+  PENDING: "Pendente",
+  PAID: "Pago",
+  REFUNDED: "Reembolsado",
+};
+
+function technicalMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "";
+}
+
+export function apiErrorStatus(error: unknown): number | undefined {
+  if (error instanceof ApiClientError && typeof error.status === "number") {
+    return error.status;
+  }
+  if (
+    error &&
+    typeof error === "object" &&
+    "status" in error &&
+    typeof (error as { status: unknown }).status === "number"
+  ) {
+    return (error as { status: number }).status;
+  }
+  return undefined;
+}
+
+export function isNetworkApiError(error: unknown): boolean {
+  if (error instanceof ApiClientError && error.code === "NETWORK") return true;
+  const status = apiErrorStatus(error);
+  if (status === 0) return true;
+  const message = technicalMessage(error);
+  if (
+    /failed to fetch|networkerror|could not reach api|load failed|network request failed|err_network|econnrefused|econnreset/i.test(
+      message,
+    )
+  ) {
+    return true;
+  }
+  return error instanceof TypeError && /fetch/i.test(message);
+}
+
+export function isUnauthorizedApiError(error: unknown): boolean {
+  const status = apiErrorStatus(error);
+  if (status === 401) return true;
+  return /unauthorized|session expired|no refresh token|token has been revoked|please log in/i.test(
+    technicalMessage(error),
+  );
+}
+
+export function isForbiddenApiError(error: unknown): boolean {
+  const status = apiErrorStatus(error);
+  if (status === 403) return true;
+  return /forbidden|not your order|acesso negado/i.test(
+    technicalMessage(error),
+  );
+}
+
+export function isNotFoundApiError(error: unknown): boolean {
+  const status = apiErrorStatus(error);
+  if (status === 404) return true;
+  return /not found|record not found/i.test(technicalMessage(error));
+}
+
+export function isRetryableReadError(error: unknown): boolean {
+  if (isNetworkApiError(error)) return true;
+  const status = apiErrorStatus(error);
+  if (status === 429) return true;
+  if (status != null && status >= 500) return true;
+  return (
+    status == null && !isForbiddenApiError(error) && !isNotFoundApiError(error)
+  );
+}
+
+function isListingConflict(error: unknown): boolean {
+  const status = apiErrorStatus(error);
+  const message = technicalMessage(error);
+  if (
+    /already reserved|not available \(status:|listing .+ is not available|no longer reserved|reservation expired/i.test(
+      message,
+    )
+  ) {
+    return true;
+  }
+  return status === 409 && /listing|reserv/i.test(message);
+}
+
+function leaksTechnicalDetail(copy: string): boolean {
+  return /localhost|127\.0\.0\.1|https?:\/\/|failed to fetch|could not reach api/i.test(
+    copy,
+  );
+}
+
+export function userFacingApiError(error: unknown): string {
+  const message = technicalMessage(error);
+  const status = apiErrorStatus(error);
+
+  let copy = USER_FACING_GENERIC;
+
+  if (isNetworkApiError(error)) {
+    copy = USER_FACING_NETWORK;
+  } else if (isListingConflict(error)) {
+    copy = USER_FACING_LISTING_CONFLICT;
+  } else if (
+    status === 409 &&
+    /email already|already registered|already exists/i.test(message)
+  ) {
+    copy = USER_FACING_EMAIL_TAKEN;
+  } else if (
+    /invalid email or password|invalid credentials|invalid password/i.test(
+      message,
+    )
+  ) {
+    copy = USER_FACING_CREDENTIALS;
+  } else if (
+    /invalid verification code|verification code expired|no pending registration|invalid or expired code/i.test(
+      message,
+    )
+  ) {
+    copy = USER_FACING_VERIFICATION_CODE;
+  } else if (/order is cancelled|order.*cancelled/i.test(message)) {
+    copy = USER_FACING_ORDER_CANCELLED;
+  } else if (isUnauthorizedApiError(error)) {
+    copy = USER_FACING_UNAUTHORIZED;
+  } else if (isForbiddenApiError(error)) {
+    copy = USER_FACING_FORBIDDEN;
+  } else if (isNotFoundApiError(error)) {
+    copy = USER_FACING_NOT_FOUND;
+  } else if (status === 409) {
+    copy = USER_FACING_CONFLICT;
+  } else if (status === 429) {
+    copy = USER_FACING_RATE_LIMIT;
+  } else if (status != null && status >= 500) {
+    copy = USER_FACING_SERVER;
+  } else if (
+    status === 400 ||
+    /invalid|validation|required|must be/i.test(message)
+  ) {
+    copy = USER_FACING_VALIDATION;
+  }
+
+  return leaksTechnicalDetail(copy) ? USER_FACING_GENERIC : copy;
+}
+
+export function logTechnicalError(error: unknown): void {
+  if (import.meta.env.DEV) {
+    console.error(error);
+  }
+}
+
+export function listingStatusLabel(status: string): string {
+  return LISTING_STATUS_LABELS[status] ?? "Indefinido";
+}
+
+export function orderStatusLabel(status: string): string {
+  return ORDER_STATUS_LABELS[status] ?? "Indefinido";
+}
+
+export function paymentStatusLabel(status: string): string {
+  return PAYMENT_STATUS_LABELS[status] ?? "Indefinido";
+}

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -6,6 +6,7 @@ import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
 import {
   Table,
   TableBody,
@@ -94,11 +95,7 @@ export default function AdminDashboard() {
     return (
       <ErrorState
         title="Erro ao carregar o painel"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button
             type="button"
@@ -311,10 +308,14 @@ function RecentOrdersTable({ orders }: { orders: Order[] }) {
                 {new Date(order.createdAt).toLocaleDateString("pt-BR")}
               </TableCell>
               <TableCell>
-                <Badge variant="outline">{order.paymentStatus}</Badge>
+                <Badge variant="outline">
+                  {paymentStatusLabel(order.paymentStatus)}
+                </Badge>
               </TableCell>
               <TableCell>
-                <Badge variant="secondary">{order.status}</Badge>
+                <Badge variant="secondary">
+                  {orderStatusLabel(order.status)}
+                </Badge>
               </TableCell>
             </TableRow>
           ))}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -21,6 +21,10 @@ import {
 } from "@/lib/orderPaymentView";
 import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
 import { redirectToExternal } from "@/lib/redirect";
+import {
+  logTechnicalError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
 import type { Order } from "@/types/api";
 
 export default function Checkout() {
@@ -130,7 +134,8 @@ export default function Checkout() {
         navigate(`/orders/${createdOrderId}`);
         return;
       }
-      setError(e instanceof Error ? e.message : "Falha ao criar pedido");
+      logTechnicalError(e);
+      setError(userFacingApiError(e));
     } finally {
       inFlightRef.current = false;
       if (!leftCheckout) setLoading(false);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -40,11 +40,7 @@ export default function IndexPage() {
       {isError ? (
         <ErrorState
           title="Erro ao carregar listings"
-          description={
-            error instanceof Error
-              ? error.message
-              : "Tente novamente em instantes."
-          }
+          error={error}
           action={
             <Button type="button" variant="outline" onClick={() => refetch()}>
               Tentar novamente

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -8,6 +8,11 @@ import { getPriceHistory } from "@/api/price-history";
 import { useCart } from "@/contexts/CartContext";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  isNotFoundApiError,
+  isRetryableReadError,
+  listingStatusLabel,
+} from "@/lib/userFacingApiError";
 
 export default function ListingDetail() {
   const { id } = useParams<{ id: string }>();
@@ -74,20 +79,26 @@ export default function ListingDetail() {
   }
 
   if (isError || !listing) {
+    const missing = isNotFoundApiError(error);
+    const canRetry = isRetryableReadError(error);
     return (
       <div className="container py-10">
         <ErrorState
-          title="Listing não encontrado"
-          description={
-            error instanceof Error
-              ? error.message
-              : "Este item não está disponível."
+          title={
+            missing ? "Listing não encontrado" : "Erro ao carregar listing"
           }
+          error={error}
           action={
             <div className="flex justify-center gap-2">
-              <Button type="button" variant="outline" onClick={() => refetch()}>
-                Tentar novamente
-              </Button>
+              {canRetry ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => refetch()}
+                >
+                  Tentar novamente
+                </Button>
+              ) : null}
               <Button asChild>
                 <Link to="/products">Voltar ao Market</Link>
               </Button>
@@ -193,8 +204,7 @@ export default function ListingDetail() {
               </span>
             </div>
             <p className="text-sm text-muted-foreground">
-              Status:{" "}
-              {listing.status === "ACTIVE" ? "Disponível" : listing.status}
+              Status: {listingStatusLabel(listing.status)}
             </p>
             {latestHistory ? (
               <p className="text-sm text-muted-foreground">

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -22,6 +22,12 @@ import {
 } from "@/lib/orderPaymentView";
 import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
 import { redirectToExternal } from "@/lib/redirect";
+import {
+  logTechnicalError,
+  orderStatusLabel,
+  paymentStatusLabel,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
 import type { Order } from "@/types/api";
 
 function OrderHeadline({
@@ -145,12 +151,11 @@ export default function OrderStatusPage() {
           title={
             accessError ? "Pedido não encontrado" : "Erro ao carregar o pedido"
           }
+          error={error}
           description={
             accessError
               ? "Este pedido não existe ou não pertence à sua conta."
-              : error instanceof Error
-                ? error.message
-                : "Falha de rede. Tente novamente."
+              : undefined
           }
           action={
             accessError ? (
@@ -195,11 +200,8 @@ export default function OrderStatusPage() {
         "Não foi possível obter o link do PayPal. O pedido existente não foi marcado como pago.",
       );
     } catch (e) {
-      setRetryError(
-        e instanceof Error
-          ? e.message
-          : "Não foi possível reutilizar este pedido para um novo pagamento.",
-      );
+      logTechnicalError(e);
+      setRetryError(userFacingApiError(e));
     } finally {
       setRetrying(false);
     }
@@ -216,9 +218,11 @@ export default function OrderStatusPage() {
 
       <section className="space-y-4 rounded-md border border-border bg-card p-4">
         <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="secondary">Pedido {order.status}</Badge>
+          <Badge variant="secondary">
+            Pedido {orderStatusLabel(order.status)}
+          </Badge>
           <Badge variant={paid ? "default" : "outline"}>
-            Pagamento {order.paymentStatus}
+            Pagamento {paymentStatusLabel(order.paymentStatus)}
           </Badge>
         </div>
 

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -220,11 +220,7 @@ export default function Products() {
       {isError && (
         <ErrorState
           title="Erro ao carregar listings"
-          description={
-            error instanceof Error
-              ? error.message
-              : "Tente novamente em instantes."
-          }
+          error={error}
           action={
             <Button type="button" variant="outline" onClick={() => refetch()}>
               Tentar novamente

--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -8,6 +8,7 @@ import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { orderStatusLabel } from "@/lib/userFacingApiError";
 import type { Order } from "@/types/api";
 
 function orderTotal(order: Order): number {
@@ -86,11 +87,7 @@ export default function SellerDashboard() {
     return (
       <ErrorState
         title="Erro ao carregar o painel"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button
             type="button"
@@ -182,7 +179,7 @@ export default function SellerDashboard() {
                     ${orderTotal(order).toFixed(2)}
                   </p>
                   <Badge variant="secondary" className="mt-1">
-                    {order.status}
+                    {orderStatusLabel(order.status)}
                   </Badge>
                 </div>
               </li>

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Checkout from "../Checkout";
 import type { Listing, Order, User } from "@/types/api";
 import { PRE_ORDER_HOLD_COPY } from "@/lib/orderPaymentView";
+import { USER_FACING_NETWORK } from "@/lib/userFacingApiError";
 
 const createOrder = vi.fn();
 const createPaymentLink = vi.fn();
@@ -311,7 +312,7 @@ describe("Checkout", () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
     asCustomer();
-    createOrder.mockRejectedValue(new Error("Falha de rede"));
+    createOrder.mockRejectedValue(new Error("Failed to fetch"));
 
     renderCheckout();
     await waitForPayable();
@@ -321,14 +322,14 @@ describe("Checkout", () => {
     expect(cartState.removeItems).not.toHaveBeenCalled();
     expect(cartState.clearCart).not.toHaveBeenCalled();
     expect(createPaymentLink).not.toHaveBeenCalled();
-    expect(screen.getByText("Falha de rede")).toBeTruthy();
+    expect(screen.getByText(USER_FACING_NETWORK)).toBeTruthy();
   });
 
   it("sends a non-empty Idempotency-Key of at most 128 characters", async () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
     asCustomer();
-    createOrder.mockRejectedValue(new Error("Falha de rede"));
+    createOrder.mockRejectedValue(new Error("Failed to fetch"));
 
     renderCheckout();
     await waitForPayable();
@@ -346,14 +347,14 @@ describe("Checkout", () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;
     asCustomer();
-    createOrder.mockRejectedValue(new Error("Falha de rede"));
+    createOrder.mockRejectedValue(new Error("Failed to fetch"));
 
     renderCheckout();
     await waitForPayable();
     fireEvent.click(screen.getByRole("button", { name: /Pagar com PayPal/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("Falha de rede")).toBeTruthy();
+      expect(screen.getByText(USER_FACING_NETWORK)).toBeTruthy();
       expect(
         screen.getByRole("button", { name: "Tentar novamente" }),
       ).toBeTruthy();
@@ -372,7 +373,7 @@ describe("Checkout", () => {
     cartState.items = [{ listing: listing(100, "listing-ak") }];
     cartState.totalPrice = 100;
     asCustomer();
-    createOrder.mockRejectedValue(new Error("Falha de rede"));
+    createOrder.mockRejectedValue(new Error("Failed to fetch"));
 
     const view = renderCheckout(0);
     await waitForPayable();

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ListingDetail from "../ListingDetail";
 import type { Listing, PriceHistory } from "@/types/api";
+import { USER_FACING_NOT_FOUND } from "@/lib/userFacingApiError";
 
 const getListing = vi.fn();
 const listListings = vi.fn();
@@ -153,7 +154,7 @@ describe("ListingDetail", () => {
     expect(addButton).toHaveProperty("disabled", true);
     addButton.click();
     expect(addItem).not.toHaveBeenCalled();
-    expect(screen.getByText("Status: SOLD")).toBeTruthy();
+    expect(screen.getByText("Status: Vendido")).toBeTruthy();
   });
 
   it("disables purchase while a future trade lock is active", async () => {
@@ -175,7 +176,12 @@ describe("ListingDetail", () => {
     renderDetail("missing");
 
     expect(await screen.findByText("Listing não encontrado")).toBeTruthy();
-    expect(screen.getByText("Listing not found")).toBeTruthy();
+    expect(screen.getByText(USER_FACING_NOT_FOUND)).toBeTruthy();
+    expect(screen.queryByText("Listing not found")).toBeNull();
+    expect(screen.queryByText(/localhost/i)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Tentar novamente" }),
+    ).toBeNull();
     expect(screen.getByText("Voltar ao Market")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Adicionar ao Carrinho" }),

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -8,6 +8,10 @@ import {
   EXPIRED_HOLD_COPY,
   VERIFYING_RESERVATION_COPY,
 } from "@/lib/orderPaymentView";
+import {
+  USER_FACING_NETWORK,
+  USER_FACING_ORDER_CANCELLED,
+} from "@/lib/userFacingApiError";
 
 const getOrder = vi.fn();
 const createPaymentLink = vi.fn();
@@ -109,8 +113,8 @@ describe("OrderStatusPage", () => {
     ).toBeTruthy();
     expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
     expect(screen.getAllByText("$105.00").length).toBeGreaterThan(0);
-    expect(screen.getByText("Pedido PENDING")).toBeTruthy();
-    expect(screen.getByText("Pagamento PENDING")).toBeTruthy();
+    expect(screen.getByText("Pedido Pendente")).toBeTruthy();
+    expect(screen.getByText("Pagamento Pendente")).toBeTruthy();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
     expect(screen.getByText(/confirmação real vem do PayPal/i)).toBeTruthy();
     expect(screen.getAllByText(/Reservado para você/).length).toBeGreaterThan(
@@ -128,7 +132,7 @@ describe("OrderStatusPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Pagamento confirmado." }),
     ).toBeTruthy();
-    expect(screen.getByText("Pagamento PAID")).toBeTruthy();
+    expect(screen.getByText("Pagamento Pago")).toBeTruthy();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Pagar novamente" }),
@@ -149,7 +153,7 @@ describe("OrderStatusPage", () => {
     );
     expect(screen.getByText(/\d{2}:\d{2}/)).toBeTruthy();
     expect(screen.queryByText("15:00")).toBeNull();
-    expect(screen.getByText("Pedido PENDING")).toBeTruthy();
+    expect(screen.getByText("Pedido Pendente")).toBeTruthy();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Pagar novamente" }),
@@ -170,11 +174,17 @@ describe("OrderStatusPage", () => {
   });
 
   it("offers a network retry that does not invent a paid state", async () => {
-    getOrder.mockRejectedValue(new Error("Falha de rede"));
+    getOrder.mockRejectedValue(
+      new Error(
+        "Could not reach API at http://localhost:3001/orders: Failed to fetch",
+      ),
+    );
     renderPage("/orders/order-1/return");
 
     expect(await screen.findByText("Erro ao carregar o pedido")).toBeTruthy();
-    expect(screen.getByText("Falha de rede")).toBeTruthy();
+    expect(screen.getByText(USER_FACING_NETWORK)).toBeTruthy();
+    expect(screen.queryByText(/localhost/i)).toBeNull();
+    expect(screen.queryByText(/Failed to fetch/i)).toBeNull();
     expect(screen.queryByText(/15:00/)).toBeNull();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     getOrder.mockResolvedValue(pendingOrder());
@@ -296,7 +306,7 @@ describe("OrderStatusPage", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Pagar novamente" }),
     );
-    expect(await screen.findByText("Order is cancelled")).toBeTruthy();
+    expect(await screen.findByText(USER_FACING_ORDER_CANCELLED)).toBeTruthy();
     expect(createOrder).not.toHaveBeenCalled();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
   });

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -4,6 +4,7 @@ import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
 import {
   Table,
   TableBody,
@@ -42,11 +43,7 @@ export default function AdminOrders() {
     return (
       <ErrorState
         title="Erro ao carregar os pedidos"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button
             type="button"
@@ -94,10 +91,14 @@ export default function AdminOrders() {
                     {new Date(order.createdAt).toLocaleDateString("pt-BR")}
                   </TableCell>
                   <TableCell>
-                    <Badge variant="outline">{order.paymentStatus}</Badge>
+                    <Badge variant="outline">
+                      {paymentStatusLabel(order.paymentStatus)}
+                    </Badge>
                   </TableCell>
                   <TableCell>
-                    <Badge variant="secondary">{order.status}</Badge>
+                    <Badge variant="secondary">
+                      {orderStatusLabel(order.status)}
+                    </Badge>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/pages/admin/AdminSellers.tsx
+++ b/src/pages/admin/AdminSellers.tsx
@@ -68,11 +68,7 @@ export default function AdminSellers() {
     return (
       <ErrorState
         title="Erro ao carregar os vendedores"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button
             type="button"

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -38,11 +38,7 @@ export default function AdminUsers() {
     return (
       <ErrorState
         title="Erro ao carregar os usuários"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button
             type="button"

--- a/src/pages/admin/__tests__/AdminOrders.test.tsx
+++ b/src/pages/admin/__tests__/AdminOrders.test.tsx
@@ -48,7 +48,7 @@ describe("AdminOrders", () => {
     expect(await screen.findByText("Pedidos")).toBeTruthy();
     expect(screen.getByText("#order-ab")).toBeTruthy();
     expect(screen.getByText("$18.50")).toBeTruthy();
-    expect(screen.getByText("PAID")).toBeTruthy();
+    expect(screen.getByText("Pago")).toBeTruthy();
     expect(listAdminOrders).toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Aprovar" })).toBeNull();
   });

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -51,6 +51,11 @@ import { EmptyState, ErrorState } from "@/components/page-state";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import {
+  listingStatusLabel,
+  logTechnicalError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -94,7 +99,8 @@ export default function SellerListings() {
       setSeller(s);
       return s.id;
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Erro ao carregar vendedor");
+      logTechnicalError(e);
+      setError(userFacingApiError(e));
       return null;
     }
   };
@@ -105,7 +111,8 @@ export default function SellerListings() {
       setListings(res.items);
       setTotal(res.total);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Erro ao carregar listings");
+      logTechnicalError(e);
+      setError(userFacingApiError(e));
     } finally {
       setLoading(false);
     }
@@ -215,9 +222,10 @@ export default function SellerListings() {
       setFormOpen(false);
       await loadListings();
     } catch (e) {
+      logTechnicalError(e);
       toast({
         title: editingListing ? "Erro ao atualizar" : "Erro ao criar",
-        description: e instanceof Error ? e.message : undefined,
+        description: userFacingApiError(e),
         variant: "destructive",
       });
     } finally {
@@ -239,9 +247,10 @@ export default function SellerListings() {
       setPriceFormOpen(false);
       await loadListings();
     } catch (e) {
+      logTechnicalError(e);
       toast({
         title: "Erro ao atualizar preço",
-        description: e instanceof Error ? e.message : undefined,
+        description: userFacingApiError(e),
         variant: "destructive",
       });
     } finally {
@@ -257,7 +266,7 @@ export default function SellerListings() {
     } catch (e) {
       toast({
         title: "Erro ao cancelar",
-        description: e instanceof Error ? e.message : undefined,
+        description: userFacingApiError(e),
         variant: "destructive",
       });
     }
@@ -274,7 +283,7 @@ export default function SellerListings() {
     } catch (e) {
       toast({
         title: "Erro ao cancelar",
-        description: e instanceof Error ? e.message : undefined,
+        description: userFacingApiError(e),
         variant: "destructive",
       });
     } finally {
@@ -365,7 +374,7 @@ export default function SellerListings() {
                               : "bg-muted text-muted-foreground"
                         }`}
                       >
-                        {l.status}
+                        {listingStatusLabel(l.status)}
                       </span>
                     </TableCell>
                     <TableCell className="text-right">

--- a/src/pages/seller/SellerOrders.tsx
+++ b/src/pages/seller/SellerOrders.tsx
@@ -6,6 +6,7 @@ import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { orderStatusLabel } from "@/lib/userFacingApiError";
 import type { Order } from "@/types/api";
 
 function orderTotal(order: Order): number {
@@ -53,11 +54,7 @@ export default function SellerOrdersPage() {
     return (
       <ErrorState
         title="Erro ao carregar pedidos"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button type="button" variant="outline" onClick={() => refetch()}>
             Tentar novamente
@@ -107,7 +104,9 @@ export default function SellerOrdersPage() {
                     {extra}
                   </p>
                   <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <Badge variant="secondary">{order.status}</Badge>
+                    <Badge variant="secondary">
+                      {orderStatusLabel(order.status)}
+                    </Badge>
                     {order.createdAt ? (
                       <span className="text-xs text-muted-foreground">
                         {new Date(order.createdAt).toLocaleDateString()}

--- a/src/pages/seller/SellerProducts.tsx
+++ b/src/pages/seller/SellerProducts.tsx
@@ -48,11 +48,7 @@ export default function SellerProductsPage() {
     return (
       <ErrorState
         title="Erro ao carregar o catálogo"
-        description={
-          error instanceof Error
-            ? error.message
-            : "Tente novamente em instantes."
-        }
+        error={error}
         action={
           <Button type="button" variant="outline" onClick={() => refetch()}>
             Tentar novamente


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Um mapper no cliente traduz erros e status da API para português. O DOM visível não mostra `localhost`, `Failed to fetch` nem a URL de `API_BASE`; o detalhe técnico fica no `Error` e em log de DEV.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/88

## O que muda

- `userFacingApiError()`: rede, 401, 403, 404, 409, 429, 5xx, validação.
- Labels PT de listing/order/payment (`Disponível`, `Vendido`, `Pago`, …).
- `ErrorState` e superfícies Home, Market, Listing, Auth, Seller, Admin, Cart/Checkout.
- 409 de listing: “Este item acabou de ser reservado por outro comprador.”
- Rede: “Não foi possível conectar. Verifique sua conexão e tente de novo.”

## Critérios de aceite

- [x] Storefront não renderiza `localhost` / `Failed to fetch` / URL da API no DOM
- [x] Status de listing visível em português
- [x] Mapper coberto por teste unitário
- [x] `Error.message` técnico preservado para debug

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → pass
- `npm test` → 33 files, 177 tests passed

## Riscos

- Mensagens inglesas desconhecidas do backend viram copy genérica em PT, não tradução 1:1.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

