### PR TITLE
#143 — P1 — Tornar o seed de demo idempotente no Seller.balance

### DIFF
--- a/docs/adr/0011-seller-ledger.md
+++ b/docs/adr/0011-seller-ledger.md
@@ -28,5 +28,5 @@ Drop the two CHECK constraints. Unique `(sellerId, orderId)` and the confirm-pat
 ## Consequences
 
 - Duplicate payment confirmation remains a no-op after the order claim (`paymentStatus = PENDING AND status = PENDING`); the unique constraint is defense in depth.
-- Demo seed sets `Seller.balance` to `"0.00"` with no `SellerTransaction` rows so the projection matches an empty PAID `SUM(netAmount)`. Non-zero credits are written only by `confirmPayment`. `GET /commissions/balance` returns the Decimal projection without `Number()`. Periodic SUM-vs-projection reconciliation remains #45.
+- Demo seed sets `Seller.balance` to `"0.00"` with no `SellerTransaction` rows so the projection matches an empty PAID `SUM(netAmount)`. Re-seed on an existing demo seller writes catalog `"0.00"` only when there are no PAID ledger rows; if PAID rows exist, the projection is set to that SUM so credited net is not wiped. Non-zero production credits are written only by `confirmPayment`. `GET /commissions/balance` returns the Decimal projection without `Number()`. Periodic SUM-vs-projection reconciliation remains #45.
 - Capture after reservation expiry still creates no ledger row (ADR 0002).

--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -91,7 +91,7 @@ Rules:
 3. Confirmation writes `status = PAID`. `REFUNDED` is not an application path.
 4. `Seller.balance` is a materialized projection of PAID net amounts, updated in the same local database transaction as the ledger insert. If they disagree, the ledger wins.
 5. Duplicate confirm, webhook replay, and concurrent confirmation must not insert a second row or double-credit the projection.
-6. `GET /commissions/balance` exposes that projection as Prisma Decimal JSON (string), not a JavaScript `number`. Demo seed writes `"0.00"` with no ledger rows so display data cannot diverge from an empty SUM.
+6. `GET /commissions/balance` exposes that projection as Prisma Decimal JSON (string), not a JavaScript `number`. Demo seed writes `"0.00"` with no ledger rows so display data cannot diverge from an empty SUM. Re-seed zeros a stale catalog projection only when that seller has no PAID rows; existing PAID net is aligned to `SUM(netAmount)`, not wiped.
 
 ## Authorization
 

--- a/docs/domain/invariants.md
+++ b/docs/domain/invariants.md
@@ -132,7 +132,7 @@ Related IDs below keep this catalog aligned with the architecture narrative. Cit
 - Schema: unique `(sellerId, orderId)`; CHECK net identity and non-negative amounts. `Seller.balance` documented as projection (ADR 0011).
 - Service: `confirmPayment` claim (`paymentStatus = PENDING AND status = PENDING`) plus ledger insert. Duplicate claims are no-ops.
 - HTTP: `GET /commissions/balance` returns the Prisma Decimal projection (JSON string via Decimal#toJSON). No `Number()`.
-- Seed: demo `Seller.balance` is `"0.00"` with no ledger rows so the projection matches empty PAID SUM. Confirm remains the only non-zero writer.
+- Seed: demo `Seller.balance` is `"0.00"` with no ledger rows so the projection matches empty PAID SUM. Re-seed writes that catalog zero only when the seller has no PAID ledger rows; if PAID rows exist, seed sets the projection to `SUM(netAmount)` and does not wipe credited net. Confirm remains the only production non-zero writer.
 - Tests: `seller.ledger.integration.test.ts` (sequential and concurrent confirm, net identity, Decimal vs float); `reservation.lifecycle.integration.test.ts`; `paypal.webhook.integration.test.ts`; `commissions.service.test.ts`; `demoCatalog.test.ts`; `seed.ledger.integration.test.ts`.
 
 **Related:** `INV-SELLER-COMMISSION-DECIMAL`, `INV-SELLER-TXN-UNIQUE`. Issue #45 (not implemented) can reconcile projection vs `SUM(netAmount) WHERE status = 'PAID'`.

--- a/server/src/__tests__/seed.ledger.integration.test.ts
+++ b/server/src/__tests__/seed.ledger.integration.test.ts
@@ -6,7 +6,7 @@ import { commissionsService } from "../modules/commissions/commissions.service.j
 import { paymentsService } from "../modules/payments/payments.service.js";
 import { seedDemoData } from "../scripts/seedDemoData.js";
 import { DEMO_USERS } from "../scripts/demoCatalog.js";
-import { createCheckoutGraph, createOrder, orderKey } from "./helpers/index.js";
+import { createCheckoutGraph, createListing, createOrder, orderKey } from "./helpers/index.js";
 
 describe(`${DomainInvariant.SELLER_LEDGER_SOURCE} demo seed and GET balance`, () => {
   it("seeds seller balances that match PAID ledger SUM(netAmount)", async () => {
@@ -29,6 +29,79 @@ describe(`${DomainInvariant.SELLER_LEDGER_SOURCE} demo seed and GET balance`, ()
 
     const ledgerRows = await prisma.sellerTransaction.count();
     expect(ledgerRows).toBe(0);
+  });
+
+  it("re-seed zeros stale catalog balances when the PAID ledger is empty", async () => {
+    await seedDemoData();
+
+    const staleByEmail: Record<string, string> = {
+      "seller@skinmarket.gg": "1250.75",
+      "pro_trader@skinmarket.gg": "580.00",
+      "rustking@skinmarket.gg": "210.40",
+    };
+
+    for (const [email, stale] of Object.entries(staleByEmail)) {
+      const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+      await prisma.seller.update({
+        where: { userId: user.id },
+        data: { balance: new Prisma.Decimal(stale) },
+      });
+    }
+
+    await seedDemoData();
+
+    for (const email of Object.keys(staleByEmail)) {
+      const user = await prisma.user.findUniqueOrThrow({ where: { email } });
+      const seller = await prisma.seller.findUniqueOrThrow({ where: { userId: user.id } });
+      const paid = await prisma.sellerTransaction.count({
+        where: { sellerId: seller.id, status: "PAID" },
+      });
+      expect(paid).toBe(0);
+      expect(seller.balance.equals(new Prisma.Decimal("0.00"))).toBe(true);
+    }
+  });
+
+  it("re-seed does not wipe PAID ledger net already credited by confirm", async () => {
+    await seedDemoData();
+
+    const sellerUser = await prisma.user.findUniqueOrThrow({
+      where: { email: "seller@skinmarket.gg" },
+    });
+    const seller = await prisma.seller.findUniqueOrThrow({ where: { userId: sellerUser.id } });
+    const buyer = await prisma.user.findUniqueOrThrow({ where: { email: "buyer@skinmarket.gg" } });
+    const product = await prisma.product.findFirstOrThrow();
+    const listing = await createListing({
+      productId: product.id,
+      sellerId: seller.id,
+      price: "100.00",
+    });
+    const created = await createOrder(buyer.id, [listing.id], orderKey("seed-paid-ledger"));
+    await paymentsService.confirmPayment(created.id);
+
+    const credited = await prisma.sellerTransaction.aggregate({
+      where: { sellerId: seller.id, status: "PAID" },
+      _sum: { netAmount: true },
+    });
+    expect(credited._sum.netAmount?.equals(new Prisma.Decimal("90"))).toBe(true);
+
+    await prisma.seller.update({
+      where: { id: seller.id },
+      data: { balance: new Prisma.Decimal("1250.75") },
+    });
+
+    await seedDemoData();
+
+    const after = await prisma.seller.findUniqueOrThrow({ where: { id: seller.id } });
+    const orders = await prisma.order.count({ where: { id: created.id } });
+    const txns = await prisma.sellerTransaction.count({
+      where: { sellerId: seller.id, status: "PAID" },
+    });
+
+    expect(after.balance.equals(credited._sum.netAmount!)).toBe(true);
+    expect(after.balance.equals(new Prisma.Decimal("0.00"))).toBe(false);
+    expect(after.balance.equals(new Prisma.Decimal("1250.75"))).toBe(false);
+    expect(orders).toBe(1);
+    expect(txns).toBe(1);
   });
 
   it("GET balance JSON is a Decimal string equal to the PAID ledger net", async () => {

--- a/server/src/scripts/__tests__/seedDemoSellerBalance.test.ts
+++ b/server/src/scripts/__tests__/seedDemoSellerBalance.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import { projectedDemoSellerBalance } from "../seedDemoData.js";
+
+describe("projectedDemoSellerBalance", () => {
+  it("uses catalog zero when the seller has no PAID ledger rows", () => {
+    const balance = projectedDemoSellerBalance("0.00", null);
+
+    expect(balance).toBeInstanceOf(Prisma.Decimal);
+    expect(balance.equals(new Prisma.Decimal("0.00"))).toBe(true);
+    expect(typeof balance).not.toBe("number");
+  });
+
+  it("keeps SUM(PAID netAmount) so re-seed does not wipe credited net", () => {
+    const credited = new Prisma.Decimal("90.00");
+    const balance = projectedDemoSellerBalance("0.00", credited);
+
+    expect(balance.equals(credited)).toBe(true);
+    expect(balance.isZero()).toBe(false);
+  });
+});

--- a/server/src/scripts/seedDemoData.ts
+++ b/server/src/scripts/seedDemoData.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import type { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import { prisma } from "../shared/database/index.js";
 import { hashPassword } from "../shared/utils/hash.js";
 import { logger } from "../shared/logger.js";
@@ -14,6 +14,7 @@ import {
   listingPrice,
   type DemoListing,
   type DemoProduct,
+  type DemoSellerProfile,
 } from "./demoCatalog.js";
 
 export type SeedSummary = {
@@ -25,6 +26,62 @@ export type SeedSummary = {
 };
 
 const RESERVATION_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Demo re-seed of `Seller.balance` (INV-SELLER-LEDGER-SOURCE).
+ *
+ * Empty PAID ledger → catalog `"0.00"` so a stale pre-#140 projection
+ * (1250.75 / 580.00 / 210.40) cannot survive `update: {}`.
+ * Existing PAID rows → SUM(netAmount); seed does not wipe confirm credits
+ * and is not a second production writer.
+ */
+export function projectedDemoSellerBalance(
+  catalogBalance: string,
+  paidLedgerNet: Prisma.Decimal | null
+): Prisma.Decimal {
+  if (paidLedgerNet === null) {
+    return new Prisma.Decimal(catalogBalance);
+  }
+  return paidLedgerNet;
+}
+
+async function upsertDemoSeller(
+  client: PrismaClient,
+  userId: string,
+  profile: DemoSellerProfile
+) {
+  return client.$transaction(async (tx) => {
+    const existing = await tx.seller.findUnique({ where: { userId } });
+
+    if (!existing) {
+      return tx.seller.create({
+        data: {
+          userId,
+          storeName: profile.storeName,
+          commissionRate: profile.commissionRate,
+          balance: profile.balance,
+          isApproved: profile.isApproved,
+        },
+      });
+    }
+
+    // Hold the projection row so confirmPayment's increment cannot land
+    // between the PAID SUM read and this write.
+    await tx.$queryRaw`SELECT 1 FROM "Seller" WHERE id = ${existing.id} FOR UPDATE`;
+
+    const paid = await tx.sellerTransaction.aggregate({
+      where: { sellerId: existing.id, status: "PAID" },
+      _sum: { netAmount: true },
+    });
+
+    return tx.seller.update({
+      where: { id: existing.id },
+      data: {
+        balance: projectedDemoSellerBalance(profile.balance, paid._sum.netAmount),
+      },
+    });
+  });
+}
 
 function listingCreateData(
   listing: DemoListing,
@@ -84,19 +141,7 @@ export async function seedDemoData(client: PrismaClient = prisma): Promise<SeedS
     userIds.set(account.email, user.id);
 
     if (account.seller) {
-      const seller = await client.seller.upsert({
-        where: { userId: user.id },
-        update: {},
-        create: {
-          userId: user.id,
-          storeName: account.seller.storeName,
-          commissionRate: account.seller.commissionRate,
-          // Zero projection: no SellerTransaction rows are seeded. confirmPayment
-          // is the only writer of non-zero Seller.balance (ADR 0011 / #140).
-          balance: account.seller.balance,
-          isApproved: account.seller.isApproved,
-        },
-      });
+      const seller = await upsertDemoSeller(client, user.id, account.seller);
       sellerIds.set(account.email, seller.id);
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Re-seed de demo deixa de preservar `Seller.balance` órfão. `seller.upsert` no update alinha a projeção ao catálogo (`"0.00"`) quando não há ledger PAID; se houver lançamentos PAID, grava `SUM(netAmount)` em vez de zerar crédito real.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/143

## O que muda

- `update: {}` no upsert de seller demo foi removido.
- Create continua com `"0.00"`.
- Update: `FOR UPDATE` + soma PAID; zero só se o ledger estiver vazio.
- Sem job de reconciliação (#45). Pedidos/pagamentos não são apagados.

## Verificação

- `cd server && npm run typecheck` → pass
- unit seed/catalog → 6 passed
- seed ledger integration → 4 passed
- `cd server && npm run test:integration` → 77 passed

## Riscos

- Seed não toca sellers fora do catálogo demo.
- Reconciliação periódica continua sendo #45.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

