### PR TITLE
#89 — [UX] Exibir motivo visível quando Adicionar ao Carrinho estiver desabilitado ou o add for ignorado

### DIFF
--- a/src/components/ListingCartCta.tsx
+++ b/src/components/ListingCartCta.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { ShoppingCart } from "lucide-react";
+import type { Listing } from "@/types/api";
+import { useCart } from "@/contexts/CartContext";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import {
+  CART_ADDED_MESSAGE,
+  CART_CTA_ADD,
+  CART_CTA_SIMILAR,
+  CART_CTA_VIEW_CART,
+  resolveListingCartCta,
+} from "@/lib/listingCartCta";
+import { cn } from "@/lib/utils";
+
+export function ListingCartCta({
+  listing,
+  variant,
+}: {
+  listing: Listing;
+  variant: "detail" | "card";
+}) {
+  const { addItem, items } = useCart();
+  const { toast } = useToast();
+  const [liveMessage, setLiveMessage] = useState("");
+  const inCart = items.some((item) => item.listing.id === listing.id);
+  const cta = resolveListingCartCta(listing, inCart);
+
+  const onAdd = () => {
+    const result = addItem(listing);
+    if (result === "added") {
+      setLiveMessage(CART_ADDED_MESSAGE);
+      toast({ title: CART_ADDED_MESSAGE });
+    }
+  };
+
+  const liveRegion = (
+    <p className="sr-only" aria-live="polite" aria-atomic="true">
+      {liveMessage}
+    </p>
+  );
+
+  if (cta.kind === "available") {
+    if (variant === "detail") {
+      return (
+        <div className="flex w-full gap-3">
+          {liveRegion}
+          <Button className="flex-1" size="lg" onClick={onAdd}>
+            <ShoppingCart className="mr-2 h-5 w-5" /> {CART_CTA_ADD}
+          </Button>
+          <Button variant="outline" size="lg" asChild>
+            <Link to="/cart">Ver Carrinho</Link>
+          </Button>
+        </div>
+      );
+    }
+    return (
+      <>
+        {liveRegion}
+        <Button
+          size="icon"
+          variant="outline"
+          onClick={(event) => {
+            event.preventDefault();
+            onAdd();
+          }}
+          aria-label={CART_CTA_ADD}
+        >
+          <ShoppingCart className="h-4 w-4" />
+        </Button>
+      </>
+    );
+  }
+
+  const reasonClass =
+    variant === "detail"
+      ? "text-sm text-muted-foreground"
+      : "text-[11px] leading-tight text-muted-foreground";
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 gap-2",
+        variant === "detail"
+          ? "w-full flex-col sm:flex-row sm:items-center"
+          : "flex-col items-end text-right",
+      )}
+    >
+      {liveRegion}
+      {cta.reason ? <p className={reasonClass}>{cta.reason}</p> : null}
+      {cta.kind === "in-cart" ? (
+        <Button
+          variant={variant === "detail" ? "default" : "link"}
+          size={variant === "detail" ? "lg" : "sm"}
+          className={
+            variant === "card" ? "h-auto min-h-0 p-0 text-[11px]" : undefined
+          }
+          asChild
+        >
+          <Link to="/cart">{CART_CTA_VIEW_CART}</Link>
+        </Button>
+      ) : null}
+      {cta.kind === "sold" ? (
+        <Button
+          variant={variant === "detail" ? "default" : "link"}
+          size={variant === "detail" ? "lg" : "sm"}
+          className={
+            variant === "card" ? "h-auto min-h-0 p-0 text-[11px]" : undefined
+          }
+          asChild
+        >
+          <Link to="/products">{CART_CTA_SIMILAR}</Link>
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,19 +1,13 @@
 import { Link } from "react-router-dom";
-import { ShoppingCart } from "lucide-react";
 import type { Listing } from "@/types/api";
-import { useCart } from "@/contexts/CartContext";
-import { Button } from "@/components/ui/button";
+import { ListingCartCta } from "@/components/ListingCartCta";
 
 export function ListingCard({ listing }: { listing: Listing }) {
-  const { addItem } = useCart();
   const price =
     typeof listing.price === "number" ? listing.price : Number(listing.price);
   const sellerName =
     listing.seller?.user?.name ?? listing.seller?.storeName ?? "";
   const productName = `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
-  const isAvailable =
-    listing.status === "ACTIVE" &&
-    (!listing.tradeLockUntil || new Date(listing.tradeLockUntil) <= new Date());
   const monogram = listing.product.weapon.slice(0, 3).toUpperCase();
 
   return (
@@ -54,27 +48,11 @@ export function ListingCard({ listing }: { listing: Listing }) {
             Pattern: {listing.pattern}
           </span>
         )}
-        <div className="mt-auto flex items-center justify-between border-t border-border pt-2">
+        <div className="mt-auto flex items-center justify-between gap-2 border-t border-border pt-2">
           <span className="tabular-nums text-base font-semibold text-foreground">
             ${price.toFixed(2)}
           </span>
-          <Button
-            size="icon"
-            variant="outline"
-            onClick={(e) => {
-              e.preventDefault();
-              addItem(listing);
-            }}
-            disabled={!isAvailable}
-            title={
-              !isAvailable ? "Item não disponível" : "Adicionar ao carrinho"
-            }
-            aria-label={
-              !isAvailable ? "Item não disponível" : "Adicionar ao carrinho"
-            }
-          >
-            <ShoppingCart className="h-4 w-4" />
-          </Button>
+          <ListingCartCta listing={listing} variant="card" />
         </div>
       </div>
     </article>

--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -1,9 +1,22 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ListingCard } from "../ProductCard";
 import { CartProvider, useCart } from "../../contexts/CartContext";
 import type { Listing } from "@/types/api";
+import {
+  CART_ADDED_MESSAGE,
+  CART_CTA_ADD,
+  CART_CTA_IN_CART,
+  CART_CTA_SIMILAR,
+  CART_CTA_VIEW_CART,
+} from "@/lib/listingCartCta";
+
+const toast = vi.fn();
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
 
 function makeListing(overrides: Partial<Listing> = {}): Listing {
   return {
@@ -60,11 +73,14 @@ function renderCard(listing: Listing) {
 
 function addButton() {
   return screen.getByRole("button", {
-    name: /adicionar ao carrinho|item não disponível/i,
+    name: CART_CTA_ADD,
   });
 }
 
 describe("ListingCard", () => {
+  beforeEach(() => {
+    toast.mockReset();
+  });
   it("renders weapon | skin (exterior) as the display name", () => {
     renderCard(makeListing());
     expect(
@@ -135,8 +151,8 @@ describe("ListingCard", () => {
     renderCard(makeListing({ status: "ACTIVE", tradeLockUntil: null }));
     const button = addButton();
     expect(button).toBeEnabled();
-    expect(button).toHaveAttribute("title", "Adicionar ao carrinho");
-    expect(button).toHaveAttribute("aria-label", "Adicionar ao carrinho");
+    expect(button).toHaveAttribute("aria-label", CART_CTA_ADD);
+    expect(button).not.toHaveAttribute("title");
   });
 
   it("enables add-to-cart when trade lock has already expired", () => {
@@ -147,39 +163,43 @@ describe("ListingCard", () => {
       }),
     );
     expect(addButton()).toBeEnabled();
-    expect(addButton()).toHaveAttribute("title", "Adicionar ao carrinho");
+    expect(addButton()).toHaveAttribute("aria-label", CART_CTA_ADD);
   });
 
-  it("disables add-to-cart when status is SOLD", () => {
+  it("shows Vendido and similar items instead of a disabled add button when SOLD", () => {
     renderCard(makeListing({ status: "SOLD" }));
-    const button = addButton();
-    expect(button).toBeDisabled();
-    expect(button).toHaveAttribute("title", "Item não disponível");
-    expect(button).toHaveAttribute("aria-label", "Item não disponível");
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getByText("Vendido")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: CART_CTA_SIMILAR }),
+    ).toHaveAttribute("href", "/products");
+    fireEvent.click(screen.getByRole("link", { name: CART_CTA_SIMILAR }));
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
+    expect(toast).not.toHaveBeenCalled();
   });
 
-  it("disables add-to-cart when status is RESERVED", () => {
+  it("shows Reservado instead of add-to-cart when status is RESERVED", () => {
     renderCard(makeListing({ status: "RESERVED" }));
-    expect(addButton()).toBeDisabled();
-    expect(addButton()).toHaveAttribute("title", "Item não disponível");
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getByText("Reservado")).toBeInTheDocument();
   });
 
-  it("disables add-to-cart when status is CANCELED", () => {
+  it("shows Cancelado instead of add-to-cart when status is CANCELED", () => {
     renderCard(makeListing({ status: "CANCELED" }));
-    expect(addButton()).toBeDisabled();
-    expect(addButton()).toHaveAttribute("title", "Item não disponível");
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getByText("Cancelado")).toBeInTheDocument();
   });
 
-  it("disables add-to-cart when tradeLockUntil is in the future", () => {
+  it("shows a visible trade lock reason when tradeLockUntil is in the future", () => {
     const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     renderCard(makeListing({ tradeLockUntil: future }));
-    expect(addButton()).toBeDisabled();
-    expect(addButton()).toHaveAttribute("title", "Item não disponível");
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getByText(/Trade lock até/)).toBeInTheDocument();
   });
 
-  it("does not add a SOLD listing when the disabled button is activated", () => {
+  it("does not add a SOLD listing from the similar-items path", () => {
     renderCard(makeListing({ status: "SOLD" }));
-    fireEvent.click(addButton());
+    fireEvent.click(screen.getByRole("link", { name: CART_CTA_SIMILAR }));
     expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
   });
 
@@ -188,6 +208,25 @@ describe("ListingCard", () => {
     expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
     fireEvent.click(addButton());
     expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+    expect(toast).toHaveBeenCalledWith({ title: CART_ADDED_MESSAGE });
+    expect(screen.getByText(CART_ADDED_MESSAGE)).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
+  });
+
+  it("explains a second add of the same listing as already in the cart", () => {
+    renderCard(makeListing({ status: "ACTIVE" }));
+    fireEvent.click(addButton());
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getByText(CART_CTA_IN_CART)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: CART_CTA_VIEW_CART }),
+    ).toHaveAttribute("href", "/cart");
+    fireEvent.click(screen.getByRole("link", { name: CART_CTA_VIEW_CART }));
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+    expect(toast).toHaveBeenCalledTimes(1);
   });
 
   it("shows pattern when present and hides it when null", () => {
@@ -207,11 +246,10 @@ describe("ListingCard", () => {
 
   it("links both the image and the title to /listing/:id", () => {
     renderCard(makeListing({ id: "listing-abc" }));
-    const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(2);
-    for (const link of links) {
-      expect(link).toHaveAttribute("href", "/listing/listing-abc");
-    }
+    const listingLinks = screen
+      .getAllByRole("link")
+      .filter((link) => link.getAttribute("href") === "/listing/listing-abc");
+    expect(listingLinks).toHaveLength(2);
   });
 
   it("does not leak SKINMARKET or CS2 Skin Marketplace copy", () => {

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -8,6 +8,8 @@ import {
 import type { Listing } from "@/types/api";
 import { cartSnapshotNeedsUpdate } from "@/lib/cartListingStatus";
 
+export type AddItemResult = "added" | "duplicate" | "unavailable";
+
 export interface CartItem {
   listing: Listing;
   priceWhenAdded: Listing["price"];
@@ -15,7 +17,7 @@ export interface CartItem {
 
 interface CartContextType {
   items: CartItem[];
-  addItem: (listing: Listing) => void;
+  addItem: (listing: Listing) => AddItemResult;
   updateListing: (listing: Listing) => void;
   removeItem: (listingId: string) => void;
   removeItems: (listingIds: string[]) => void;
@@ -29,16 +31,19 @@ const CartContext = createContext<CartContextType | null>(null);
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([]);
 
-  const addItem = (listing: Listing) => {
-    // Check if listing is already in cart
-    if (items.some((i) => i.listing.id === listing.id)) {
-      return; // Already in cart, each listing is unique
-    }
-    // Check if listing is available
+  const addItem = (listing: Listing): AddItemResult => {
     if (listing.status !== "ACTIVE") {
-      return; // Cannot add non-active listings
+      return "unavailable";
     }
-    setItems((prev) => [...prev, { listing, priceWhenAdded: listing.price }]);
+    let result: AddItemResult = "added";
+    setItems((prev) => {
+      if (prev.some((item) => item.listing.id === listing.id)) {
+        result = "duplicate";
+        return prev;
+      }
+      return [...prev, { listing, priceWhenAdded: listing.price }];
+    });
+    return result;
   };
 
   const updateListing = useCallback((listing: Listing) => {

--- a/src/lib/__tests__/listingCartCta.test.ts
+++ b/src/lib/__tests__/listingCartCta.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  CART_CTA_IN_CART,
+  formatTradeLockUntil,
+  resolveListingCartCta,
+} from "../listingCartCta";
+
+describe("resolveListingCartCta", () => {
+  it("allows add when ACTIVE, unlocked, and not in the cart", () => {
+    expect(
+      resolveListingCartCta({ status: "ACTIVE", tradeLockUntil: null }, false),
+    ).toEqual({ kind: "available", reason: null, canAdd: true });
+  });
+
+  it("uses the shared SOLD label instead of a clickable add CTA", () => {
+    expect(
+      resolveListingCartCta({ status: "SOLD", tradeLockUntil: null }, false),
+    ).toEqual({ kind: "sold", reason: "Vendido", canAdd: false });
+  });
+
+  it("uses the shared RESERVED and CANCELED labels", () => {
+    expect(
+      resolveListingCartCta({ status: "RESERVED", tradeLockUntil: null }, false)
+        .reason,
+    ).toBe("Reservado");
+    expect(
+      resolveListingCartCta({ status: "CANCELED", tradeLockUntil: null }, false)
+        .reason,
+    ).toBe("Cancelado");
+  });
+
+  it("explains a future trade lock with a visible date", () => {
+    const lockUntil = "2026-12-01T00:00:00.000Z";
+    const view = resolveListingCartCta(
+      { status: "ACTIVE", tradeLockUntil: lockUntil },
+      false,
+      Date.parse("2026-09-05T00:00:00.000Z"),
+    );
+    expect(view.kind).toBe("trade-lock");
+    expect(view.canAdd).toBe(false);
+    expect(view.reason).toBe(
+      `Trade lock até ${formatTradeLockUntil(lockUntil)}`,
+    );
+  });
+
+  it("explains a duplicate add as already in the cart", () => {
+    expect(
+      resolveListingCartCta({ status: "ACTIVE", tradeLockUntil: null }, true),
+    ).toEqual({
+      kind: "in-cart",
+      reason: CART_CTA_IN_CART,
+      canAdd: false,
+    });
+  });
+
+  it("prefers listing status over in-cart when the item is no longer ACTIVE", () => {
+    expect(
+      resolveListingCartCta({ status: "SOLD", tradeLockUntil: null }, true)
+        .kind,
+    ).toBe("sold");
+  });
+
+  it("falls back to Indisponível for an unknown status", () => {
+    expect(
+      resolveListingCartCta(
+        { status: "UNKNOWN" as "ACTIVE", tradeLockUntil: null },
+        false,
+      ),
+    ).toEqual({ kind: "unavailable", reason: "Indisponível", canAdd: false });
+  });
+});

--- a/src/lib/listingCartCta.ts
+++ b/src/lib/listingCartCta.ts
@@ -1,0 +1,86 @@
+import type { Listing } from "@/types/api";
+import { isListingTradeLocked } from "@/lib/cartListingStatus";
+import { listingStatusLabel } from "@/lib/userFacingApiError";
+
+export const CART_CTA_ADD = "Adicionar ao Carrinho";
+export const CART_CTA_IN_CART = "No carrinho";
+export const CART_CTA_VIEW_CART = "Ver carrinho";
+export const CART_CTA_SIMILAR = "Ver itens semelhantes";
+export const CART_ADDED_MESSAGE = "Adicionado ao carrinho";
+
+export type ListingCartCtaKind =
+  | "available"
+  | "in-cart"
+  | "sold"
+  | "reserved"
+  | "canceled"
+  | "trade-lock"
+  | "unavailable";
+
+export interface ListingCartCtaView {
+  kind: ListingCartCtaKind;
+  reason: string | null;
+  canAdd: boolean;
+}
+
+function unavailableReason(status: string): string {
+  const label = listingStatusLabel(status);
+  return label === "Indefinido" ? "Indisponível" : label;
+}
+
+export function formatTradeLockUntil(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+export function resolveListingCartCta(
+  listing: Pick<Listing, "status" | "tradeLockUntil">,
+  inCart: boolean,
+  now = Date.now(),
+): ListingCartCtaView {
+  if (listing.status === "SOLD") {
+    return {
+      kind: "sold",
+      reason: listingStatusLabel("SOLD"),
+      canAdd: false,
+    };
+  }
+  if (listing.status === "RESERVED") {
+    return {
+      kind: "reserved",
+      reason: listingStatusLabel("RESERVED"),
+      canAdd: false,
+    };
+  }
+  if (listing.status === "CANCELED") {
+    return {
+      kind: "canceled",
+      reason: listingStatusLabel("CANCELED"),
+      canAdd: false,
+    };
+  }
+  if (listing.status !== "ACTIVE") {
+    return {
+      kind: "unavailable",
+      reason: unavailableReason(listing.status),
+      canAdd: false,
+    };
+  }
+  if (isListingTradeLocked(listing, now)) {
+    const until = listing.tradeLockUntil
+      ? formatTradeLockUntil(listing.tradeLockUntil)
+      : "";
+    return {
+      kind: "trade-lock",
+      reason: until ? `Trade lock até ${until}` : "Trade lock ativo",
+      canAdd: false,
+    };
+  }
+  if (inCart) {
+    return {
+      kind: "in-cart",
+      reason: CART_CTA_IN_CART,
+      canAdd: false,
+    };
+  }
+  return { kind: "available", reason: null, canAdd: true };
+}

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1,11 +1,11 @@
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, ShoppingCart } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { ListingCard } from "@/components/ProductCard";
+import { ListingCartCta } from "@/components/ListingCartCta";
 import { ErrorState } from "@/components/page-state";
 import { getListing, listListings } from "@/api/listings";
 import { getPriceHistory } from "@/api/price-history";
-import { useCart } from "@/contexts/CartContext";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -17,7 +17,6 @@ import {
 export default function ListingDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { addItem } = useCart();
 
   const {
     data: listing,
@@ -54,10 +53,6 @@ export default function ListingDetail() {
   const productName = listing
     ? `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`
     : "";
-  const isAvailable =
-    listing?.status === "ACTIVE" &&
-    (!listing.tradeLockUntil || new Date(listing.tradeLockUntil) <= new Date());
-
   if (isLoading) {
     return (
       <div className="container py-10">
@@ -211,22 +206,7 @@ export default function ListingDetail() {
                 Última alteração: ${Number(latestHistory.newPrice).toFixed(2)}
               </p>
             ) : null}
-            <div className="flex gap-3">
-              <Button
-                className="flex-1"
-                size="lg"
-                onClick={() => addItem(listing)}
-                disabled={!isAvailable}
-                title={
-                  !isAvailable ? "Item não disponível" : "Adicionar ao carrinho"
-                }
-              >
-                <ShoppingCart className="mr-2 h-5 w-5" /> Adicionar ao Carrinho
-              </Button>
-              <Button variant="outline" size="lg" asChild>
-                <Link to="/cart">Ver Carrinho</Link>
-              </Button>
-            </div>
+            <ListingCartCta listing={listing} variant="detail" />
           </div>
 
           {priceHistory && priceHistory.length > 0 ? (

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ListingDetail from "../ListingDetail";
@@ -154,7 +154,7 @@ describe("ListingDetail", () => {
     })[0];
     expect(addButton).not.toHaveProperty("disabled", true);
     expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
-    addButton.click();
+    fireEvent.click(addButton);
     expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
     expect(toast).toHaveBeenCalledWith({ title: CART_ADDED_MESSAGE });
     expect(screen.getByText(CART_ADDED_MESSAGE)).toHaveAttribute(
@@ -175,7 +175,7 @@ describe("ListingDetail", () => {
     expect(screen.getAllByText("Vendido").length).toBeGreaterThan(0);
     const similar = screen.getByRole("link", { name: CART_CTA_SIMILAR });
     expect(similar).toHaveAttribute("href", "/products");
-    similar.click();
+    fireEvent.click(similar);
     expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
     expect(toast).not.toHaveBeenCalled();
   });
@@ -196,13 +196,13 @@ describe("ListingDetail", () => {
     renderDetail();
 
     const addButton = await screen.findByRole("button", { name: CART_CTA_ADD });
-    addButton.click();
+    fireEvent.click(addButton);
     expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
     expect(screen.getByText(CART_CTA_IN_CART)).toBeTruthy();
     expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
     const viewCart = screen.getByRole("link", { name: CART_CTA_VIEW_CART });
     expect(viewCart).toHaveAttribute("href", "/cart");
-    viewCart.click();
+    fireEvent.click(viewCart);
     expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
     expect(toast).toHaveBeenCalledTimes(1);
   });

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -3,14 +3,22 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ListingDetail from "../ListingDetail";
+import { CartProvider, useCart } from "@/contexts/CartContext";
 import type { Listing, PriceHistory } from "@/types/api";
 import { USER_FACING_NOT_FOUND } from "@/lib/userFacingApiError";
+import {
+  CART_ADDED_MESSAGE,
+  CART_CTA_ADD,
+  CART_CTA_IN_CART,
+  CART_CTA_SIMILAR,
+  CART_CTA_VIEW_CART,
+} from "@/lib/listingCartCta";
 
 const getListing = vi.fn();
 const listListings = vi.fn();
 const getPriceHistory = vi.fn();
-const addItem = vi.fn();
 const reserveListing = vi.fn();
+const toast = vi.fn();
 
 vi.mock("@/api/listings", () => ({
   getListing: (...args: unknown[]) => getListing(...args),
@@ -22,8 +30,8 @@ vi.mock("@/api/price-history", () => ({
   getPriceHistory: (...args: unknown[]) => getPriceHistory(...args),
 }));
 
-vi.mock("@/contexts/CartContext", () => ({
-  useCart: () => ({ addItem }),
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
 }));
 
 function makeListing(overrides: Partial<Listing> = {}): Listing {
@@ -76,6 +84,11 @@ function history(): PriceHistory[] {
   ];
 }
 
+function CartProbe() {
+  const { totalItems } = useCart();
+  return <span data-testid="cart-count">{totalItems}</span>;
+}
+
 function renderDetail(id = "listing-1") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -83,9 +96,12 @@ function renderDetail(id = "listing-1") {
   return render(
     <QueryClientProvider client={client}>
       <MemoryRouter initialEntries={[`/listing/${id}`]}>
-        <Routes>
-          <Route path="/listing/:id" element={<ListingDetail />} />
-        </Routes>
+        <CartProvider>
+          <Routes>
+            <Route path="/listing/:id" element={<ListingDetail />} />
+          </Routes>
+          <CartProbe />
+        </CartProvider>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -96,8 +112,8 @@ describe("ListingDetail", () => {
     getListing.mockReset();
     listListings.mockReset();
     getPriceHistory.mockReset();
-    addItem.mockReset();
     reserveListing.mockReset();
+    toast.mockReset();
     listListings.mockResolvedValue({ items: [], total: 0, page: 1, limit: 4 });
     getPriceHistory.mockResolvedValue([]);
   });
@@ -133,42 +149,62 @@ describe("ListingDetail", () => {
     expect(screen.getByText("Histórico de Preços")).toBeTruthy();
     expect(screen.getByText("Outros listings desta skin")).toBeTruthy();
 
-    const addButton = screen.getByRole("button", {
-      name: "Adicionar ao Carrinho",
-    });
+    const addButton = screen.getAllByRole("button", {
+      name: CART_CTA_ADD,
+    })[0];
     expect(addButton).not.toHaveProperty("disabled", true);
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
     addButton.click();
-    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+    expect(toast).toHaveBeenCalledWith({ title: CART_ADDED_MESSAGE });
+    expect(screen.getByText(CART_ADDED_MESSAGE)).toHaveAttribute(
+      "aria-live",
+      "polite",
+    );
     expect(reserveListing).not.toHaveBeenCalled();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(screen.queryByText(/15:00/)).toBeNull();
   });
 
-  it("disables purchase when the listing is not ACTIVE", async () => {
+  it("replaces the add CTA on a SOLD listing with Vendido and similar items", async () => {
     getListing.mockResolvedValue(makeListing({ status: "SOLD" }));
     renderDetail();
 
-    const addButton = await screen.findByRole("button", {
-      name: "Adicionar ao Carrinho",
-    });
-    expect(addButton).toHaveProperty("disabled", true);
-    addButton.click();
-    expect(addItem).not.toHaveBeenCalled();
-    expect(screen.getByText("Status: Vendido")).toBeTruthy();
+    expect(await screen.findByText("Status: Vendido")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getAllByText("Vendido").length).toBeGreaterThan(0);
+    const similar = screen.getByRole("link", { name: CART_CTA_SIMILAR });
+    expect(similar).toHaveAttribute("href", "/products");
+    similar.click();
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
+    expect(toast).not.toHaveBeenCalled();
   });
 
-  it("disables purchase while a future trade lock is active", async () => {
+  it("shows a visible trade lock reason instead of a dimmed add button", async () => {
     const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
     getListing.mockResolvedValue(makeListing({ tradeLockUntil: future }));
     renderDetail();
 
-    const addButton = await screen.findByRole("button", {
-      name: "Adicionar ao Carrinho",
-    });
-    expect(addButton).toHaveProperty("disabled", true);
-    expect(screen.getByText("Trade Lock até")).toBeTruthy();
+    expect(await screen.findByText("Trade Lock até")).toBeTruthy();
+    expect(screen.getByText(/Trade lock até/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
+  });
+
+  it("explains a second add of the same listing as already in the cart", async () => {
+    getListing.mockResolvedValue(makeListing());
+    renderDetail();
+
+    const addButton = await screen.findByRole("button", { name: CART_CTA_ADD });
     addButton.click();
-    expect(addItem).not.toHaveBeenCalled();
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+    expect(screen.getByText(CART_CTA_IN_CART)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
+    const viewCart = screen.getByRole("link", { name: CART_CTA_VIEW_CART });
+    expect(viewCart).toHaveAttribute("href", "/cart");
+    viewCart.click();
+    expect(screen.getByTestId("cart-count")).toHaveTextContent("1");
+    expect(toast).toHaveBeenCalledTimes(1);
   });
 
   it("does not offer purchase when the listing is missing", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
CTA de carrinho deixa de ser um botão dimmed sem explicação. SOLD, reserva, trade lock e duplicado têm motivo visível; add válido anuncia para leitor de tela.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/89

## O que muda

- `ListingCartCta` + máquina de estados; labels reutilizam o mapper PT do #88.
- SOLD → “Vendido” + “Ver itens semelhantes”.
- Já no carrinho → “No carrinho” / “Ver carrinho”.
- Sucesso → toast “Adicionado ao carrinho” + `aria-live="polite"`.
- Trade lock → “Trade lock até {data}”, não add dimmed.
- Badge só incrementa em add real. Sem `POST /listings/:id/reserve`.

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 34 files, 186 passed

## Riscos

- “Ver itens semelhantes” aponta para `/products` (Market) sem filtro por `productId`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

