### PR TITLE
#146 — [UX] Filtrar o Market pelo productId no CTA Ver itens semelhantes

### DIFF
--- a/src/components/ListingCartCta.tsx
+++ b/src/components/ListingCartCta.tsx
@@ -11,6 +11,7 @@ import {
   CART_CTA_SIMILAR,
   CART_CTA_VIEW_CART,
   resolveListingCartCta,
+  similarItemsMarketPath,
 } from "@/lib/listingCartCta";
 import { cn } from "@/lib/utils";
 
@@ -110,7 +111,9 @@ export function ListingCartCta({
           }
           asChild
         >
-          <Link to="/products">{CART_CTA_SIMILAR}</Link>
+          <Link to={similarItemsMarketPath(listing.productId)}>
+            {CART_CTA_SIMILAR}
+          </Link>
         </Button>
       ) : null}
     </div>

--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -172,7 +172,7 @@ describe("ListingCard", () => {
     expect(screen.getByText("Vendido")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: CART_CTA_SIMILAR }),
-    ).toHaveAttribute("href", "/products");
+    ).toHaveAttribute("href", "/products?productId=prod-1");
     fireEvent.click(screen.getByRole("link", { name: CART_CTA_SIMILAR }));
     expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
     expect(toast).not.toHaveBeenCalled();

--- a/src/lib/__tests__/listingCartCta.test.ts
+++ b/src/lib/__tests__/listingCartCta.test.ts
@@ -3,6 +3,7 @@ import {
   CART_CTA_IN_CART,
   formatTradeLockUntil,
   resolveListingCartCta,
+  similarItemsMarketPath,
 } from "../listingCartCta";
 
 describe("resolveListingCartCta", () => {
@@ -67,5 +68,14 @@ describe("resolveListingCartCta", () => {
         false,
       ),
     ).toEqual({ kind: "unavailable", reason: "Indisponível", canAdd: false });
+  });
+});
+
+describe("similarItemsMarketPath", () => {
+  it("builds a Market href filtered by the listing productId", () => {
+    expect(similarItemsMarketPath("ak-redline-ft")).toBe(
+      "/products?productId=ak-redline-ft",
+    );
+    expect(similarItemsMarketPath("  ")).toBe("/products");
   });
 });

--- a/src/lib/listingCartCta.ts
+++ b/src/lib/listingCartCta.ts
@@ -7,6 +7,16 @@ export const CART_CTA_IN_CART = "No carrinho";
 export const CART_CTA_VIEW_CART = "Ver carrinho";
 export const CART_CTA_SIMILAR = "Ver itens semelhantes";
 export const CART_ADDED_MESSAGE = "Adicionado ao carrinho";
+export const MARKET_SIMILAR_EMPTY_TITLE = "Nenhum listing ativo desta skin";
+export const MARKET_SIMILAR_EMPTY_DESCRIPTION =
+  "Não há outro listing disponível desta skin no momento.";
+export const MARKET_VIEW_CTA = "Ver Market";
+
+export function similarItemsMarketPath(productId: string): string {
+  const trimmed = productId.trim();
+  if (!trimmed) return "/products";
+  return `/products?${new URLSearchParams({ productId: trimmed }).toString()}`;
+}
 
 export type ListingCartCtaKind =
   | "available"

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Filter } from "lucide-react";
 import { ListingCard } from "@/components/ProductCard";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { listListings } from "@/api/listings";
+import {
+  MARKET_SIMILAR_EMPTY_DESCRIPTION,
+  MARKET_SIMILAR_EMPTY_TITLE,
+  MARKET_VIEW_CTA,
+} from "@/lib/listingCartCta";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -51,6 +57,8 @@ function Chip({
 }
 
 export default function Products() {
+  const [searchParams] = useSearchParams();
+  const productId = searchParams.get("productId")?.trim() || undefined;
   const [exterior, setExterior] = useState("");
   const [isStattrak, setIsStattrak] = useState<boolean | undefined>(undefined);
   const [sort, setSort] = useState("");
@@ -61,13 +69,14 @@ export default function Products() {
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: [
       "listings",
-      { page, exterior, isStattrak, sort, minPrice, maxPrice },
+      { page, exterior, isStattrak, sort, minPrice, maxPrice, productId },
     ],
     queryFn: () =>
       listListings({
         page,
         limit: PAGE_SIZE,
         status: "ACTIVE",
+        ...(productId ? { productId } : {}),
         ...(exterior ? { exterior } : {}),
         ...(isStattrak !== undefined ? { isStattrak } : {}),
         ...(minPrice ? { minPrice: parseFloat(minPrice) } : {}),
@@ -99,7 +108,9 @@ export default function Products() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Market</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Listings ativos · item único
+            {productId
+              ? "Listings ativos desta skin · item único"
+              : "Listings ativos · item único"}
           </p>
         </div>
         {!isLoading && !isError ? (
@@ -229,12 +240,25 @@ export default function Products() {
         />
       )}
 
-      {!isLoading && !isError && sortedItems.length === 0 && (
-        <EmptyState
-          title="Nenhum item encontrado"
-          description="Tente ajustar os filtros"
-        />
-      )}
+      {!isLoading &&
+        !isError &&
+        sortedItems.length === 0 &&
+        (productId ? (
+          <EmptyState
+            title={MARKET_SIMILAR_EMPTY_TITLE}
+            description={MARKET_SIMILAR_EMPTY_DESCRIPTION}
+            action={
+              <Button asChild>
+                <Link to="/products">{MARKET_VIEW_CTA}</Link>
+              </Button>
+            }
+          />
+        ) : (
+          <EmptyState
+            title="Nenhum item encontrado"
+            description="Tente ajustar os filtros"
+          />
+        ))}
 
       {!isLoading && !isError && sortedItems.length > 0 && (
         <>

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -174,7 +174,10 @@ describe("ListingDetail", () => {
     expect(screen.queryByRole("button", { name: CART_CTA_ADD })).toBeNull();
     expect(screen.getAllByText("Vendido").length).toBeGreaterThan(0);
     const similar = screen.getByRole("link", { name: CART_CTA_SIMILAR });
-    expect(similar).toHaveAttribute("href", "/products");
+    expect(similar).toHaveAttribute(
+      "href",
+      "/products?productId=ak-redline-ft",
+    );
     fireEvent.click(similar);
     expect(screen.getByTestId("cart-count")).toHaveTextContent("0");
     expect(toast).not.toHaveBeenCalled();

--- a/src/pages/__tests__/Products.test.tsx
+++ b/src/pages/__tests__/Products.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import Products from "../Products";
+import { CartProvider } from "@/contexts/CartContext";
+import type { Listing } from "@/types/api";
+import {
+  MARKET_SIMILAR_EMPTY_DESCRIPTION,
+  MARKET_SIMILAR_EMPTY_TITLE,
+  MARKET_VIEW_CTA,
+} from "@/lib/listingCartCta";
+
+const listListings = vi.fn();
+
+vi.mock("@/api/listings", () => ({
+  listListings: (...args: unknown[]) => listListings(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: "listing-1",
+    productId: "ak-redline-ft",
+    sellerId: "seller-1",
+    floatValue: 0.14501234,
+    pattern: 456,
+    price: 22,
+    currency: "USD",
+    status: "ACTIVE",
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: {
+      id: "ak-redline-ft",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      collection: "The Huntsman Collection",
+      imageUrl: null,
+      isStattrak: false,
+      isSouvenir: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    seller: {
+      id: "seller-1",
+      storeName: "NeonTrader Store",
+      rating: 4.5,
+      user: { id: "user-1", name: "NeonTrader" },
+    },
+    ...overrides,
+  };
+}
+
+function renderMarket(path = "/products") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <CartProvider>
+          <Routes>
+            <Route path="/products" element={<Products />} />
+          </Routes>
+        </CartProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Products", () => {
+  beforeEach(() => {
+    listListings.mockReset();
+  });
+
+  it("lists ACTIVE listings without a productId filter by default", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket();
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+    });
+    expect(screen.queryByText(MARKET_SIMILAR_EMPTY_TITLE)).toBeNull();
+  });
+
+  it("passes productId from the query string to listListings", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing({ id: "listing-2" })],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?productId=ak-redline-ft");
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+      productId: "ak-redline-ft",
+    });
+  });
+
+  it("shows a skin-specific empty state when no ACTIVE listing matches productId", async () => {
+    listListings.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?productId=ak-redline-ft");
+
+    expect(await screen.findByText(MARKET_SIMILAR_EMPTY_TITLE)).toBeTruthy();
+    expect(screen.getByText(MARKET_SIMILAR_EMPTY_DESCRIPTION)).toBeTruthy();
+    expect(screen.getByRole("link", { name: MARKET_VIEW_CTA })).toHaveAttribute(
+      "href",
+      "/products",
+    );
+    expect(screen.queryByText("Nenhum item encontrado")).toBeNull();
+    expect(screen.queryByText("Tente ajustar os filtros")).toBeNull();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+      productId: "ak-redline-ft",
+    });
+  });
+
+  it("keeps the generic catalog empty state when productId is absent", async () => {
+    listListings.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket();
+
+    expect(await screen.findByText("Nenhum item encontrado")).toBeTruthy();
+    expect(screen.getByText("Tente ajustar os filtros")).toBeTruthy();
+    expect(screen.queryByText(MARKET_SIMILAR_EMPTY_TITLE)).toBeNull();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
O CTA “Ver itens semelhantes” de listing SOLD passa a abrir o Market filtrado por `productId`. A API `listListings({ productId })` já existia na PDP.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/146

## O que muda

- Href do CTA inclui `productId` do listing.
- `Products.tsx` lê o query e chama `listListings` com `status: ACTIVE`.
- Empty específico quando não há outro ACTIVE da mesma skin; “Ver Market” limpa o filtro.

Não implementa #107 (rails na PDP), #92 (todos os filtros na URL) nem #103 (arma/raridade).

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 35 files, 191 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

