### PR TITLE
#45 — P1 — Criar reconciliação financeira periódica

### DIFF
--- a/docs/adr/0010-audit-log.md
+++ b/docs/adr/0010-audit-log.md
@@ -20,6 +20,7 @@ The project is a modular monolith with PostgreSQL as the source of truth. Redis,
    - listing price change and cancel (`LISTING_PRICE_CHANGE`, `LISTING_CANCEL`)
    - order fulfillment status transitions (`ORDER_STATUS_CHANGE`)
    - local payment confirmation (`PAYMENT_CONFIRMED`, system actor)
+   - seller ledger projection correction (`SELLER_BALANCE_RECONCILED`, system actor; same transaction as the `Seller.balance` SET)
 5. Read access is ADMIN-only (`GET /admin/audit-logs` behind `authenticate` + `requireRole("ADMIN")`). CUSTOMER/SELLER receive 403; missing auth receives 401.
 6. Retention: **365 days**. `createdAt` is indexed. No Redis TTL worker and no new cron/SQS infrastructure. An operator may delete aged rows with a one-shot SQL statement when needed.
 7. `before`/`after` are field-level non-sensitive diffs (status, price, approval flags). The repository redacts known secret keys and JWT-shaped values as defense in depth. Full PayPal payloads, passwords, and tokens must never be stored.

--- a/docs/adr/0011-seller-ledger.md
+++ b/docs/adr/0011-seller-ledger.md
@@ -19,14 +19,28 @@ The project is a modular monolith. PostgreSQL is the source of truth. Redis, Kaf
 5. **Scale / rounding:** listing prices and PayPal capture use 2 decimal places (`toFixed(2)` at the PayPal boundary). Commission keeps exact Decimal `gross × rate` (extra fractional digits from the rate are preserved). This is the existing policy; a separate banker's-rounding step is not introduced.
 6. **Status:** `SellerTransaction.status` is `PaymentStatus` (`PENDING`, `PAID`, `REFUNDED`). Confirmation writes `PAID`. `PENDING` is the unused column default. `REFUNDED` exists for enum alignment with `Order.paymentStatus`; no application path writes it. Do not invent refunds.
 7. **Database enforcement:** keep `@@unique([sellerId, orderId])`. Add CHECK constraints `netAmount = grossAmount - commissionAmount` and non-negative amounts.
-8. **Issue #45 (not implemented here):** periodic financial reconciliation would compare `Seller.balance` to `SELECT sellerId, SUM("netAmount") FROM "SellerTransaction" WHERE status = 'PAID' GROUP BY "sellerId"` and treat ledger SUM as the correct figure. No job, cron, or product UI is added in this change.
+8. **Periodic reconciliation (issue #45):** an in-process job (same `setInterval` + `unref` pattern as PayPal GET reconcile / reservation expiry) compares each `Seller.balance` to `SUM(netAmount) WHERE status = 'PAID'`. There is no Render cron, Redis, or extra worker.
+
+## Correction strategy (issue #45)
+
+Safe correction is **projection-only**. Ledger rows are never inserted, updated, or deleted to "fix" a drift.
+
+1. Unlocked scan: load seller projections and grouped PAID SUMs. Compare with Prisma `Decimal.equals` (never JavaScript `number`).
+2. For each candidate, open a PostgreSQL transaction, `SELECT … FROM "Seller" WHERE id = $id FOR UPDATE`, re-read `balance` and PAID `SUM(netAmount)`.
+3. If they still disagree: `UPDATE Seller SET balance = $sum` (assignment to the ledger figure, not `increment`) and append `AuditLog` `SELLER_BALANCE_RECONCILED` with a system actor (`actorId`/`actorRole` null) in **that same transaction**. `before`/`after` store Decimal strings only.
+4. If they agree under the lock: commit with no write. A second sweep is a no-op.
+5. Structured `warn` + counters `seller.ledger.drift_detected` / `seller.ledger.corrected` fire only after the transaction commits. Metrics have no sellerId labels.
+6. Concurrent `confirmPayment` is safe because it increments `Seller.balance` in the same transaction as the ledger insert; `FOR UPDATE` serializes the corrective SET against that increment so the job cannot apply a stale SUM after a committed credit, and cannot double-credit.
+
+Do not invent refunds, PayPal capture reversal, or a public "fix balance" HTTP route.
 
 ## Rollback
 
-Drop the two CHECK constraints. Unique `(sellerId, orderId)` and the confirm-path claim remain from earlier migrations. Documentation and the shared `computeSellerLedgerAmounts` helper can be reverted independently; doing so would not restore a second source of truth.
+Drop the two CHECK constraints. Unique `(sellerId, orderId)` and the confirm-path claim remain from earlier migrations. Documentation and the shared `computeSellerLedgerAmounts` helper can be reverted independently; doing so would not restore a second source of truth. The reconcile job can be removed from `startApiProcess` without changing ledger writes; in-flight sweeps may finish, then projections stop being auto-aligned.
 
 ## Consequences
 
 - Duplicate payment confirmation remains a no-op after the order claim (`paymentStatus = PENDING AND status = PENDING`); the unique constraint is defense in depth.
-- Demo seed sets `Seller.balance` to `"0.00"` with no `SellerTransaction` rows so the projection matches an empty PAID `SUM(netAmount)`. Re-seed on an existing demo seller writes catalog `"0.00"` only when there are no PAID ledger rows; if PAID rows exist, the projection is set to that SUM so credited net is not wiped. Non-zero production credits are written only by `confirmPayment`. `GET /commissions/balance` returns the Decimal projection without `Number()`. Periodic SUM-vs-projection reconciliation remains #45.
+- Demo seed sets `Seller.balance` to `"0.00"` with no `SellerTransaction` rows so the projection matches an empty PAID `SUM(netAmount)`. Re-seed on an existing demo seller writes catalog `"0.00"` only when there are no PAID ledger rows; if PAID rows exist, the projection is set to that SUM so credited net is not wiped. Non-zero production credits are written only by `confirmPayment`. `GET /commissions/balance` returns the Decimal projection without `Number()`. The in-process job periodically realigns a drifted projection to PAID SUM (ledger wins).
 - Capture after reservation expiry still creates no ledger row (ADR 0002).
+- Multiple API replicas may run the same sweep; extra executions no-op after the first correction.

--- a/docs/architecture/c4.md
+++ b/docs/architecture/c4.md
@@ -126,6 +126,7 @@ One Node process does HTTP **and** timers. Adding replicas duplicates those time
 |---|---|---|
 | Reservation expiry | 30s | Conditional `RESERVED → ACTIVE` when TTL elapsed; cannot overwrite `SOLD`. |
 | PayPal GET reconciliation | 60s, min age 2 min, batch 20 | Recover capture if webhook was lost. Cannot sell an expired hold. |
+| Seller ledger reconciliation | 60s | Compare `Seller.balance` to PAID `SUM(netAmount)`; SET projection if they disagree (ledger wins). |
 
 OpenTelemetry is **optional** (`OTEL_ENABLED` defaults off). There is no sidecar collector in `render.yaml`.
 
@@ -179,7 +180,7 @@ C4Component
     Component(orders, "orders", "modules/orders", "Checkout + Idempotency-Key")
     Component(payments, "payments", "modules/payments", "PaymentLink, webhook, confirmPayment")
     Component(other, "other domains", "users, sellers, products, commissions, reviews, admin")
-    Component(jobs, "in-process jobs", "shared/jobs", "Expiry sweep + PayPal GET reconcile")
+    Component(jobs, "in-process jobs", "shared/jobs", "Expiry + PayPal GET + seller ledger reconcile")
     Component(paypalc, "PayPal adapter", "shared/utils", "Create/capture/GET; webhook RSA-SHA256")
     ComponentDb(db, "PostgreSQL", "Prisma")
   }
@@ -194,6 +195,7 @@ C4Component
   Rel(paypal, payments, "webhook")
   Rel(jobs, listings, "expireReservations")
   Rel(jobs, payments, "reconcile PENDING")
+  Rel(jobs, other, "reconcile Seller.balance")
   Rel(auth, db, "users, RevokedToken")
   Rel(listings, db, "Listing")
   Rel(orders, db, "Order, OrderIdempotencyKey")

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -32,7 +32,7 @@ Express API --> PayPal
 Express API --> Resend
 ```
 
-The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts` and `startApiProcess`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling. `startApiProcess` binds `0.0.0.0:$PORT`, starts the in-process reservation-expiry and PayPal-reconciliation jobs, and registers SIGTERM/SIGINT graceful shutdown (drain HTTP, stop jobs, disconnect Prisma, shut down telemetry). `GET /ready` returns 503 `shutting_down` after shutdown begins.
+The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts` and `startApiProcess`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling. `startApiProcess` binds `0.0.0.0:$PORT`, starts the in-process reservation-expiry, PayPal-reconciliation, and seller-ledger-reconciliation jobs, and registers SIGTERM/SIGINT graceful shutdown (drain HTTP, stop jobs, disconnect Prisma, shut down telemetry). `GET /ready` returns 503 `shutting_down` after shutdown begins.
 
 Observability is optional. `OTEL_ENABLED` defaults to off so `npm run dev` does not need a collector. See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
 
@@ -91,7 +91,7 @@ Webhook handling:
 
 A process crash after PayPal capture is recovered by webhook retry (unique event id) or the in-process reconciliation job, which GETs PayPal order status for stale `PENDING` orders (every 60s, minimum age 2 minutes, batch 20) and reuses `confirmPayment`.
 
-Critical workflows emit explicit spans (`orders.create`, `listings.reserve`, `payments.confirm`, `paypal.webhook.*`, `payments.reconcile`) and low-cardinality business counters. Expected 4xx results use `app.outcome` and are not marked span `ERROR`. Prisma calls get `db.prisma` spans without SQL text or parameters. PayPal HTTP uses stable operation names such as `paypal.orders_create`.
+Critical workflows emit explicit spans (`orders.create`, `listings.reserve`, `payments.confirm`, `paypal.webhook.*`, `payments.reconcile`, `seller.ledger.reconcile`) and low-cardinality business counters. Expected 4xx results use `app.outcome` and are not marked span `ERROR`. Prisma calls get `db.prisma` spans without SQL text or parameters. PayPal HTTP uses stable operation names such as `paypal.orders_create`.
 
 ## Testing
 

--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -89,7 +89,7 @@ Rules:
 1. Commission uses the applicable seller commission rate. Arithmetic is Prisma `Decimal`, never JavaScript `number`.
 2. `SellerTransaction` is the authoritative ledger. One row per `(sellerId, orderId)`. Currency is BRL (PayPal capture). Listing prices and PayPal amounts use 2 decimal places; commission is exact `gross × rate` with no extra rounding step. See `docs/adr/0011-seller-ledger.md`.
 3. Confirmation writes `status = PAID`. `REFUNDED` is not an application path.
-4. `Seller.balance` is a materialized projection of PAID net amounts, updated in the same local database transaction as the ledger insert. If they disagree, the ledger wins.
+4. `Seller.balance` is a materialized projection of PAID net amounts, updated in the same local database transaction as the ledger insert. If they disagree, the ledger wins. An in-process job SETs a drifted projection to PAID `SUM(netAmount)` (no ledger-row rewrite) and records `SELLER_BALANCE_RECONCILED`.
 5. Duplicate confirm, webhook replay, and concurrent confirmation must not insert a second row or double-credit the projection.
 6. `GET /commissions/balance` exposes that projection as Prisma Decimal JSON (string), not a JavaScript `number`. Demo seed writes `"0.00"` with no ledger rows so display data cannot diverge from an empty SUM. Re-seed zeros a stale catalog projection only when that seller has no PAID rows; existing PAID net is aligned to `SUM(netAmount)`, not wiped.
 

--- a/docs/architecture/failure-modes.md
+++ b/docs/architecture/failure-modes.md
@@ -69,7 +69,7 @@ Should Neon Arsenal later reverse captured funds automatically, and with which *
 On SIGTERM/SIGINT the API:
 
 1. Marks itself shutting down (`GET /ready` returns 503 `shutting_down`).
-2. Stops reservation-expiry and PayPal-reconciliation timers (in-flight sweeps may finish).
+2. Stops reservation-expiry, PayPal-reconciliation, and seller-ledger-reconciliation timers (in-flight sweeps may finish).
 3. Stops accepting new HTTP connections and drains in-flight requests for up to 10s, then closes remaining connections.
 4. Disconnects Prisma.
 5. Shuts down OpenTelemetry exporters.

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -126,13 +126,13 @@ These are **implemented**. Threats below assume an attacker trying to bypass the
 - Listing reserve: `ACTIVE` → `RESERVED` via conditional update (lost update → conflict).
 - Order create: durable `OrderIdempotencyKey` before PayPal.
 - Money: Prisma Decimal, not IEEE floats.
-- Unique seller ledger row per `(sellerId, orderId)`. `Seller.balance` is a projection; the ledger wins if they disagree (ADR 0011).
+- Unique seller ledger row per `(sellerId, orderId)`. `Seller.balance` is a projection; the ledger wins if they disagree (ADR 0011). Periodic in-process reconciliation SETs a drifted projection to PAID SUM under `FOR UPDATE`.
 
 These are **correctness** controls; they also limit economic abuse (double spend of a unique listing, double credit).
 
 ### 4.6 Audit trail
 
-- Append-only `AuditLog` in PostgreSQL for seller approval, listing price/cancel, order status transitions, and local payment confirmation (`docs/adr/0010-audit-log.md`).
+- Append-only `AuditLog` in PostgreSQL for seller approval, listing price/cancel, order status transitions, local payment confirmation, and seller-ledger projection correction (`docs/adr/0010-audit-log.md`).
 - Read API: `GET /admin/audit-logs` is `authenticate` + `requireRole("ADMIN")`. CUSTOMER/SELLER → 403; missing token → 401.
 - `before`/`after` are non-sensitive field diffs. Known secret keys and JWT-shaped values are redacted at write. Full PayPal payloads are not stored.
 - Retention: 365 days (documented policy + `createdAt` index). No Redis TTL worker.

--- a/docs/domain/invariants.md
+++ b/docs/domain/invariants.md
@@ -130,12 +130,13 @@ Related IDs below keep this catalog aligned with the architecture narrative. Cit
 **Enforced:**
 
 - Schema: unique `(sellerId, orderId)`; CHECK net identity and non-negative amounts. `Seller.balance` documented as projection (ADR 0011).
-- Service: `confirmPayment` claim (`paymentStatus = PENDING AND status = PENDING`) plus ledger insert. Duplicate claims are no-ops.
+- Service: `confirmPayment` claim (`paymentStatus = PENDING AND status = PENDING`) plus ledger insert. Duplicate claims are no-ops. `commissionsService.reconcileSellerLedger` SETs a drifted `Seller.balance` to PAID `SUM(netAmount)` under `FOR UPDATE`; it does not insert or delete ledger rows.
 - HTTP: `GET /commissions/balance` returns the Prisma Decimal projection (JSON string via Decimal#toJSON). No `Number()`.
-- Seed: demo `Seller.balance` is `"0.00"` with no ledger rows so the projection matches empty PAID SUM. Re-seed writes that catalog zero only when the seller has no PAID ledger rows; if PAID rows exist, seed sets the projection to `SUM(netAmount)` and does not wipe credited net. Confirm remains the only production non-zero writer.
-- Tests: `seller.ledger.integration.test.ts` (sequential and concurrent confirm, net identity, Decimal vs float); `reservation.lifecycle.integration.test.ts`; `paypal.webhook.integration.test.ts`; `commissions.service.test.ts`; `demoCatalog.test.ts`; `seed.ledger.integration.test.ts`.
+- Seed: demo `Seller.balance` is `"0.00"` with no ledger rows so the projection matches empty PAID SUM. Re-seed writes that catalog zero only when the seller has no PAID ledger rows; if PAID rows exist, seed sets the projection to `SUM(netAmount)` and does not wipe credited net. Confirm remains the only production non-zero writer of ledger rows.
+- Job: in-process interval (60s) started with the PayPal/reservation jobs. Second run is a no-op when aligned. Concurrent confirm vs reconcile cannot double-credit because the corrective write holds the seller row and assigns SUM rather than incrementing.
+- Tests: `seller.ledger.integration.test.ts` (sequential and concurrent confirm, net identity, Decimal vs float); `seller.ledger.reconcile.integration.test.ts`; `commissions.reconcile.test.ts`; `reservation.lifecycle.integration.test.ts`; `paypal.webhook.integration.test.ts`; `commissions.service.test.ts`; `demoCatalog.test.ts`; `seed.ledger.integration.test.ts`.
 
-**Related:** `INV-SELLER-COMMISSION-DECIMAL`, `INV-SELLER-TXN-UNIQUE`. Issue #45 (not implemented) can reconcile projection vs `SUM(netAmount) WHERE status = 'PAID'`.
+**Related:** `INV-SELLER-COMMISSION-DECIMAL`, `INV-SELLER-TXN-UNIQUE`. Periodic projection vs PAID SUM reconciliation is implemented (issue #45); see ADR 0011.
 
 ---
 
@@ -165,4 +166,4 @@ These are already specified in the architecture narrative. This table is the ID 
 3. Add or extend the regression/integration test named in the row.
 4. Write an ADR when the change is significant.
 
-Periodic financial reconciliation as a product (#45) is a separate issue. The ledger contract in ADR 0011 is the input that work would use.
+Periodic financial reconciliation as a product (#45) is implemented: in-process job, ledger-wins SET of `Seller.balance`, audit + metrics. See `docs/adr/0011-seller-ledger.md`.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -41,6 +41,7 @@ Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second
 | `payments.confirm` | Payment confirmation |
 | `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
 | `payments.reconcile` | PayPal GET reconciliation batch |
+| `seller.ledger.reconcile` | Seller.balance vs PAID ledger SUM |
 | `paypal.webhook.verify` | Webhook signature verification |
 | `paypal.webhook.handle` | Event claim, ignore, confirm or fail |
 | `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP |
@@ -75,6 +76,7 @@ Business counters (no labels):
 - `reservations.created`, `reservations.conflict`, `reservations.expired`
 - `payments.confirmed`, `payments.failed`
 - `paypal.webhooks.received`, `paypal.webhooks.duplicate`, `paypal.webhooks.ignored`, `paypal.webhooks.failed`
+- `seller.ledger.drift_detected`, `seller.ledger.corrected`
 
 There is no `orders.pending` gauge. That would scrape PostgreSQL on a timer; query `Order` where `paymentStatus = PENDING` when you need the count.
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -10,7 +10,7 @@ API service: `neon-arsenal-api` (Docker, `server/Dockerfile`, context `server/`)
 2. `server/entrypoint.sh` runs `prisma migrate deploy`.
 3. If `SEED_DEMO_DATA=true`, the entrypoint also runs `npm run db:seed`.
 4. `node dist/index.js` starts. It binds **`0.0.0.0:$PORT`** (`PORT` is `3001` in the Blueprint). If `SEED_DEMO_DATA=true`, `index.ts` seeds again. Both passes upsert; they do not overwrite existing rows.
-5. In-process jobs start after listen: reservation expiry (30s) and PayPal GET reconciliation (60s).
+5. In-process jobs start after listen: reservation expiry (30s), PayPal GET reconciliation (60s), and seller ledger reconciliation (60s).
 
 The Blueprint also defines static `neon-arsenal-web`. The public demo often uses Vercel for the Vite client and Render only for the API; set `FRONTEND_URL` on the API and `API_URL` on the frontend. Do not invent env vars.
 
@@ -36,7 +36,7 @@ A new Render deploy does not take traffic until `GET /ready` is 2xx/3xx (Postgre
 On SIGTERM/SIGINT (`docs/adr/0005-external-retry-and-graceful-shutdown.md`):
 
 1. Mark shutting down → `GET /ready` is 503 `shutting_down`.
-2. Stop reservation-expiry and PayPal-reconciliation timers (in-flight sweeps may finish).
+2. Stop reservation-expiry, PayPal-reconciliation, and seller-ledger-reconciliation timers (in-flight sweeps may finish).
 3. `server.close()`: no new HTTP connections; in-flight requests get **10s** (`SHUTDOWN_DRAIN_MS`), then remaining connections are closed.
 4. Disconnect Prisma.
 5. Shut down OpenTelemetry exporters.
@@ -83,7 +83,7 @@ ORDER BY "receivedAt" DESC
 LIMIT 50;
 ```
 
-Logs (no secrets): `paypal webhook received`, `paypal capture webhook processed`, `paypal webhook duplicate ignored`, `paypal webhook not applied: reservation expired`, `paypal reconciliation skipped: reservation expired`, `graceful shutdown started`.
+Logs (no secrets): `paypal webhook received`, `paypal capture webhook processed`, `paypal webhook duplicate ignored`, `paypal webhook not applied: reservation expired`, `paypal reconciliation skipped: reservation expired`, `seller ledger projection drifted; corrected to PAID SUM`, `graceful shutdown started`.
 
 Capture after the reservation TTL is a split-brain with PayPal. Procedure: **Capture after reservation expiry** below.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,6 +107,8 @@ Integration tests are not skipped when PostgreSQL is down. A missing or unreacha
 | `reservation.lifecycle.integration.test.ts` | Reservation timestamps, concurrent buyers, expiration vs payment, no duplicate seller transactions. |
 | `paypal.webhook.integration.test.ts` | Duplicate/out-of-order events, expired capture, stale-order capture, payment rollback. PayPal remains isolated. |
 | `observability.integration.test.ts` | Order/reservation/payment/webhook spans and counters against real PostgreSQL. No secrets or high-cardinality labels. |
+| `seller.ledger.integration.test.ts` | Sequential/concurrent confirm; Decimal net identity; projection matches PAID SUM. |
+| `seller.ledger.reconcile.integration.test.ts` | Matching projection is a no-op; drifted projection is SET once + audited; concurrent confirmPayment cannot double-credit. |
 | `performance.evidence.integration.test.ts` | `EXPLAIN ANALYZE` on market/expiry/reconciliation SQL uses the hot-path indexes; listing/order/payment timings stay bounded. |
 
 OpenTelemetry is disabled for normal development. Telemetry tests start an in-memory exporter with `startTestTelemetry()` and do not require a collector. Unit tests also cover request-ID correlation, HTTP route cardinality, business-vs-operational span status, redaction and the disabled/OTLP-down paths. See `docs/observability.md`.

--- a/server/src/__tests__/seller.ledger.reconcile.integration.test.ts
+++ b/server/src/__tests__/seller.ledger.reconcile.integration.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import { DomainInvariant } from "../shared/domain/invariants.js";
+import { prisma } from "../shared/database/index.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import { commissionsService } from "../modules/commissions/commissions.service.js";
+import { AuditAction, AuditResourceType } from "../modules/audit/audit.types.js";
+import {
+  createCheckoutGraph,
+  createListing,
+  createOrder,
+  createSeller,
+  orderKey,
+} from "./helpers/index.js";
+
+async function paidLedgerSum(sellerId: string) {
+  const paid = await prisma.sellerTransaction.aggregate({
+    where: { sellerId, status: "PAID" },
+    _sum: { netAmount: true },
+  });
+  return paid._sum.netAmount ?? new Prisma.Decimal(0);
+}
+
+describe(`${DomainInvariant.SELLER_LEDGER_SOURCE} seller ledger reconcile (postgres)`, () => {
+  it("does not write when the projection already matches PAID SUM", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(
+      fixture.customer.id,
+      [fixture.listings[0].id],
+      orderKey("reconcile-match")
+    );
+    await paymentsService.confirmPayment(created.id);
+
+    const beforeSeller = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+    const beforeAudit = await prisma.auditLog.count({
+      where: {
+        action: AuditAction.SELLER_BALANCE_RECONCILED,
+        resourceId: fixture.seller.id,
+      },
+    });
+    const beforeTxns = await prisma.sellerTransaction.count({
+      where: { sellerId: fixture.seller.id },
+    });
+
+    const result = await commissionsService.reconcileSellerLedger();
+
+    expect(result.corrected).toBe(0);
+    const afterSeller = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+    const afterAudit = await prisma.auditLog.count({
+      where: {
+        action: AuditAction.SELLER_BALANCE_RECONCILED,
+        resourceId: fixture.seller.id,
+      },
+    });
+    const afterTxns = await prisma.sellerTransaction.count({
+      where: { sellerId: fixture.seller.id },
+    });
+
+    expect(afterSeller?.balance.equals(beforeSeller!.balance)).toBe(true);
+    expect(afterSeller?.balance.equals(await paidLedgerSum(fixture.seller.id))).toBe(true);
+    expect(afterAudit).toBe(beforeAudit);
+    expect(afterTxns).toBe(beforeTxns);
+  });
+
+  it("corrects a drifted projection once, audits, and is a no-op on the second run", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(
+      fixture.customer.id,
+      [fixture.listings[0].id],
+      orderKey("reconcile-drift")
+    );
+    await paymentsService.confirmPayment(created.id);
+
+    await prisma.seller.update({
+      where: { id: fixture.seller.id },
+      data: { balance: new Prisma.Decimal("0.00") },
+    });
+
+    const ledgerSum = await paidLedgerSum(fixture.seller.id);
+    expect(ledgerSum.equals(new Prisma.Decimal("90"))).toBe(true);
+
+    const first = await commissionsService.reconcileSellerLedger();
+    expect(first.corrected).toBe(1);
+
+    const corrected = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+    expect(corrected?.balance.equals(ledgerSum)).toBe(true);
+
+    const audits = await prisma.auditLog.findMany({
+      where: {
+        action: AuditAction.SELLER_BALANCE_RECONCILED,
+        resourceType: AuditResourceType.Seller,
+        resourceId: fixture.seller.id,
+      },
+    });
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.actorId).toBeNull();
+    expect(audits[0]?.actorRole).toBeNull();
+    const before = audits[0]?.before as { balance: string };
+    const after = audits[0]?.after as { balance: string };
+    expect(new Prisma.Decimal(before.balance).equals(new Prisma.Decimal("0"))).toBe(true);
+    expect(new Prisma.Decimal(after.balance).equals(ledgerSum)).toBe(true);
+
+    const txnCount = await prisma.sellerTransaction.count({
+      where: { sellerId: fixture.seller.id },
+    });
+    expect(txnCount).toBe(1);
+
+    const second = await commissionsService.reconcileSellerLedger();
+    expect(second.corrected).toBe(0);
+    const still = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+    expect(still?.balance.equals(ledgerSum)).toBe(true);
+    expect(
+      await prisma.auditLog.count({
+        where: {
+          action: AuditAction.SELLER_BALANCE_RECONCILED,
+          resourceId: fixture.seller.id,
+        },
+      })
+    ).toBe(1);
+  });
+
+  it("zeros a stale catalog projection when the PAID ledger is empty", async () => {
+    const seller = await createSeller();
+    await prisma.seller.update({
+      where: { id: seller.id },
+      data: { balance: new Prisma.Decimal("1250.75") },
+    });
+
+    const result = await commissionsService.reconcileSellerLedger();
+    expect(result.corrected).toBeGreaterThanOrEqual(1);
+
+    const aligned = await prisma.seller.findUnique({ where: { id: seller.id } });
+    expect(aligned?.balance.equals(new Prisma.Decimal(0))).toBe(true);
+    expect(await prisma.sellerTransaction.count({ where: { sellerId: seller.id } })).toBe(0);
+
+    const audit = await prisma.auditLog.findFirst({
+      where: {
+        action: AuditAction.SELLER_BALANCE_RECONCILED,
+        resourceId: seller.id,
+      },
+    });
+    expect(
+      new Prisma.Decimal((audit?.before as { balance: string }).balance).equals(
+        new Prisma.Decimal("1250.75")
+      )
+    ).toBe(true);
+    expect(
+      new Prisma.Decimal((audit?.after as { balance: string }).balance).equals(new Prisma.Decimal(0))
+    ).toBe(true);
+  });
+
+  it("does not double-credit when reconcile races confirmPayment", async () => {
+    const fixture = await createCheckoutGraph();
+    const listing2 = await createListing({
+      productId: fixture.product.id,
+      sellerId: fixture.seller.id,
+      price: "100.00",
+    });
+    const first = await createOrder(
+      fixture.customer.id,
+      [fixture.listings[0].id],
+      orderKey("reconcile-race-1")
+    );
+    await paymentsService.confirmPayment(first.id);
+
+    await prisma.seller.update({
+      where: { id: fixture.seller.id },
+      data: { balance: new Prisma.Decimal("50.00") },
+    });
+
+    const second = await createOrder(
+      fixture.customer.id,
+      [listing2.id],
+      orderKey("reconcile-race-2")
+    );
+
+    const results = await Promise.allSettled([
+      paymentsService.confirmPayment(second.id),
+      commissionsService.reconcileSellerLedger(),
+      commissionsService.reconcileSellerLedger(),
+    ]);
+    expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+
+    const txns = await prisma.sellerTransaction.findMany({
+      where: { sellerId: fixture.seller.id, status: "PAID" },
+    });
+    expect(txns).toHaveLength(2);
+    const ledgerSum = txns.reduce(
+      (sum, row) => sum.plus(row.netAmount),
+      new Prisma.Decimal(0)
+    );
+    const seller = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+    expect(seller?.balance.equals(ledgerSum)).toBe(true);
+    expect(seller?.balance.equals(new Prisma.Decimal("180.00"))).toBe(true);
+  });
+});

--- a/server/src/modules/audit/audit.types.ts
+++ b/server/src/modules/audit/audit.types.ts
@@ -8,6 +8,7 @@ export const AuditAction = {
   LISTING_CANCEL: "LISTING_CANCEL",
   ORDER_STATUS_CHANGE: "ORDER_STATUS_CHANGE",
   PAYMENT_CONFIRMED: "PAYMENT_CONFIRMED",
+  SELLER_BALANCE_RECONCILED: "SELLER_BALANCE_RECONCILED",
 } as const;
 
 export type AuditActionName = (typeof AuditAction)[keyof typeof AuditAction];

--- a/server/src/modules/commissions/__tests__/commissions.reconcile.test.ts
+++ b/server/src/modules/commissions/__tests__/commissions.reconcile.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Prisma } from "@prisma/client";
+import { DomainInvariant } from "../../../shared/domain/invariants.js";
+
+vi.mock("../../../shared/database/index.js", () => ({
+  prisma: {
+    seller: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    sellerTransaction: {
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+      aggregate: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("../commissions.repository.js", () => ({
+  commissionsRepository: {
+    findMany: vi.fn(),
+    findManyBySellerId: vi.fn(),
+    getBalance: vi.fn(),
+    listProjections: vi.fn(),
+    sumPaidNetGrouped: vi.fn(),
+    lockSellerForUpdate: vi.fn(),
+    sumPaidNetForSeller: vi.fn(),
+  },
+}));
+
+vi.mock("../../audit/audit.repository.js", () => ({
+  auditRepository: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("../../../shared/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { prisma } from "../../../shared/database/index.js";
+import { commissionsRepository } from "../commissions.repository.js";
+import { auditRepository } from "../../audit/audit.repository.js";
+import { commissionsService } from "../commissions.service.js";
+import { AuditAction, AuditResourceType } from "../../audit/audit.types.js";
+import { logger } from "../../../shared/logger.js";
+
+describe(`${DomainInvariant.SELLER_LEDGER_SOURCE} reconcileSellerLedger()`, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: (client: typeof prisma) => unknown) =>
+      fn(prisma)
+    );
+  });
+
+  it("does not write when every projection already matches PAID SUM", async () => {
+    vi.mocked(commissionsRepository.listProjections).mockResolvedValue([
+      { id: "seller-1", balance: new Prisma.Decimal("90.00") },
+    ] as never);
+    vi.mocked(commissionsRepository.sumPaidNetGrouped).mockResolvedValue([
+      { sellerId: "seller-1", _sum: { netAmount: new Prisma.Decimal("90.00") } },
+    ] as never);
+
+    const result = await commissionsService.reconcileSellerLedger();
+
+    expect(result).toEqual({ scanned: 1, driftCandidates: 0, corrected: 0 });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.seller.update).not.toHaveBeenCalled();
+    expect(auditRepository.create).not.toHaveBeenCalled();
+    expect(prisma.sellerTransaction.create).not.toHaveBeenCalled();
+    expect(prisma.sellerTransaction.deleteMany).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("sets the projection to PAID SUM once and writes a system audit row", async () => {
+    vi.mocked(commissionsRepository.listProjections).mockResolvedValue([
+      { id: "seller-1", balance: new Prisma.Decimal("80.00") },
+    ] as never);
+    vi.mocked(commissionsRepository.sumPaidNetGrouped).mockResolvedValue([
+      { sellerId: "seller-1", _sum: { netAmount: new Prisma.Decimal("90.00") } },
+    ] as never);
+    vi.mocked(prisma.seller.findUnique).mockResolvedValue({
+      balance: new Prisma.Decimal("80.00"),
+    } as never);
+    vi.mocked(commissionsRepository.sumPaidNetForSeller).mockResolvedValue(new Prisma.Decimal("90.00"));
+    vi.mocked(prisma.seller.update).mockResolvedValue({} as never);
+    vi.mocked(auditRepository.create).mockResolvedValue({} as never);
+
+    const result = await commissionsService.reconcileSellerLedger();
+
+    expect(result.corrected).toBe(1);
+    expect(commissionsRepository.lockSellerForUpdate).toHaveBeenCalledWith(prisma, "seller-1");
+    const updateArg = vi.mocked(prisma.seller.update).mock.calls[0]?.[0] as {
+      where: { id: string };
+      data: { balance: Prisma.Decimal };
+    };
+    expect(updateArg.where).toEqual({ id: "seller-1" });
+    expect(updateArg.data.balance.equals(new Prisma.Decimal("90.00"))).toBe(true);
+    expect(auditRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: null,
+        actorRole: null,
+        action: AuditAction.SELLER_BALANCE_RECONCILED,
+        resourceType: AuditResourceType.Seller,
+        resourceId: "seller-1",
+      }),
+      prisma
+    );
+    const auditInput = vi.mocked(auditRepository.create).mock.calls[0]?.[0] as unknown as {
+      before: { balance: string };
+      after: { balance: string };
+    };
+    expect(new Prisma.Decimal(auditInput.before.balance).equals(new Prisma.Decimal("80"))).toBe(true);
+    expect(new Prisma.Decimal(auditInput.after.balance).equals(new Prisma.Decimal("90"))).toBe(true);
+    expect(prisma.sellerTransaction.create).not.toHaveBeenCalled();
+    expect(prisma.sellerTransaction.deleteMany).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ sellerId: "seller-1" }),
+      "seller ledger projection drifted; corrected to PAID SUM"
+    );
+  });
+
+  it("is a no-op when the locked re-read is already aligned", async () => {
+    vi.mocked(commissionsRepository.listProjections).mockResolvedValue([
+      { id: "seller-1", balance: new Prisma.Decimal("80.00") },
+    ] as never);
+    vi.mocked(commissionsRepository.sumPaidNetGrouped).mockResolvedValue([
+      { sellerId: "seller-1", _sum: { netAmount: new Prisma.Decimal("90.00") } },
+    ] as never);
+    vi.mocked(prisma.seller.findUnique).mockResolvedValue({
+      balance: new Prisma.Decimal("90.00"),
+    } as never);
+    vi.mocked(commissionsRepository.sumPaidNetForSeller).mockResolvedValue(new Prisma.Decimal("90.00"));
+
+    const result = await commissionsService.reconcileSellerLedger();
+
+    expect(result).toEqual({ scanned: 1, driftCandidates: 1, corrected: 0 });
+    expect(prisma.seller.update).not.toHaveBeenCalled();
+    expect(auditRepository.create).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("corrects a stale non-zero projection when the PAID ledger is empty", async () => {
+    vi.mocked(commissionsRepository.listProjections).mockResolvedValue([
+      { id: "seller-1", balance: new Prisma.Decimal("1250.75") },
+    ] as never);
+    vi.mocked(commissionsRepository.sumPaidNetGrouped).mockResolvedValue([]);
+    vi.mocked(prisma.seller.findUnique).mockResolvedValue({
+      balance: new Prisma.Decimal("1250.75"),
+    } as never);
+    vi.mocked(commissionsRepository.sumPaidNetForSeller).mockResolvedValue(new Prisma.Decimal(0));
+    vi.mocked(prisma.seller.update).mockResolvedValue({} as never);
+    vi.mocked(auditRepository.create).mockResolvedValue({} as never);
+
+    const result = await commissionsService.reconcileSellerLedger();
+
+    expect(result.corrected).toBe(1);
+    const updateArg = vi.mocked(prisma.seller.update).mock.calls[0]?.[0] as {
+      where: { id: string };
+      data: { balance: Prisma.Decimal };
+    };
+    expect(updateArg.where).toEqual({ id: "seller-1" });
+    expect(updateArg.data.balance.equals(new Prisma.Decimal(0))).toBe(true);
+    const auditInput = vi.mocked(auditRepository.create).mock.calls[0]?.[0] as unknown as {
+      before: { balance: string };
+      after: { balance: string };
+    };
+    expect(new Prisma.Decimal(auditInput.before.balance).equals(new Prisma.Decimal("1250.75"))).toBe(
+      true
+    );
+    expect(new Prisma.Decimal(auditInput.after.balance).equals(new Prisma.Decimal(0))).toBe(true);
+  });
+});

--- a/server/src/modules/commissions/commissions.repository.ts
+++ b/server/src/modules/commissions/commissions.repository.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../../shared/database/index.js";
+import { paidLedgerSumOrZero } from "../../shared/money/sellerLedger.js";
 
 export const commissionsRepository = {
   async findManyBySellerId(sellerId: string) {
@@ -29,5 +30,35 @@ export const commissionsRepository = {
       select: { balance: true },
     });
     return seller?.balance ?? new Prisma.Decimal(0);
+  },
+
+  async listProjections() {
+    return prisma.seller.findMany({
+      select: { id: true, balance: true },
+    });
+  },
+
+  async sumPaidNetGrouped() {
+    return prisma.sellerTransaction.groupBy({
+      by: ["sellerId"],
+      where: { status: "PAID" },
+      _sum: { netAmount: true },
+    });
+  },
+
+  /**
+   * Hold the projection row so confirmPayment's increment cannot land between
+   * the PAID SUM read and a corrective SET (issue #45 / ADR 0011).
+   */
+  async lockSellerForUpdate(tx: Prisma.TransactionClient, sellerId: string) {
+    await tx.$queryRaw`SELECT 1 FROM "Seller" WHERE id = ${sellerId} FOR UPDATE`;
+  },
+
+  async sumPaidNetForSeller(tx: Prisma.TransactionClient, sellerId: string) {
+    const paid = await tx.sellerTransaction.aggregate({
+      where: { sellerId, status: "PAID" },
+      _sum: { netAmount: true },
+    });
+    return paidLedgerSumOrZero(paid._sum.netAmount);
   },
 };

--- a/server/src/modules/commissions/commissions.service.ts
+++ b/server/src/modules/commissions/commissions.service.ts
@@ -1,6 +1,16 @@
 import { prisma } from "../../shared/database/index.js";
 import { commissionsRepository } from "./commissions.repository.js";
 import { AppError } from "../../shared/errors/AppError.js";
+import { logger } from "../../shared/logger.js";
+import { appMetrics } from "../../shared/observability/metrics.js";
+import { withSpan } from "../../shared/observability/tracing.js";
+import {
+  findSellerProjectionDrifts,
+  sellerProjectionMatchesLedger,
+} from "../../shared/money/sellerLedger.js";
+import { auditRepository } from "../audit/audit.repository.js";
+import { AuditAction, AuditResourceType } from "../audit/audit.types.js";
+import { systemAuditActor } from "../audit/audit.service.js";
 
 export const commissionsService = {
   async listTransactions(userId: string, role: string) {
@@ -24,4 +34,88 @@ export const commissionsService = {
     // uses Decimal#toJSON (a string), matching listing price / order totalAmount.
     return { balance };
   },
+
+  /**
+   * INV-SELLER-LEDGER-SOURCE / issue #45
+   *
+   * Compare `Seller.balance` to `SUM(netAmount) WHERE status = PAID`.
+   * On confirmed mismatch: audit + SET the projection to the ledger SUM in
+   * one transaction. Never insert/delete SellerTransaction rows.
+   * A second run is a no-op when already aligned.
+   */
+  async reconcileSellerLedger() {
+    return withSpan("seller.ledger.reconcile", {}, async (span) => {
+      const projections = await commissionsRepository.listProjections();
+      const grouped = await commissionsRepository.sumPaidNetGrouped();
+      const drifts = findSellerProjectionDrifts(
+        projections,
+        grouped.map((row) => ({ sellerId: row.sellerId, netAmount: row._sum.netAmount }))
+      );
+
+      span.setAttribute("app.reconcile_scanned", projections.length);
+      span.setAttribute("app.reconcile_drift_candidates", drifts.length);
+
+      let corrected = 0;
+      for (const drift of drifts) {
+        const didCorrect = await correctSellerProjectionIfDrifted(drift.sellerId);
+        if (didCorrect) corrected += 1;
+      }
+
+      span.setAttribute("app.reconcile_corrected", corrected);
+      return {
+        scanned: projections.length,
+        driftCandidates: drifts.length,
+        corrected,
+      };
+    });
+  },
 };
+
+async function correctSellerProjectionIfDrifted(sellerId: string): Promise<boolean> {
+  const result = await prisma.$transaction(async (tx) => {
+    await commissionsRepository.lockSellerForUpdate(tx, sellerId);
+    const row = await tx.seller.findUnique({
+      where: { id: sellerId },
+      select: { balance: true },
+    });
+    if (!row) return null;
+
+    const ledgerSum = await commissionsRepository.sumPaidNetForSeller(tx, sellerId);
+    if (sellerProjectionMatchesLedger(row.balance, ledgerSum)) {
+      return { corrected: false as const };
+    }
+
+    await tx.seller.update({
+      where: { id: sellerId },
+      data: { balance: ledgerSum },
+    });
+
+    await auditRepository.create(
+      {
+        ...systemAuditActor(),
+        action: AuditAction.SELLER_BALANCE_RECONCILED,
+        resourceType: AuditResourceType.Seller,
+        resourceId: sellerId,
+        before: { balance: row.balance.toString() },
+        after: { balance: ledgerSum.toString() },
+      },
+      tx
+    );
+
+    return {
+      corrected: true as const,
+      projected: row.balance.toString(),
+      ledgerSum: ledgerSum.toString(),
+    };
+  });
+
+  if (!result?.corrected) return false;
+
+  appMetrics.sellerLedgerDriftDetected();
+  appMetrics.sellerLedgerCorrected();
+  logger.warn(
+    { sellerId, projected: result.projected, ledgerSum: result.ledgerSum },
+    "seller ledger projection drifted; corrected to PAID SUM"
+  );
+  return true;
+}

--- a/server/src/shared/config/sellerLedger.ts
+++ b/server/src/shared/config/sellerLedger.ts
@@ -1,0 +1,5 @@
+/**
+ * How often the in-process sweep compares Seller.balance to PAID ledger SUM.
+ * Constant, matching PAYPAL_RECONCILE_INTERVAL_MS — not an env var.
+ */
+export const SELLER_LEDGER_RECONCILE_INTERVAL_MS = 60_000;

--- a/server/src/shared/jobs/sellerLedgerReconciliationJob.ts
+++ b/server/src/shared/jobs/sellerLedgerReconciliationJob.ts
@@ -1,0 +1,24 @@
+import { commissionsService } from "../../modules/commissions/commissions.service.js";
+import { logger } from "../logger.js";
+import { SELLER_LEDGER_RECONCILE_INTERVAL_MS } from "../config/sellerLedger.js";
+
+/**
+ * In-process seller ledger reconciliation for the modular monolith.
+ * PostgreSQL remains the source of truth: SellerTransaction (PAID SUM) wins
+ * over Seller.balance. Overlapping replicas are safe because each correction
+ * locks the seller row, re-reads, and no-ops when already aligned.
+ */
+export function startSellerLedgerReconciliationJob(): NodeJS.Timeout {
+  const timer = setInterval(() => {
+    commissionsService.reconcileSellerLedger().catch((err: unknown) => {
+      logger.error({ err }, "seller ledger reconciliation sweep failed");
+    });
+  }, SELLER_LEDGER_RECONCILE_INTERVAL_MS);
+
+  timer.unref();
+  logger.info(
+    { intervalMs: SELLER_LEDGER_RECONCILE_INTERVAL_MS },
+    "seller ledger reconciliation sweep started"
+  );
+  return timer;
+}

--- a/server/src/shared/lifecycle/startApi.ts
+++ b/server/src/shared/lifecycle/startApi.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import { logger } from "../logger.js";
 import { startPaypalReconciliationJob } from "../jobs/paypalReconciliationJob.js";
 import { startReservationExpiryJob } from "../jobs/reservationExpiryJob.js";
+import { startSellerLedgerReconciliationJob } from "../jobs/sellerLedgerReconciliationJob.js";
 import { installProcessShutdownHandlers } from "./shutdown.js";
 
 export function startApiProcess(
@@ -16,7 +17,11 @@ export function startApiProcess(
   const server = app.listen(port, host, () => {
     logger.info({ host, port }, "http server listening");
     console.log(`Server running on http://${host}:${port}`);
-    jobs.push(startReservationExpiryJob(), startPaypalReconciliationJob());
+    jobs.push(
+      startReservationExpiryJob(),
+      startPaypalReconciliationJob(),
+      startSellerLedgerReconciliationJob()
+    );
   });
 
   const stopJobs = () => {

--- a/server/src/shared/money/__tests__/sellerLedger.test.ts
+++ b/server/src/shared/money/__tests__/sellerLedger.test.ts
@@ -5,7 +5,10 @@ import {
   SELLER_LEDGER_CURRENCY,
   SELLER_LEDGER_PRICE_SCALE,
   computeSellerLedgerAmounts,
+  findSellerProjectionDrifts,
   ledgerNetMatchesGrossMinusCommission,
+  paidLedgerSumOrZero,
+  sellerProjectionMatchesLedger,
 } from "../sellerLedger.js";
 
 describe(`${DomainInvariant.SELLER_COMMISSION_DECIMAL} seller ledger amounts`, () => {
@@ -47,5 +50,52 @@ describe(`${DomainInvariant.SELLER_COMMISSION_DECIMAL} seller ledger amounts`, (
 
     expect(amounts.netAmount.equals(new Prisma.Decimal("0.00"))).toBe(true);
     expect(ledgerNetMatchesGrossMinusCommission(amounts)).toBe(true);
+  });
+});
+
+describe(`${DomainInvariant.SELLER_LEDGER_SOURCE} projection vs PAID SUM`, () => {
+  it("treats a missing SUM as Decimal zero", () => {
+    expect(paidLedgerSumOrZero(null).equals(new Prisma.Decimal(0))).toBe(true);
+    expect(paidLedgerSumOrZero(undefined).equals(new Prisma.Decimal(0))).toBe(true);
+    expect(paidLedgerSumOrZero(new Prisma.Decimal("90.00")).equals(new Prisma.Decimal("90.00"))).toBe(
+      true
+    );
+  });
+
+  it("matches projection to ledger with Decimal.equals, not JavaScript number", () => {
+    const projected = new Prisma.Decimal("0.10").plus(new Prisma.Decimal("0.20"));
+    expect(sellerProjectionMatchesLedger(projected, new Prisma.Decimal("0.30"))).toBe(true);
+    expect(sellerProjectionMatchesLedger(projected, new Prisma.Decimal("0.300"))).toBe(true);
+    expect(0.1 + 0.2).not.toBe(0.3);
+  });
+
+  it("finds no drifts when every projection equals PAID SUM", () => {
+    const drifts = findSellerProjectionDrifts(
+      [
+        { id: "seller-a", balance: new Prisma.Decimal("90.00") },
+        { id: "seller-b", balance: new Prisma.Decimal(0) },
+      ],
+      [
+        { sellerId: "seller-a", netAmount: new Prisma.Decimal("90.00") },
+      ]
+    );
+    expect(drifts).toEqual([]);
+  });
+
+  it("flags a stale projection and an empty-ledger seller with leftover balance", () => {
+    const drifts = findSellerProjectionDrifts(
+      [
+        { id: "seller-a", balance: new Prisma.Decimal("80.00") },
+        { id: "seller-b", balance: new Prisma.Decimal("1250.75") },
+      ],
+      [{ sellerId: "seller-a", netAmount: new Prisma.Decimal("90.00") }]
+    );
+
+    expect(drifts).toHaveLength(2);
+    expect(drifts[0]?.sellerId).toBe("seller-a");
+    expect(drifts[0]?.projected.equals(new Prisma.Decimal("80.00"))).toBe(true);
+    expect(drifts[0]?.ledgerSum.equals(new Prisma.Decimal("90.00"))).toBe(true);
+    expect(drifts[1]?.sellerId).toBe("seller-b");
+    expect(drifts[1]?.ledgerSum.equals(new Prisma.Decimal(0))).toBe(true);
   });
 });

--- a/server/src/shared/money/sellerLedger.ts
+++ b/server/src/shared/money/sellerLedger.ts
@@ -41,3 +41,54 @@ export function computeSellerLedgerAmounts(
 export function ledgerNetMatchesGrossMinusCommission(amounts: SellerLedgerAmounts): boolean {
   return amounts.netAmount.equals(amounts.grossAmount.minus(amounts.commissionAmount));
 }
+
+/** PAID `SUM(netAmount)` is empty → projection must be Decimal zero, not null. */
+export function paidLedgerSumOrZero(sum: Prisma.Decimal | null | undefined): Prisma.Decimal {
+  return sum ?? new Prisma.Decimal(0);
+}
+
+export function sellerProjectionMatchesLedger(
+  projected: Prisma.Decimal,
+  ledgerSum: Prisma.Decimal
+): boolean {
+  return projected.equals(ledgerSum);
+}
+
+export type SellerProjectionRow = {
+  id: string;
+  balance: Prisma.Decimal;
+};
+
+export type PaidLedgerSumRow = {
+  sellerId: string;
+  netAmount: Prisma.Decimal | null;
+};
+
+export type SellerProjectionDrift = {
+  sellerId: string;
+  projected: Prisma.Decimal;
+  ledgerSum: Prisma.Decimal;
+};
+
+/**
+ * Unlocked candidate scan. Callers must re-read `Seller.balance` and PAID SUM
+ * under `SELECT … FOR UPDATE` before correcting (issue #45).
+ */
+export function findSellerProjectionDrifts(
+  projections: SellerProjectionRow[],
+  paidSums: PaidLedgerSumRow[]
+): SellerProjectionDrift[] {
+  const ledgerBySeller = new Map<string, Prisma.Decimal>();
+  for (const row of paidSums) {
+    ledgerBySeller.set(row.sellerId, paidLedgerSumOrZero(row.netAmount));
+  }
+
+  const drifts: SellerProjectionDrift[] = [];
+  for (const seller of projections) {
+    const ledgerSum = ledgerBySeller.get(seller.id) ?? new Prisma.Decimal(0);
+    if (!sellerProjectionMatchesLedger(seller.balance, ledgerSum)) {
+      drifts.push({ sellerId: seller.id, projected: seller.balance, ledgerSum });
+    }
+  }
+  return drifts;
+}

--- a/server/src/shared/observability/__tests__/telemetry.test.ts
+++ b/server/src/shared/observability/__tests__/telemetry.test.ts
@@ -180,6 +180,8 @@ describe("OpenTelemetry runtime", () => {
     appMetrics.webhooksDuplicate();
     appMetrics.webhooksIgnored();
     appMetrics.webhooksFailed();
+    appMetrics.sellerLedgerDriftDetected();
+    appMetrics.sellerLedgerCorrected();
 
     const metrics = await collectMetrics();
     expect(sumMetric(metrics, "orders.created")).toBe(1);
@@ -187,6 +189,8 @@ describe("OpenTelemetry runtime", () => {
     expect(sumMetric(metrics, "orders.idempotency_conflict")).toBe(1);
     expect(sumMetric(metrics, "reservations.conflict")).toBe(1);
     expect(sumMetric(metrics, "paypal.webhooks.duplicate")).toBe(1);
+    expect(sumMetric(metrics, "seller.ledger.drift_detected")).toBe(1);
+    expect(sumMetric(metrics, "seller.ledger.corrected")).toBe(1);
     expect(telemetryContainsSensitive(await collectSpans(), metrics)).toBe(false);
   });
 

--- a/server/src/shared/observability/metrics.ts
+++ b/server/src/shared/observability/metrics.ts
@@ -26,6 +26,8 @@ type Instruments = {
   webhooksDuplicate: Counter;
   webhooksIgnored: Counter;
   webhooksFailed: Counter;
+  sellerLedgerDriftDetected: Counter;
+  sellerLedgerCorrected: Counter;
 };
 
 let instruments: Instruments | undefined;
@@ -99,6 +101,12 @@ function createInstruments(meter: Meter): Instruments {
     webhooksFailed: meter.createCounter("paypal.webhooks.failed", {
       description: "Failed PayPal webhooks",
     }),
+    sellerLedgerDriftDetected: meter.createCounter("seller.ledger.drift_detected", {
+      description: "Seller.balance disagreed with PAID ledger SUM",
+    }),
+    sellerLedgerCorrected: meter.createCounter("seller.ledger.corrected", {
+      description: "Seller.balance set to PAID ledger SUM",
+    }),
   };
 }
 
@@ -169,4 +177,6 @@ export const appMetrics = {
   webhooksDuplicate: (value = 1) => add(getInstruments().webhooksDuplicate, undefined, value),
   webhooksIgnored: (value = 1) => add(getInstruments().webhooksIgnored, undefined, value),
   webhooksFailed: (value = 1) => add(getInstruments().webhooksFailed, undefined, value),
+  sellerLedgerDriftDetected: (value = 1) => add(getInstruments().sellerLedgerDriftDetected, undefined, value),
+  sellerLedgerCorrected: (value = 1) => add(getInstruments().sellerLedgerCorrected, undefined, value),
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Job in-process compara `Seller.balance` com `SUM(netAmount)` PAID do ledger. Em divergência, a projeção é **atribuída** à soma (ledger vence) na mesma transação de um `AuditLog` de sistema. Linhas de ledger não são reescritas. Segunda passagem alinhada é no-op.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/45
ADR: `docs/adr/0011-seller-ledger.md`

## O que muda

- `reconcileSellerLedger()` com `FOR UPDATE` no seller.
- Timer `setInterval` 60s ao lado dos jobs de PayPal e expiração de reserva. Sem Redis, cron Render, SQS ou env var nova.
- Métrica/log estruturado; correção só depois do commit.
- Testes de match, drift corrigido uma vez, e corrida com `confirmPayment`.

## Verificação

- `cd server && npm run typecheck` → pass
- `cd server && npm run test:unit` → 221 passed
- `cd server && npm run test:integration` → 81 passed

Sem issue extra de residual (alerta é log/OTel, não pager).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

