### PR TITLE
#90 — [Product] Reconstruir a Home como vitrine de marketplace com descoberta, novidades e confiança

### DIFF
--- a/src/api/__tests__/sellers.test.ts
+++ b/src/api/__tests__/sellers.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listSellers } from "../sellers";
+
+const get = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    get: (...args: unknown[]) => get(...args),
+  },
+}));
+
+describe("listSellers", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue([]);
+  });
+
+  it("GETs /sellers with no query when called without params", async () => {
+    await listSellers();
+    expect(get).toHaveBeenCalledWith("/sellers");
+  });
+
+  it("sends approved=true when requested", async () => {
+    await listSellers({ approved: true });
+    expect(get).toHaveBeenCalledWith("/sellers?approved=true");
+  });
+});

--- a/src/api/sellers.ts
+++ b/src/api/sellers.ts
@@ -5,8 +5,15 @@ export function getSellerMe(): Promise<Seller> {
   return api.get<Seller>("/sellers/me");
 }
 
-export function listSellers(): Promise<Seller[]> {
-  return api.get<Seller[]>("/sellers");
+export function listSellers(params?: {
+  approved?: boolean;
+}): Promise<Seller[]> {
+  const search = new URLSearchParams();
+  if (typeof params?.approved === "boolean") {
+    search.set("approved", String(params.approved));
+  }
+  const qs = search.toString();
+  return api.get<Seller[]>(`/sellers${qs ? `?${qs}` : ""}`);
 }
 
 export function getSellerById(id: string): Promise<Seller> {

--- a/src/lib/__tests__/homeDiscovery.test.ts
+++ b/src/lib/__tests__/homeDiscovery.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Product } from "@/types/api";
+import { similarItemsMarketPath } from "@/lib/listingCartCta";
+import {
+  approvedSellersCountLabel,
+  catalogDiscoveryLinks,
+  listingsCountLabel,
+} from "../homeDiscovery";
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    collection: "The Huntsman Collection",
+    imageUrl: null,
+    isStattrak: false,
+    isSouvenir: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("catalogDiscoveryLinks", () => {
+  it("uses real Market productId queries and skips duplicate skins", () => {
+    const links = catalogDiscoveryLinks([
+      makeProduct(),
+      makeProduct({
+        id: "ak-redline-mw",
+        exterior: "Minimal Wear",
+      }),
+      makeProduct({
+        id: "awp-asiimov-ft",
+        weapon: "AWP",
+        skinName: "Asiimov",
+      }),
+    ]);
+
+    expect(links).toEqual([
+      {
+        productId: "ak-redline-ft",
+        label: "AK-47 | Redline",
+        href: similarItemsMarketPath("ak-redline-ft"),
+      },
+      {
+        productId: "awp-asiimov-ft",
+        label: "AWP | Asiimov",
+        href: similarItemsMarketPath("awp-asiimov-ft"),
+      },
+    ]);
+    expect(links.every((link) => !link.href.includes("#"))).toBe(true);
+  });
+});
+
+describe("live count labels", () => {
+  it("pluralizes listings and approved sellers", () => {
+    expect(listingsCountLabel(0)).toBe("0 listings ativos");
+    expect(listingsCountLabel(1)).toBe("1 listing ativo");
+    expect(approvedSellersCountLabel(1)).toBe("1 vendedor aprovado");
+    expect(approvedSellersCountLabel(3)).toBe("3 vendedores aprovados");
+  });
+});

--- a/src/lib/homeDiscovery.ts
+++ b/src/lib/homeDiscovery.ts
@@ -1,0 +1,66 @@
+import type { Product } from "@/types/api";
+import { similarItemsMarketPath } from "@/lib/listingCartCta";
+
+export const HOME_VALUE_PROP =
+  "Skins CS2 de item único, anunciadas por vendedores. A reserva começa no checkout; o pagamento é pelo PayPal.";
+
+export const HOME_NEW_HEADING = "Recém-anunciados";
+export const HOME_NEW_SORT_COPY =
+  "Listings ativos, ordenados do mais recente para o mais antigo.";
+
+export const HOME_SHORTCUTS_HEADING = "Descobrir no Market";
+export const HOME_SHORTCUTS_COPY =
+  "Atalhos para skins do catálogo. O Market filtra pelo productId.";
+
+export const HOME_TRUST_HEADING = "Como comprar";
+export const HOME_TRUST_ITEMS = [
+  "Cada listing é um item único.",
+  "A reserva acontece no checkout, quando o pagamento começa.",
+  "O pagamento é pelo PayPal. A confirmação vem do PayPal, não desta tela.",
+  "Vendedores passam por aprovação administrativa.",
+] as const;
+
+export const HOME_SELLER_CTA = "Vender no Neon Arsenal";
+export const HOME_EMPTY_TITLE = "Nenhum listing ativo";
+export const HOME_EMPTY_DESCRIPTION =
+  "Ainda não há itens no Market. Cadastre-se como vendedor para anunciar.";
+
+export const HOME_CATALOG_SHORTCUT_LIMIT = 6;
+export const HOME_LISTING_RAIL_LIMIT = 8;
+
+export interface CatalogShortcut {
+  productId: string;
+  label: string;
+  href: string;
+}
+
+/** Distinct weapon+skin from the catalog, each with a real Market productId query. */
+export function catalogDiscoveryLinks(
+  products: Product[],
+  limit = HOME_CATALOG_SHORTCUT_LIMIT,
+): CatalogShortcut[] {
+  const seen = new Set<string>();
+  const links: CatalogShortcut[] = [];
+  for (const product of products) {
+    const id = product.id.trim();
+    if (!id) continue;
+    const key = `${product.weapon}\0${product.skinName}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push({
+      productId: id,
+      label: `${product.weapon} | ${product.skinName}`,
+      href: similarItemsMarketPath(id),
+    });
+    if (links.length >= limit) break;
+  }
+  return links;
+}
+
+export function listingsCountLabel(total: number): string {
+  return total === 1 ? "1 listing ativo" : `${total} listings ativos`;
+}
+
+export function approvedSellersCountLabel(total: number): string {
+  return total === 1 ? "1 vendedor aprovado" : `${total} vendedores aprovados`;
+}

--- a/src/lib/homeDiscovery.ts
+++ b/src/lib/homeDiscovery.ts
@@ -10,7 +10,7 @@ export const HOME_NEW_SORT_COPY =
 
 export const HOME_SHORTCUTS_HEADING = "Descobrir no Market";
 export const HOME_SHORTCUTS_COPY =
-  "Atalhos para skins do catálogo. O Market filtra pelo productId.";
+  "Atalhos para skins do catálogo. Cada um abre o Market nessa skin.";
 
 export const HOME_TRUST_HEADING = "Como comprar";
 export const HOME_TRUST_ITEMS = [

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -36,7 +36,7 @@ export default function AdminDashboard() {
   });
   const sellersQuery = useQuery({
     queryKey: ["admin-sellers"],
-    queryFn: listSellers,
+    queryFn: () => listSellers(),
   });
   const productsQuery = useQuery({
     queryKey: ["admin-products"],

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,71 +3,198 @@ import { useQuery } from "@tanstack/react-query";
 import { ListingCard } from "@/components/ProductCard";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { listListings } from "@/api/listings";
+import { listProducts } from "@/api/products";
+import { listSellers } from "@/api/sellers";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { MARKET_VIEW_CTA } from "@/lib/listingCartCta";
+import {
+  HOME_EMPTY_DESCRIPTION,
+  HOME_EMPTY_TITLE,
+  HOME_LISTING_RAIL_LIMIT,
+  HOME_NEW_HEADING,
+  HOME_NEW_SORT_COPY,
+  HOME_SELLER_CTA,
+  HOME_SHORTCUTS_COPY,
+  HOME_SHORTCUTS_HEADING,
+  HOME_TRUST_HEADING,
+  HOME_TRUST_ITEMS,
+  HOME_VALUE_PROP,
+  approvedSellersCountLabel,
+  catalogDiscoveryLinks,
+  listingsCountLabel,
+} from "@/lib/homeDiscovery";
 
 export default function IndexPage() {
-  const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ["listings", { status: "ACTIVE", limit: 8 }],
-    queryFn: () => listListings({ status: "ACTIVE", limit: 8 }),
+  const listingsQuery = useQuery({
+    queryKey: [
+      "listings",
+      { status: "ACTIVE", limit: HOME_LISTING_RAIL_LIMIT },
+    ],
+    queryFn: () =>
+      listListings({ status: "ACTIVE", limit: HOME_LISTING_RAIL_LIMIT }),
   });
-  const listings = data?.items ?? [];
+  const productsQuery = useQuery({
+    queryKey: ["products", { limit: 24 }],
+    queryFn: () => listProducts({ limit: 24 }),
+  });
+  const sellersQuery = useQuery({
+    queryKey: ["sellers", { approved: true }],
+    queryFn: () => listSellers({ approved: true }),
+  });
+
+  const listings = listingsQuery.data?.items ?? [];
+  const listingsTotal = listingsQuery.data?.total;
+  const approvedSellerCount = sellersQuery.data?.length;
+  const shortcuts = catalogDiscoveryLinks(productsQuery.data?.items ?? []);
 
   return (
-    <div className="container py-10">
-      <div className="mb-10 max-w-xl">
+    <div className="container space-y-12 py-10">
+      <header className="max-w-2xl">
         <h1 className="text-3xl font-semibold tracking-tight">Neon Arsenal</h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Listings ativos · item único. Oito em destaque.
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          {HOME_VALUE_PROP}
         </p>
-        <Button asChild className="mt-6">
-          <Link to="/products">Ver Market</Link>
-        </Button>
-      </div>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Button asChild>
+            <Link to="/products">{MARKET_VIEW_CTA}</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link to="/register">{HOME_SELLER_CTA}</Link>
+          </Button>
+        </div>
+        {(!listingsQuery.isLoading && listingsTotal != null) ||
+        approvedSellerCount != null ? (
+          <p className="mt-4 flex flex-wrap gap-x-3 text-sm tabular-nums text-muted-foreground">
+            {!listingsQuery.isLoading && listingsTotal != null ? (
+              <span>{listingsCountLabel(listingsTotal)}</span>
+            ) : null}
+            {approvedSellerCount != null ? (
+              <span>{approvedSellersCountLabel(approvedSellerCount)}</span>
+            ) : null}
+          </p>
+        ) : null}
+      </header>
 
-      {isLoading ? (
-        <div
-          className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-          role="status"
-          aria-label="Carregando"
+      <section aria-labelledby="home-shortcuts-heading">
+        <h2
+          id="home-shortcuts-heading"
+          className="text-xl font-semibold tracking-tight"
         >
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="h-64 w-full" />
-          ))}
-        </div>
-      ) : null}
-
-      {isError ? (
-        <ErrorState
-          title="Erro ao carregar listings"
-          error={error}
-          action={
-            <Button type="button" variant="outline" onClick={() => refetch()}>
-              Tentar novamente
+          {HOME_SHORTCUTS_HEADING}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {HOME_SHORTCUTS_COPY}
+        </p>
+        {productsQuery.isLoading ? (
+          <div
+            className="mt-4 flex flex-wrap gap-2"
+            role="status"
+            aria-label="Carregando atalhos"
+          >
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-11 w-36" />
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link to="/products">{MARKET_VIEW_CTA}</Link>
             </Button>
-          }
-        />
-      ) : null}
+            {shortcuts.map((shortcut) => (
+              <Button
+                key={shortcut.productId}
+                asChild
+                variant="outline"
+                size="sm"
+              >
+                <Link to={shortcut.href}>{shortcut.label}</Link>
+              </Button>
+            ))}
+          </div>
+        )}
+      </section>
 
-      {!isLoading && !isError && listings.length === 0 ? (
-        <EmptyState
-          title="Nenhum listing ativo"
-          description="Quando houver itens, eles aparecem aqui."
-          action={
-            <Button asChild>
-              <Link to="/products">Ver Market</Link>
-            </Button>
-          }
-        />
-      ) : null}
+      <section aria-labelledby="home-new-heading">
+        <h2
+          id="home-new-heading"
+          className="text-xl font-semibold tracking-tight"
+        >
+          {HOME_NEW_HEADING}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {HOME_NEW_SORT_COPY}
+        </p>
 
-      {!isLoading && !isError && listings.length > 0 ? (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          {listings.map((listing) => (
-            <ListingCard key={listing.id} listing={listing} />
+        {listingsQuery.isLoading ? (
+          <div
+            className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+            role="status"
+            aria-label="Carregando"
+          >
+            {Array.from({ length: HOME_LISTING_RAIL_LIMIT }).map((_, i) => (
+              <Skeleton key={i} className="h-64 w-full" />
+            ))}
+          </div>
+        ) : null}
+
+        {listingsQuery.isError ? (
+          <ErrorState
+            title="Erro ao carregar listings"
+            error={listingsQuery.error}
+            action={
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => listingsQuery.refetch()}
+              >
+                Tentar novamente
+              </Button>
+            }
+          />
+        ) : null}
+
+        {!listingsQuery.isLoading &&
+        !listingsQuery.isError &&
+        listings.length === 0 ? (
+          <EmptyState
+            title={HOME_EMPTY_TITLE}
+            description={HOME_EMPTY_DESCRIPTION}
+            action={
+              <Button asChild>
+                <Link to="/register">{HOME_SELLER_CTA}</Link>
+              </Button>
+            }
+          />
+        ) : null}
+
+        {!listingsQuery.isLoading &&
+        !listingsQuery.isError &&
+        listings.length > 0 ? (
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {listings.map((listing) => (
+              <ListingCard key={listing.id} listing={listing} />
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      <section
+        aria-labelledby="home-trust-heading"
+        className="max-w-2xl border-t border-border pt-10"
+      >
+        <h2
+          id="home-trust-heading"
+          className="text-xl font-semibold tracking-tight"
+        >
+          {HOME_TRUST_HEADING}
+        </h2>
+        <ul className="mt-4 space-y-3 text-sm leading-relaxed text-muted-foreground">
+          {HOME_TRUST_ITEMS.map((item) => (
+            <li key={item}>{item}</li>
           ))}
-        </div>
-      ) : null}
+        </ul>
+      </section>
     </div>
   );
 }

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import IndexPage from "../Index";
+import { CartProvider } from "@/contexts/CartContext";
+import type { Listing, Product, Seller } from "@/types/api";
+import { ApiClientError, USER_FACING_NETWORK } from "@/lib/userFacingApiError";
+import { MARKET_VIEW_CTA, similarItemsMarketPath } from "@/lib/listingCartCta";
+import {
+  HOME_EMPTY_DESCRIPTION,
+  HOME_EMPTY_TITLE,
+  HOME_NEW_HEADING,
+  HOME_NEW_SORT_COPY,
+  HOME_SELLER_CTA,
+  HOME_SHORTCUTS_HEADING,
+  HOME_TRUST_HEADING,
+  HOME_TRUST_ITEMS,
+  HOME_VALUE_PROP,
+  approvedSellersCountLabel,
+  listingsCountLabel,
+} from "@/lib/homeDiscovery";
+
+const listListings = vi.fn();
+const listProducts = vi.fn();
+const listSellers = vi.fn();
+
+vi.mock("@/api/listings", () => ({
+  listListings: (...args: unknown[]) => listListings(...args),
+}));
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+vi.mock("@/api/sellers", () => ({
+  listSellers: (...args: unknown[]) => listSellers(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    collection: "The Huntsman Collection",
+    imageUrl: null,
+    isStattrak: false,
+    isSouvenir: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  const product = overrides.product ?? makeProduct();
+  return {
+    id: "listing-1",
+    productId: product.id,
+    sellerId: "seller-1",
+    floatValue: 0.14501234,
+    pattern: 456,
+    price: 22,
+    currency: "USD",
+    status: "ACTIVE",
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product,
+    seller: {
+      id: "seller-1",
+      storeName: "NeonTrader Store",
+      rating: 4.5,
+      user: { id: "user-1", name: "NeonTrader" },
+    },
+    ...overrides,
+  };
+}
+
+function makeSeller(overrides: Partial<Seller> = {}): Seller {
+  return {
+    id: "seller-1",
+    userId: "user-1",
+    storeName: "NeonTrader Store",
+    balance: 0,
+    rating: 4.5,
+    isApproved: true,
+    ...overrides,
+  };
+}
+
+function renderHome() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/"]}>
+        <CartProvider>
+          <Routes>
+            <Route path="/" element={<IndexPage />} />
+          </Routes>
+        </CartProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Index", () => {
+  beforeEach(() => {
+    listListings.mockReset();
+    listProducts.mockReset();
+    listSellers.mockReset();
+    listProducts.mockResolvedValue({
+      items: [
+        makeProduct(),
+        makeProduct({
+          id: "awp-asiimov-ft",
+          weapon: "AWP",
+          skinName: "Asiimov",
+        }),
+      ],
+      total: 2,
+      page: 1,
+      limit: 24,
+    });
+    listSellers.mockResolvedValue([
+      makeSeller(),
+      makeSeller({ id: "seller-2", userId: "user-2" }),
+    ]);
+  });
+
+  it("renders discovery home instead of only eight cards and one button", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 12,
+      page: 1,
+      limit: 8,
+    });
+
+    renderHome();
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(screen.getByText(HOME_VALUE_PROP)).toBeTruthy();
+    expect(screen.getByText(HOME_NEW_HEADING)).toBeTruthy();
+    expect(screen.getByText(HOME_NEW_SORT_COPY)).toBeTruthy();
+    expect(screen.getByText(HOME_SHORTCUTS_HEADING)).toBeTruthy();
+    expect(screen.getByText(HOME_TRUST_HEADING)).toBeTruthy();
+    for (const item of HOME_TRUST_ITEMS) {
+      expect(screen.getByText(item)).toBeTruthy();
+    }
+    expect(screen.getByText(listingsCountLabel(12))).toBeTruthy();
+    expect(screen.getByText(approvedSellersCountLabel(2))).toBeTruthy();
+
+    const marketLinks = screen.getAllByRole("link", { name: MARKET_VIEW_CTA });
+    expect(marketLinks.length).toBeGreaterThan(1);
+    expect(marketLinks[0]).toHaveAttribute("href", "/products");
+
+    expect(
+      screen.getByRole("link", { name: "AK-47 | Redline" }),
+    ).toHaveAttribute("href", similarItemsMarketPath("ak-redline-ft"));
+    expect(screen.getByRole("link", { name: "AWP | Asiimov" })).toHaveAttribute(
+      "href",
+      similarItemsMarketPath("awp-asiimov-ft"),
+    );
+    expect(screen.queryByRole("link", { name: /#/ })).toBeNull();
+
+    const sellerCtas = screen.getAllByRole("link", { name: HOME_SELLER_CTA });
+    expect(sellerCtas[0]).toHaveAttribute("href", "/register");
+
+    expect(screen.queryByText("Em destaque")).toBeNull();
+    expect(screen.queryByText("Continue de onde parou")).toBeNull();
+    expect(screen.queryByText(/Oito em destaque/i)).toBeNull();
+    expect(document.querySelector(".scan-lines")).toBeNull();
+    expect(document.querySelector(".neon-text")).toBeNull();
+
+    expect(listListings).toHaveBeenCalledWith({ status: "ACTIVE", limit: 8 });
+    expect(listSellers).toHaveBeenCalledWith({ approved: true });
+    expect(screen.getAllByText("AK-47 | Redline (Field-Tested)")).toHaveLength(
+      1,
+    );
+  });
+
+  it("keeps the hero visible and retries listings on error", async () => {
+    listListings
+      .mockRejectedValueOnce(
+        new ApiClientError(
+          "Could not reach API at http://localhost:3001/listings: Failed to fetch",
+          { code: "NETWORK" },
+        ),
+      )
+      .mockResolvedValueOnce({
+        items: [makeListing()],
+        total: 1,
+        page: 1,
+        limit: 8,
+      });
+
+    renderHome();
+
+    expect(await screen.findByText("Erro ao carregar listings")).toBeTruthy();
+    expect(screen.getByText(USER_FACING_NETWORK)).toBeTruthy();
+    expect(screen.getByText("Neon Arsenal")).toBeTruthy();
+    expect(screen.getByText(HOME_VALUE_PROP)).toBeTruthy();
+    expect(screen.queryByText(/localhost/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+  });
+
+  it("explains an empty catalog and points to seller registration", async () => {
+    listListings.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 8,
+    });
+
+    renderHome();
+
+    expect(await screen.findByText(HOME_EMPTY_TITLE)).toBeTruthy();
+    expect(screen.getByText(HOME_EMPTY_DESCRIPTION)).toBeTruthy();
+    expect(screen.getByText(listingsCountLabel(0))).toBeTruthy();
+    const emptySeller = screen.getAllByRole("link", { name: HOME_SELLER_CTA });
+    expect(
+      emptySeller.some((link) => link.getAttribute("href") === "/register"),
+    ).toBe(true);
+    expect(screen.queryByText("Em destaque")).toBeNull();
+  });
+
+  it("shows listing rail skeletons while the catalog loads", async () => {
+    let resolveListings: (value: unknown) => void = () => undefined;
+    listListings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveListings = resolve;
+      }),
+    );
+
+    renderHome();
+
+    expect(screen.getByLabelText("Carregando")).toBeTruthy();
+    expect(screen.getByText("Neon Arsenal")).toBeTruthy();
+
+    resolveListings({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 8,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    });
+  });
+});

--- a/src/pages/admin/AdminSellers.tsx
+++ b/src/pages/admin/AdminSellers.tsx
@@ -35,7 +35,7 @@ export default function AdminSellers() {
     refetch,
   } = useQuery({
     queryKey: ["admin-sellers"],
-    queryFn: listSellers,
+    queryFn: () => listSellers(),
   });
 
   const approveSeller = useMutation({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A Home deixa de ser só 8 cards + um botão. Vira vitrine de descoberta com proposta de valor, atalhos para o Market, um rail “Recém-anunciados” (`createdAt desc`), bloco de confiança e contagens reais.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/90

## O que muda

- Hero + CTAs Market e cadastro seller (`/register`).
- Atalhos de catálogo via `/products?productId=` (#146).
- Um único rail de listings (sem duplicar os mesmos 8 IDs).
- Contagem de listings ACTIVE e sellers aprovados (`GET /sellers?approved=true`).
- Loading / empty / error PT (#88) mantidos.
- Sem rail de “recentemente vistos” (#105) e sem APIs novas.

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 38 files, 199 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

