### PR TITLE
#46 — P1 — Implementar Outbox Pattern

### DIFF
--- a/docs/adr/0012-transactional-outbox.md
+++ b/docs/adr/0012-transactional-outbox.md
@@ -1,0 +1,33 @@
+# ADR 0012 — Transactional outbox (in-process)
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #46. Payment confirmation already mutates order, listings, seller ledger, and audit in one PostgreSQL transaction. Downstream consumers (metrics, later integrations) must not run inside that transaction, and must not require a second `confirmPayment`. A lost in-process side effect after commit should be retryable without duplicating the domain write.
+
+The project is a modular monolith. PostgreSQL is the source of truth. Redis, Kafka, RabbitMQ, SQS, and a broker-backed worker are forbidden here (ADR 0007 keeps Render; issue #53 SQS is a later, separate decision). In-process jobs already exist: reservation expiry, PayPal GET reconciliation, seller-ledger reconciliation (`setInterval` + `unref`).
+
+PayPal `OrdersCreate` / `OrdersCapture` stay unretried. Outbox processing is local database work plus structured logs/metrics, not a PayPal call.
+
+## Decision
+
+1. Persist an `OutboxEvent` row in the **same local database transaction** as the domain mutation that produced it. PayPal HTTP stays outside that transaction.
+2. First events: `PAYMENT_CONFIRMED` and `ORDER_CONFIRMED`, both written from `paymentsService.confirmPayment` because that path already transitions `paymentStatus PENDING → PAID` and `status PENDING → CONFIRMED` together. Duplicate confirm (`updateMany` count = 0) does not insert.
+3. Schema: `id`, `type`, `aggregateId`, `payload` (non-secret JSON), `status` (`PENDING` / `PROCESSING` / `PUBLISHED` / `FAILED`), `attempts`, `availableAt`, `claimedAt`, `lastError`, `createdAt`. Unique `(type, aggregateId)` is defense in depth against double-insert. Payload is order id and statuses only; tokens, passwords, and PayPal secrets are never stored (writers sanitize known secret keys).
+4. Dispatch with the existing in-process job pattern: interval + `unref`, started from `startApiProcess`. Claim due `PENDING` rows, or stale `PROCESSING` rows (crash after claim), with `FOR UPDATE SKIP LOCKED`. Bounded retries with exponential backoff; then `FAILED`. Re-processing a `PUBLISHED` row (conditional `PROCESSING → PUBLISHED`) is a no-op.
+5. First handler is structured log + counters (`outbox.published` / `outbox.retry` / `outbox.failed`). It does **not** call `confirmPayment` again and does not write seller ledger. Optional `AuditLog` is omitted here because payment confirmation already records `PAYMENT_CONFIRMED` in the domain transaction.
+6. Do not implement SQS, SNS, Kafka, or a second process. Multiple API replicas are safe because claim uses skip-locked rows.
+
+## Rollback
+
+Drop `OutboxEvent` and `OutboxEventStatus`. Remove the enqueue calls and the dispatcher job from `startApiProcess`. Domain confirmation, webhook authenticity, and PayPal capture semantics are unchanged.
+
+## Consequences
+
+- A thrown listing-sell / ledger failure rolls back the outbox row with the payment claim.
+- A process crash after confirm commit and before publish leaves `PENDING` (or stale `PROCESSING`) rows; the next sweep publishes them.
+- Handler logs/metrics may repeat if a crash lands after the handler and before `PUBLISHED`; the domain effect does not. Publish metrics increment only on a successful status transition.
+- This is not a general event bus. New event types are added per use case, still in the producing transaction.

--- a/docs/architecture/c4.md
+++ b/docs/architecture/c4.md
@@ -180,7 +180,7 @@ C4Component
     Component(orders, "orders", "modules/orders", "Checkout + Idempotency-Key")
     Component(payments, "payments", "modules/payments", "PaymentLink, webhook, confirmPayment")
     Component(other, "other domains", "users, sellers, products, commissions, reviews, admin")
-    Component(jobs, "in-process jobs", "shared/jobs", "Expiry + PayPal GET + seller ledger reconcile")
+    Component(jobs, "in-process jobs", "shared/jobs", "Expiry + PayPal GET + seller ledger reconcile + outbox")
     Component(paypalc, "PayPal adapter", "shared/utils", "Create/capture/GET; webhook RSA-SHA256")
     ComponentDb(db, "PostgreSQL", "Prisma")
   }

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -32,7 +32,7 @@ Express API --> PayPal
 Express API --> Resend
 ```
 
-The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts` and `startApiProcess`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling. `startApiProcess` binds `0.0.0.0:$PORT`, starts the in-process reservation-expiry, PayPal-reconciliation, and seller-ledger-reconciliation jobs, and registers SIGTERM/SIGINT graceful shutdown (drain HTTP, stop jobs, disconnect Prisma, shut down telemetry). `GET /ready` returns 503 `shutting_down` after shutdown begins.
+The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts` and `startApiProcess`. The app applies request IDs, HTTP server spans, CORS, JSON parsing, rate limiting, health/docs routes, domain routes, 404 handling and centralized error handling. `startApiProcess` binds `0.0.0.0:$PORT`, starts the in-process reservation-expiry, PayPal-reconciliation, seller-ledger-reconciliation, and outbox-dispatcher jobs, and registers SIGTERM/SIGINT graceful shutdown (drain HTTP, stop jobs, disconnect Prisma, shut down telemetry). `GET /ready` returns 503 `shutting_down` after shutdown begins.
 
 Observability is optional. `OTEL_ENABLED` defaults to off so `npm run dev` does not need a collector. See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
 
@@ -62,7 +62,7 @@ This is not an emergency rewrite target. Agents should avoid broad refactors. Wh
 
 PostgreSQL is the source of truth for business state. Prisma is the data-access layer.
 
-The schema contains the main marketplace entities: users, pending registrations, sellers, products, listings, orders, order items, seller transactions, payment webhook events, reviews, revoked tokens and an append-only `AuditLog`. Listings contain reservation fields `reservedAt`, `reservationExpiresAt` and `reservedByOrderId`. `PaymentWebhookEvent` stores PayPal event identity with a unique `(provider, externalEventId)` constraint. Critical lifecycle columns (`User.role`, `Order.status`, `Order.paymentStatus`, `Listing.status`, payment-link and idempotency claim status, webhook processing status/provider, seller-transaction status) are PostgreSQL enums. PayPal `eventType` stays text so unknown provider events can be persisted and ignored. See `docs/adr/0009-prisma-domain-enums.md`. `AuditLog` records ADMIN/seller listing/order/payment mutations with ADMIN-only read access and a 365-day retention policy (`docs/adr/0010-audit-log.md`).
+The schema contains the main marketplace entities: users, pending registrations, sellers, products, listings, orders, order items, seller transactions, payment webhook events, reviews, revoked tokens, an append-only `AuditLog`, and a transactional `OutboxEvent` table. Listings contain reservation fields `reservedAt`, `reservationExpiresAt` and `reservedByOrderId`. `PaymentWebhookEvent` stores PayPal event identity with a unique `(provider, externalEventId)` constraint. Critical lifecycle columns (`User.role`, `Order.status`, `Order.paymentStatus`, `Listing.status`, payment-link and idempotency claim status, webhook processing status/provider, seller-transaction status, outbox processing status) are PostgreSQL enums. PayPal `eventType` stays text so unknown provider events can be persisted and ignored. See `docs/adr/0009-prisma-domain-enums.md`. `AuditLog` records ADMIN/seller listing/order/payment mutations with ADMIN-only read access and a 365-day retention policy (`docs/adr/0010-audit-log.md`). `OutboxEvent` is inserted in the same local transaction as payment confirmation and published by an in-process skip-locked dispatcher (`docs/adr/0012-transactional-outbox.md`).
 
 ## Critical workflows
 
@@ -87,11 +87,11 @@ Webhook handling:
 1. Capture the raw body and verify RSA-SHA256 using `PAYPAL_WEBHOOK_ID` and the certificate at `paypal-cert-url`. `paypal-transmission-time` must be within 5 minutes of the server clock.
 2. Claim `PaymentWebhookEvent` by PayPal event id (`id`, e.g. `WH-...`).
 3. Confirm locally only on `PAYMENT.CAPTURE.COMPLETED`. `CHECKOUT.ORDER.APPROVED` is persisted as ignored.
-4. `confirmPayment` claims the pending order, sells held listings, and writes `SellerTransaction` (authoritative ledger) plus the `Seller.balance` projection in one PostgreSQL transaction (ADR 0011).
+4. `confirmPayment` claims the pending order, sells held listings, writes `SellerTransaction` (authoritative ledger) plus the `Seller.balance` projection, and inserts `PAYMENT_CONFIRMED` / `ORDER_CONFIRMED` outbox rows in one PostgreSQL transaction (ADR 0011, ADR 0012).
 
 A process crash after PayPal capture is recovered by webhook retry (unique event id) or the in-process reconciliation job, which GETs PayPal order status for stale `PENDING` orders (every 60s, minimum age 2 minutes, batch 20) and reuses `confirmPayment`.
 
-Critical workflows emit explicit spans (`orders.create`, `listings.reserve`, `payments.confirm`, `paypal.webhook.*`, `payments.reconcile`, `seller.ledger.reconcile`) and low-cardinality business counters. Expected 4xx results use `app.outcome` and are not marked span `ERROR`. Prisma calls get `db.prisma` spans without SQL text or parameters. PayPal HTTP uses stable operation names such as `paypal.orders_create`.
+Critical workflows emit explicit spans (`orders.create`, `listings.reserve`, `payments.confirm`, `paypal.webhook.*`, `payments.reconcile`, `seller.ledger.reconcile`, `outbox.dispatch`) and low-cardinality business counters. Expected 4xx results use `app.outcome` and are not marked span `ERROR`. Prisma calls get `db.prisma` spans without SQL text or parameters. PayPal HTTP uses stable operation names such as `paypal.orders_create`.
 
 ## Testing
 

--- a/docs/architecture/domain-invariants.md
+++ b/docs/architecture/domain-invariants.md
@@ -71,6 +71,7 @@ IDs: `INV-PAYMENT-TRUSTED-CONFIRM`, `INV-PAYMENT-WEBHOOK-AUTHENTIC`, `INV-PAYMEN
 9. External PayPal calls have an explicit timeout. Creating or capturing a PayPal order is not retried. Looking up PayPal order status, fetching an OAuth token, or downloading a webhook certificate may retry HTTP 5xx/429, timeouts and network errors (max 3 attempts, exponential backoff).
 10. `POST /payments` (create payment link) is idempotent per local order. A durable `PaymentLink` row claims the order before `OrdersCreate`. A retry that finds `paypalOrderId` or a completed `PaymentLink` must return the original PayPal order without calling `OrdersCreate` again. Concurrent identical requests have one `OrdersCreate`. An in-progress claim returns HTTP 409.
 11. Optional `returnUrl` and `cancelUrl` on `POST /payments/create` are forwarded to PayPal `OrdersCreate` as `application_context.return_url` / `cancel_url` when present, and omitted when absent. The server does not invent defaults or env-based URLs. Buyer return/cancel at PayPal does not mark the order `PAID`; confirmation remains webhook or reconciliation.
+12. `confirmPayment` inserts `PAYMENT_CONFIRMED` and `ORDER_CONFIRMED` outbox rows in the same local transaction as the domain write. Duplicate confirm does not insert again. An in-process dispatcher claims with `FOR UPDATE SKIP LOCKED`. The first handler is log + metric only and must not confirm payment again (`docs/adr/0012-transactional-outbox.md`).
 
 ## Seller finances
 
@@ -117,6 +118,7 @@ Critical lifecycle fields are PostgreSQL/Prisma enums so invalid labels cannot b
 - `ListingStatus` — `Listing.status` (`ACTIVE`, `SOLD`, `RESERVED`, `CANCELED`)
 - `ClaimStatus` — `PaymentLink.status`, `OrderIdempotencyKey.status` (`IN_PROGRESS`, `COMPLETED`)
 - `WebhookEventStatus` / `PaymentProvider` — `PaymentWebhookEvent.status` and `.provider`
+- `OutboxEventStatus` — `OutboxEvent.status` (`PENDING`, `PROCESSING`, `PUBLISHED`, `FAILED`)
 
 `PaymentWebhookEvent.eventType` remains text so unknown PayPal events can still be claimed and marked `IGNORED`. Catalog fields (game, rarity, exterior, currency) are not enums.
 

--- a/docs/architecture/failure-modes.md
+++ b/docs/architecture/failure-modes.md
@@ -69,14 +69,18 @@ Should Neon Arsenal later reverse captured funds automatically, and with which *
 On SIGTERM/SIGINT the API:
 
 1. Marks itself shutting down (`GET /ready` returns 503 `shutting_down`).
-2. Stops reservation-expiry, PayPal-reconciliation, and seller-ledger-reconciliation timers (in-flight sweeps may finish).
+2. Stops reservation-expiry, PayPal-reconciliation, seller-ledger-reconciliation, and outbox-dispatcher timers (in-flight sweeps may finish).
 3. Stops accepting new HTTP connections and drains in-flight requests for up to 10s, then closes remaining connections.
 4. Disconnects Prisma.
 5. Shuts down OpenTelemetry exporters.
 
 `GET /health` remains 200 until exit so liveness probes do not kill a draining instance early. New work is refused by `server.close()` and by `/ready`.
 
-A crash during shutdown is the same as any other crash: PostgreSQL constraints plus webhook/reconciliation recover payment; the next process starts new job timers.
+A crash during shutdown is the same as any other crash: PostgreSQL constraints plus webhook/reconciliation recover payment; unpublished outbox rows stay `PENDING` or stale `PROCESSING` and are claimed by the next process; the next process starts new job timers.
+
+## Transactional outbox
+
+Payment confirmation inserts `PAYMENT_CONFIRMED` and `ORDER_CONFIRMED` in the same local transaction as the domain write (`docs/adr/0012-transactional-outbox.md`). Duplicate confirm does not insert again. The in-process dispatcher claims with `FOR UPDATE SKIP LOCKED`, retries with bounded backoff, and treats a second publish of `PUBLISHED` as a no-op. The first handler is log + metric only; it does not confirm payment again. Crash after claim: stale `PROCESSING` rows are reclaimed. This is not SQS.
 
 ## What this document does not add
 

--- a/docs/architecture/scaling-path.md
+++ b/docs/architecture/scaling-path.md
@@ -10,7 +10,7 @@ Client  →  Express API (one or more replicas)
               →  PayPal / Resend (timeouts, classified retries)
 ```
 
-Replicas do not shard business state. Reservation, idempotency and payment confirmation are conditional writes and unique constraints. Extra API processes only add more in-process sweeps, which are already idempotent.
+Replicas do not shard business state. Reservation, idempotency and payment confirmation are conditional writes and unique constraints. Extra API processes only add more in-process sweeps (expiry, PayPal GET, seller ledger, outbox), which are already idempotent.
 
 ## What is fast enough today
 

--- a/docs/architecture/threat-model.md
+++ b/docs/architecture/threat-model.md
@@ -109,7 +109,7 @@ These are **implemented**. Threats below assume an attacker trying to bypass the
   - `PAYPAL_WEBHOOK_ID` **required in production** (missing → verify returns false). **Skipped outside production if unset** (local/test convenience — a real gap if a public URL runs with non-production `NODE_ENV`).
 - Duplicate events: unique `(provider, externalEventId)` on `PaymentWebhookEvent`.
 - Only `PAYMENT.CAPTURE.COMPLETED` confirms sale. `CHECKOUT.ORDER.APPROVED` is stored as **IGNORED** (buyer approval ≠ capture).
-- Payment confirmation uses a conditional claim (unpaid order + still-held reservation) inside one PostgreSQL transaction with listing `SOLD` and seller ledger (ADR 0002).
+- Payment confirmation uses a conditional claim (unpaid order + still-held reservation) inside one PostgreSQL transaction with listing `SOLD`, seller ledger, and outbox rows (ADR 0002, ADR 0012).
 - Capture after reservation expiry: local conflict; HTTP **200** to PayPal so the provider stops retrying; listing is **not** SOLD. Manual PayPal refund/void is an **open human decision** — there is **no** refund API in this codebase.
 - Lost captures may be recovered by an **in-process PayPal order GET** sweep (ADR 0002). That path still cannot sell an expired reservation.
 

--- a/docs/domain/invariants.md
+++ b/docs/domain/invariants.md
@@ -82,8 +82,8 @@ Related IDs below keep this catalog aligned with the architecture narrative. Cit
 
 - Schema: `Order.paymentStatus` is `PaymentStatus`. `PaymentWebhookEvent` unique `(provider, externalEventId)`.
 - HTTP: `POST /payments/create` (authenticated customer) opens a PayPal order; `POST /payments/webhook` verifies PayPal headers then confirms. There is no `POST /payments/confirm`. `PATCH /orders/:id/status` accepts only fulfillment `status`; unknown `paymentStatus` on that body is stripped. CUSTOMER cannot `PENDING → CONFIRMED`.
-- Service: `confirmPayment` claims `paymentStatus = PENDING AND status = PENDING`. Duplicate claims are no-ops. Expired/mismatched reservations roll back the claim (HTTP 409).
-- Tests: `server/src/__tests__/paypal.webhook.integration.test.ts`; `server/src/modules/payments/__tests__/payments.controller.test.ts` (signature required); `server/src/modules/payments/__tests__/payments.service.test.ts`; `server/src/__tests__/order.status.integration.test.ts` (CUSTOMER cannot skip payment; cancel leaves `paymentStatus` PENDING); `server/src/shared/types/__tests__/roles.test.ts` (status DTO strips `paymentStatus`).
+- Service: `confirmPayment` claims `paymentStatus = PENDING AND status = PENDING`. Duplicate claims are no-ops. Expired/mismatched reservations roll back the claim (HTTP 409). The same transaction inserts `PAYMENT_CONFIRMED` and `ORDER_CONFIRMED` outbox rows (ADR 0012).
+- Tests: `server/src/__tests__/paypal.webhook.integration.test.ts`; `server/src/modules/payments/__tests__/payments.controller.test.ts` (signature required); `server/src/modules/payments/__tests__/payments.service.test.ts`; `server/src/__tests__/order.status.integration.test.ts` (CUSTOMER cannot skip payment; cancel leaves `paymentStatus` PENDING); `server/src/shared/types/__tests__/roles.test.ts` (status DTO strips `paymentStatus`); `server/src/__tests__/outbox.integration.test.ts`.
 
 **Related:** `INV-PAYMENT-WEBHOOK-AUTHENTIC`, `INV-PAYMENT-WEBHOOK-IDEMPOTENT`, `INV-PAYMENT-LINK-IDEMPOTENT`.
 
@@ -158,6 +158,8 @@ These are already specified in the architecture narrative. This table is the ID 
 | `INV-SELLER-TXN-UNIQUE` | One seller transaction per `(sellerId, orderId)`. | schema unique + confirm claim | `postgres.constraints.integration.test.ts`, `seller.ledger.integration.test.ts` |
 | `INV-AUDIT-APPEND-ONLY` | Sensitive mutations append `AuditLog`; ADMIN-only read; 365-day retention; no secrets on the trail. | `auditRepository`, `GET /admin/audit-logs` | `audit.integration.test.ts`, `docs/adr/0010-audit-log.md` |
 | `INV-DB-ENUMS` | Lifecycle columns are PostgreSQL enums; invalid labels fail with `22P02`. | Prisma enums | `postgres.enums.integration.test.ts`, `roles.test.ts` |
+
+Transactional outbox (#46) is implemented: `OutboxEvent` in the confirm transaction, in-process skip-locked dispatcher, no SQS. See `docs/adr/0012-transactional-outbox.md`.
 
 ## Changing an invariant
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -42,6 +42,7 @@ Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second
 | `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
 | `payments.reconcile` | PayPal GET reconciliation batch |
 | `seller.ledger.reconcile` | Seller.balance vs PAID ledger SUM |
+| `outbox.dispatch` | Claim and publish transactional outbox rows |
 | `paypal.webhook.verify` | Webhook signature verification |
 | `paypal.webhook.handle` | Event claim, ignore, confirm or fail |
 | `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP |
@@ -77,6 +78,7 @@ Business counters (no labels):
 - `payments.confirmed`, `payments.failed`
 - `paypal.webhooks.received`, `paypal.webhooks.duplicate`, `paypal.webhooks.ignored`, `paypal.webhooks.failed`
 - `seller.ledger.drift_detected`, `seller.ledger.corrected`
+- `outbox.published`, `outbox.retry`, `outbox.failed`
 
 There is no `orders.pending` gauge. That would scrape PostgreSQL on a timer; query `Order` where `paymentStatus = PENDING` when you need the count.
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -36,7 +36,7 @@ A new Render deploy does not take traffic until `GET /ready` is 2xx/3xx (Postgre
 On SIGTERM/SIGINT (`docs/adr/0005-external-retry-and-graceful-shutdown.md`):
 
 1. Mark shutting down → `GET /ready` is 503 `shutting_down`.
-2. Stop reservation-expiry, PayPal-reconciliation, and seller-ledger-reconciliation timers (in-flight sweeps may finish).
+2. Stop reservation-expiry, PayPal-reconciliation, seller-ledger-reconciliation, and outbox-dispatcher timers (in-flight sweeps may finish).
 3. `server.close()`: no new HTTP connections; in-flight requests get **10s** (`SHUTDOWN_DRAIN_MS`), then remaining connections are closed.
 4. Disconnect Prisma.
 5. Shut down OpenTelemetry exporters.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,6 +91,18 @@ Implemented:
 
 See `docs/performance.md`, `docs/architecture/scaling-path.md` and `docs/adr/0006-hot-path-indexes.md`.
 
+### P1.5 Transactional outbox
+
+Implemented:
+
+- `OutboxEvent` committed in the same PostgreSQL transaction as payment confirmation (`PAYMENT_CONFIRMED` / `ORDER_CONFIRMED`);
+- in-process dispatcher (`setInterval` + `unref` + `FOR UPDATE SKIP LOCKED`);
+- bounded retries, backoff, stale-claim recovery, unique `(type, aggregateId)`;
+- first handler is structured log + metrics (no second `confirmPayment`);
+- not SQS / Kafka / Redis.
+
+See `docs/adr/0012-transactional-outbox.md`.
+
 ## P2 — Cloud and operational maturity
 
 **Current production** (see `docs/adr/0007-cloud-target-render.md`):

--- a/server/prisma/migrations/20260905220000_outbox_event/migration.sql
+++ b/server/prisma/migrations/20260905220000_outbox_event/migration.sql
@@ -1,0 +1,24 @@
+-- Transactional outbox (docs/adr/0012-transactional-outbox.md).
+-- Events commit in the same local transaction as the domain mutation.
+-- PayPal HTTP stays outside that transaction. No secrets in payload.
+
+CREATE TYPE "OutboxEventStatus" AS ENUM ('PENDING', 'PROCESSING', 'PUBLISHED', 'FAILED');
+
+CREATE TABLE "OutboxEvent" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "aggregateId" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status" "OutboxEventStatus" NOT NULL DEFAULT 'PENDING',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "availableAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "claimedAt" TIMESTAMP(3),
+    "lastError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OutboxEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "OutboxEvent_type_aggregateId_key" ON "OutboxEvent"("type", "aggregateId");
+CREATE INDEX "OutboxEvent_status_availableAt_idx" ON "OutboxEvent"("status", "availableAt");
+CREATE INDEX "OutboxEvent_aggregateId_idx" ON "OutboxEvent"("aggregateId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -53,6 +53,13 @@ enum PaymentProvider {
   PAYPAL
 }
 
+enum OutboxEventStatus {
+  PENDING
+  PROCESSING
+  PUBLISHED
+  FAILED
+}
+
 model User {
   id        String   @id @default(cuid())
   name      String
@@ -329,4 +336,26 @@ model AuditLog {
   @@index([createdAt])
   @@index([resourceType, resourceId])
   @@index([actorId])
+}
+
+// Transactional outbox (issue #46 / ADR 0012). Inserted in the same local
+// PostgreSQL transaction as the domain mutation. PayPal HTTP stays outside.
+// Payload is non-secret JSON (order ids, statuses). No tokens, passwords,
+// or provider secrets. Unique (type, aggregateId) makes a second insert for
+// the same confirmation a constraint violation rather than a duplicate event.
+model OutboxEvent {
+  id          String            @id @default(cuid())
+  type        String
+  aggregateId String
+  payload     Json
+  status      OutboxEventStatus @default(PENDING)
+  attempts    Int               @default(0)
+  availableAt DateTime          @default(now())
+  claimedAt   DateTime?
+  lastError   String?
+  createdAt   DateTime          @default(now())
+
+  @@unique([type, aggregateId])
+  @@index([status, availableAt])
+  @@index([aggregateId])
 }

--- a/server/src/__tests__/helpers/lifecycle.ts
+++ b/server/src/__tests__/helpers/lifecycle.ts
@@ -27,6 +27,7 @@ export const BUSINESS_TABLES = [
   "PendingRegistration",
   "RevokedToken",
   "AuditLog",
+  "OutboxEvent",
   "User",
 ] as const;
 

--- a/server/src/__tests__/outbox.integration.test.ts
+++ b/server/src/__tests__/outbox.integration.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../shared/database/index.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import { dispatchOutboxEvents } from "../shared/outbox/outbox.dispatcher.js";
+import { OutboxEventType } from "../shared/outbox/outbox.types.js";
+import { OUTBOX_CLAIM_TIMEOUT_MS, OUTBOX_MAX_ATTEMPTS } from "../shared/config/outbox.js";
+import { createCheckoutGraph, createOrder, orderKey } from "./helpers/index.js";
+
+async function confirmFreshOrder() {
+  const fixture = await createCheckoutGraph();
+  const created = await createOrder(
+    fixture.customer.id,
+    [fixture.listings[0].id],
+    orderKey("outbox-confirm")
+  );
+  await paymentsService.confirmPayment(created.id);
+  return { fixture, orderId: created.id };
+}
+
+describe("transactional outbox (postgres)", () => {
+  it("inserts PAYMENT_CONFIRMED and ORDER_CONFIRMED in the same transaction as confirm", async () => {
+    const { orderId } = await confirmFreshOrder();
+
+    const events = await prisma.outboxEvent.findMany({
+      where: { aggregateId: orderId },
+      orderBy: { type: "asc" },
+    });
+    const order = await prisma.order.findUnique({ where: { id: orderId } });
+
+    expect(order?.paymentStatus).toBe("PAID");
+    expect(order?.status).toBe("CONFIRMED");
+    expect(events.map((event) => event.type).sort()).toEqual([
+      OutboxEventType.ORDER_CONFIRMED,
+      OutboxEventType.PAYMENT_CONFIRMED,
+    ]);
+    expect(events.every((event) => event.status === "PENDING")).toBe(true);
+    expect(events.every((event) => event.attempts === 0)).toBe(true);
+    for (const event of events) {
+      const payload = event.payload as { orderId?: string };
+      expect(payload.orderId).toBe(orderId);
+    }
+  });
+
+  it("rolls back outbox rows when the payment claim cannot sell listings", async () => {
+    const fixture = await createCheckoutGraph();
+    const created = await createOrder(
+      fixture.customer.id,
+      [fixture.listings[0].id],
+      orderKey("outbox-rollback")
+    );
+    await prisma.listing.update({
+      where: { id: fixture.listings[0].id },
+      data: { reservationExpiresAt: new Date(Date.now() - 1_000) },
+    });
+
+    await expect(paymentsService.confirmPayment(created.id)).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    const order = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(order?.paymentStatus).toBe("PENDING");
+    expect(await prisma.outboxEvent.count({ where: { aggregateId: created.id } })).toBe(0);
+  });
+
+  it("does not insert a second pair on duplicate confirmPayment", async () => {
+    const { orderId } = await confirmFreshOrder();
+    await paymentsService.confirmPayment(orderId);
+    await paymentsService.confirmPayment(orderId);
+
+    expect(await prisma.outboxEvent.count({ where: { aggregateId: orderId } })).toBe(2);
+    expect(
+      await prisma.outboxEvent.count({
+        where: { aggregateId: orderId, type: OutboxEventType.PAYMENT_CONFIRMED },
+      })
+    ).toBe(1);
+  });
+
+  it("rejects a duplicate (type, aggregateId) insert at PostgreSQL", async () => {
+    const { orderId } = await confirmFreshOrder();
+
+    let caught: unknown;
+    try {
+      await prisma.outboxEvent.create({
+        data: {
+          type: OutboxEventType.PAYMENT_CONFIRMED,
+          aggregateId: orderId,
+          payload: { orderId },
+        },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+    expect((caught as Prisma.PrismaClientKnownRequestError).code).toBe("P2002");
+    expect(await prisma.outboxEvent.count({ where: { aggregateId: orderId } })).toBe(2);
+  });
+
+  it("publishes claimed rows once; a second sweep is a no-op", async () => {
+    const { orderId } = await confirmFreshOrder();
+
+    const first = await dispatchOutboxEvents();
+    const second = await dispatchOutboxEvents();
+
+    const events = await prisma.outboxEvent.findMany({ where: { aggregateId: orderId } });
+    expect(first.published).toBe(2);
+    expect(second.published).toBe(0);
+    expect(second.claimed).toBe(0);
+    expect(events).toHaveLength(2);
+    expect(events.every((event) => event.status === "PUBLISHED")).toBe(true);
+    expect(events.every((event) => event.attempts === 1)).toBe(true);
+  });
+
+  it("retries a crash after claim by reclaiming stale PROCESSING rows", async () => {
+    const { orderId } = await confirmFreshOrder();
+    const staleAt = new Date(Date.now() - OUTBOX_CLAIM_TIMEOUT_MS - 1_000);
+    await prisma.outboxEvent.updateMany({
+      where: { aggregateId: orderId },
+      data: { status: "PROCESSING", claimedAt: staleAt, attempts: 1 },
+    });
+
+    const result = await dispatchOutboxEvents();
+    const events = await prisma.outboxEvent.findMany({ where: { aggregateId: orderId } });
+
+    expect(result.published).toBe(2);
+    expect(events.every((event) => event.status === "PUBLISHED")).toBe(true);
+    expect(events.every((event) => event.attempts === 2)).toBe(true);
+  });
+
+  it("lets only one concurrent dispatcher claim each row", async () => {
+    const { orderId } = await confirmFreshOrder();
+
+    const results = await Promise.all([dispatchOutboxEvents(), dispatchOutboxEvents()]);
+    const published = results.reduce((sum, result) => sum + result.published, 0);
+    const claimed = results.reduce((sum, result) => sum + result.claimed, 0);
+    const events = await prisma.outboxEvent.findMany({ where: { aggregateId: orderId } });
+
+    expect(published).toBe(2);
+    expect(claimed).toBe(2);
+    expect(events.every((event) => event.status === "PUBLISHED")).toBe(true);
+    expect(events.every((event) => event.attempts === 1)).toBe(true);
+  });
+
+  it("moves a row to FAILED after bounded retries", async () => {
+    const { orderId } = await confirmFreshOrder();
+    await prisma.outboxEvent.deleteMany({
+      where: { aggregateId: orderId, type: OutboxEventType.ORDER_CONFIRMED },
+    });
+    await prisma.outboxEvent.updateMany({
+      where: { aggregateId: orderId },
+      data: { attempts: OUTBOX_MAX_ATTEMPTS - 1, status: "PENDING", availableAt: new Date() },
+    });
+
+    const result = await dispatchOutboxEvents({
+      handle: async () => {
+        throw new Error("forced handler failure");
+      },
+    });
+
+    const event = await prisma.outboxEvent.findFirst({
+      where: { aggregateId: orderId, type: OutboxEventType.PAYMENT_CONFIRMED },
+    });
+    expect(result.failed).toBe(1);
+    expect(event?.status).toBe("FAILED");
+    expect(event?.attempts).toBe(OUTBOX_MAX_ATTEMPTS);
+    expect(event?.lastError).toBe("forced handler failure");
+  });
+});

--- a/server/src/__tests__/postgres.enums.integration.test.ts
+++ b/server/src/__tests__/postgres.enums.integration.test.ts
@@ -213,4 +213,28 @@ describe("PostgreSQL domain enums", () => {
     expect(order.status).toBe("CANCELLED");
     expect(order.paymentStatus).toBe("REFUNDED");
   });
+
+  it("rejects an invalid outbox status at PostgreSQL", async () => {
+    const event = await prisma.outboxEvent.create({
+      data: {
+        type: "PAYMENT_CONFIRMED",
+        aggregateId: `order-enum-${uniqueSuffix()}`,
+        payload: { orderId: "order-enum" },
+        status: "PENDING",
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await prisma.$executeRawUnsafe(
+        `UPDATE "OutboxEvent" SET "status" = $1::"OutboxEventStatus" WHERE "id" = $2`,
+        "SENT",
+        event.id
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expectInvalidEnumLabel(caught);
+    expect((await prisma.outboxEvent.findUnique({ where: { id: event.id } }))?.status).toBe("PENDING");
+  });
 });

--- a/server/src/modules/payments/__tests__/payments.service.test.ts
+++ b/server/src/modules/payments/__tests__/payments.service.test.ts
@@ -34,6 +34,9 @@ vi.mock("../../../shared/database/index.js", () => ({
     auditLog: {
       create: vi.fn(),
     },
+    outboxEvent: {
+      create: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -267,6 +270,7 @@ describe("paymentsService", () => {
         vi.mocked(prisma.sellerTransaction.create).mockResolvedValue({} as never);
         vi.mocked(prisma.seller.update).mockResolvedValue({} as never);
         vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
+        vi.mocked(prisma.outboxEvent.create).mockResolvedValue({} as never);
         return fn(prisma);
       });
     };
@@ -289,6 +293,27 @@ describe("paymentsService", () => {
             actorId: null,
             before: { paymentStatus: "PENDING", status: "PENDING" },
             after: { paymentStatus: "PAID", status: "CONFIRMED" },
+          }),
+        })
+      );
+      expect(prisma.outboxEvent.create).toHaveBeenCalledTimes(2);
+      expect(prisma.outboxEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: "PAYMENT_CONFIRMED",
+            aggregateId: "order-1",
+            payload: { orderId: "order-1", paymentStatus: "PAID", status: "CONFIRMED" },
+            status: "PENDING",
+          }),
+        })
+      );
+      expect(prisma.outboxEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: "ORDER_CONFIRMED",
+            aggregateId: "order-1",
+            payload: { orderId: "order-1", status: "CONFIRMED" },
+            status: "PENDING",
           }),
         })
       );
@@ -328,6 +353,7 @@ describe("paymentsService", () => {
         vi.mocked(prisma.sellerTransaction.create).mockResolvedValue({} as never);
         vi.mocked(prisma.seller.update).mockResolvedValue({} as never);
         vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
+        vi.mocked(prisma.outboxEvent.create).mockResolvedValue({} as never);
         return fn(prisma);
       });
 
@@ -403,6 +429,7 @@ describe("paymentsService", () => {
       expect(prisma.seller.update).not.toHaveBeenCalled();
       expect(prisma.listing.updateMany).not.toHaveBeenCalled();
       expect(prisma.auditLog.create).not.toHaveBeenCalled();
+      expect(prisma.outboxEvent.create).not.toHaveBeenCalled();
     });
 
     it("does not perform seller payout when payment claim fails", async () => {
@@ -411,6 +438,7 @@ describe("paymentsService", () => {
       await paymentsService.confirmPayment("order-1");
 
       expect(prisma.sellerTransaction.create).not.toHaveBeenCalled();
+      expect(prisma.outboxEvent.create).not.toHaveBeenCalled();
     });
 
     it("throws and skips payout when reserved listings cannot be sold", async () => {
@@ -426,6 +454,7 @@ describe("paymentsService", () => {
         message: expect.stringContaining("expired"),
       });
       expect(prisma.sellerTransaction.create).not.toHaveBeenCalled();
+      expect(prisma.outboxEvent.create).not.toHaveBeenCalled();
     });
   });
 
@@ -562,6 +591,7 @@ function setupWebhookTransaction() {
     vi.mocked(prisma.sellerTransaction.create).mockResolvedValue({} as never);
     vi.mocked(prisma.seller.update).mockResolvedValue({} as never);
     vi.mocked(prisma.auditLog.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.outboxEvent.create).mockResolvedValue({} as never);
     return fn(prisma);
   });
 }

--- a/server/src/modules/payments/payments.service.ts
+++ b/server/src/modules/payments/payments.service.ts
@@ -24,6 +24,8 @@ import { withSpan } from "../../shared/observability/tracing.js";
 import { auditRepository } from "../audit/audit.repository.js";
 import { AuditAction, AuditResourceType } from "../audit/audit.types.js";
 import { computeSellerLedgerAmounts } from "../../shared/money/sellerLedger.js";
+import { outboxRepository } from "../../shared/outbox/outbox.repository.js";
+import { OutboxEventType } from "../../shared/outbox/outbox.types.js";
 
 const WEBHOOK_PROVIDER = PaymentProvider.PAYPAL;
 
@@ -321,6 +323,20 @@ export const paymentsService = {
           data: { balance: { increment: netAmount } },
         });
       }
+
+      // Same local transaction as the domain mutation (ADR 0012). PayPal HTTP
+      // is not in this transaction. Duplicate confirm never reaches here
+      // (claimed.count === 0). Unique (type, aggregateId) is defense in depth.
+      await outboxRepository.enqueue(tx, {
+        type: OutboxEventType.PAYMENT_CONFIRMED,
+        aggregateId: orderId,
+        payload: { orderId, paymentStatus: "PAID", status: "CONFIRMED" },
+      });
+      await outboxRepository.enqueue(tx, {
+        type: OutboxEventType.ORDER_CONFIRMED,
+        aggregateId: orderId,
+        payload: { orderId, status: "CONFIRMED" },
+      });
     })
     );
       if (claimedCount === 0) {

--- a/server/src/shared/config/outbox.ts
+++ b/server/src/shared/config/outbox.ts
@@ -1,0 +1,30 @@
+/**
+ * In-process outbox dispatcher constants.
+ * Matching PAYPAL_RECONCILE_INTERVAL_MS: not env vars.
+ * Issue #46 / ADR 0012. Do not add Redis, SQS, or a broker.
+ */
+
+/** How often the API process claims PENDING outbox rows. */
+export const OUTBOX_DISPATCH_INTERVAL_MS = 5_000;
+
+export const OUTBOX_CLAIM_BATCH_SIZE = 20;
+
+/** After this many claims, the row is FAILED. Includes the first attempt. */
+export const OUTBOX_MAX_ATTEMPTS = 8;
+
+/** Exponential backoff base: delay = min(base * 2^(attempts-1), max). */
+export const OUTBOX_BACKOFF_BASE_MS = 1_000;
+
+export const OUTBOX_BACKOFF_MAX_MS = 5 * 60 * 1000;
+
+/**
+ * PROCESSING rows whose claimedAt is older than this are treated as a crash
+ * after claim and may be reclaimed with FOR UPDATE SKIP LOCKED.
+ */
+export const OUTBOX_CLAIM_TIMEOUT_MS = 30_000;
+
+export function outboxBackoffDelayMs(attempts: number): number {
+  const safeAttempts = Math.max(1, attempts);
+  const delay = OUTBOX_BACKOFF_BASE_MS * 2 ** (safeAttempts - 1);
+  return Math.min(delay, OUTBOX_BACKOFF_MAX_MS);
+}

--- a/server/src/shared/jobs/outboxDispatcherJob.ts
+++ b/server/src/shared/jobs/outboxDispatcherJob.ts
@@ -1,0 +1,20 @@
+import { dispatchOutboxEvents } from "../outbox/outbox.dispatcher.js";
+import { logger } from "../logger.js";
+import { OUTBOX_DISPATCH_INTERVAL_MS } from "../config/outbox.js";
+
+/**
+ * In-process transactional-outbox dispatcher for the modular monolith.
+ * PostgreSQL remains the source of truth: this timer claims PENDING rows with
+ * FOR UPDATE SKIP LOCKED. Overlapping replicas are safe. Not SQS (#53).
+ */
+export function startOutboxDispatcherJob(): NodeJS.Timeout {
+  const timer = setInterval(() => {
+    dispatchOutboxEvents().catch((err: unknown) => {
+      logger.error({ err }, "outbox dispatcher sweep failed");
+    });
+  }, OUTBOX_DISPATCH_INTERVAL_MS);
+
+  timer.unref();
+  logger.info({ intervalMs: OUTBOX_DISPATCH_INTERVAL_MS }, "outbox dispatcher started");
+  return timer;
+}

--- a/server/src/shared/lifecycle/startApi.ts
+++ b/server/src/shared/lifecycle/startApi.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import { logger } from "../logger.js";
 import { startPaypalReconciliationJob } from "../jobs/paypalReconciliationJob.js";
 import { startReservationExpiryJob } from "../jobs/reservationExpiryJob.js";
+import { startOutboxDispatcherJob } from "../jobs/outboxDispatcherJob.js";
 import { startSellerLedgerReconciliationJob } from "../jobs/sellerLedgerReconciliationJob.js";
 import { installProcessShutdownHandlers } from "./shutdown.js";
 
@@ -20,7 +21,8 @@ export function startApiProcess(
     jobs.push(
       startReservationExpiryJob(),
       startPaypalReconciliationJob(),
-      startSellerLedgerReconciliationJob()
+      startSellerLedgerReconciliationJob(),
+      startOutboxDispatcherJob()
     );
   });
 

--- a/server/src/shared/observability/metrics.ts
+++ b/server/src/shared/observability/metrics.ts
@@ -28,6 +28,9 @@ type Instruments = {
   webhooksFailed: Counter;
   sellerLedgerDriftDetected: Counter;
   sellerLedgerCorrected: Counter;
+  outboxPublished: Counter;
+  outboxRetry: Counter;
+  outboxFailed: Counter;
 };
 
 let instruments: Instruments | undefined;
@@ -107,6 +110,15 @@ function createInstruments(meter: Meter): Instruments {
     sellerLedgerCorrected: meter.createCounter("seller.ledger.corrected", {
       description: "Seller.balance set to PAID ledger SUM",
     }),
+    outboxPublished: meter.createCounter("outbox.published", {
+      description: "Outbox events published",
+    }),
+    outboxRetry: meter.createCounter("outbox.retry", {
+      description: "Outbox handler retries scheduled",
+    }),
+    outboxFailed: meter.createCounter("outbox.failed", {
+      description: "Outbox events moved to FAILED",
+    }),
   };
 }
 
@@ -179,4 +191,7 @@ export const appMetrics = {
   webhooksFailed: (value = 1) => add(getInstruments().webhooksFailed, undefined, value),
   sellerLedgerDriftDetected: (value = 1) => add(getInstruments().sellerLedgerDriftDetected, undefined, value),
   sellerLedgerCorrected: (value = 1) => add(getInstruments().sellerLedgerCorrected, undefined, value),
+  outboxPublished: (value = 1) => add(getInstruments().outboxPublished, undefined, value),
+  outboxRetry: (value = 1) => add(getInstruments().outboxRetry, undefined, value),
+  outboxFailed: (value = 1) => add(getInstruments().outboxFailed, undefined, value),
 };

--- a/server/src/shared/outbox/__tests__/outbox.dispatcher.test.ts
+++ b/server/src/shared/outbox/__tests__/outbox.dispatcher.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OUTBOX_MAX_ATTEMPTS, outboxBackoffDelayMs } from "../../config/outbox.js";
+import type { ClaimedOutboxEvent } from "../outbox.types.js";
+
+vi.mock("../../database/index.js", () => ({
+  prisma: {
+    $transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn({})),
+  },
+}));
+
+vi.mock("../outbox.repository.js", () => ({
+  outboxRepository: {
+    claimBatch: vi.fn(),
+    markPublished: vi.fn(),
+    scheduleRetry: vi.fn(),
+    markFailed: vi.fn(),
+  },
+}));
+
+vi.mock("../../observability/metrics.js", () => ({
+  appMetrics: {
+    outboxPublished: vi.fn(),
+    outboxRetry: vi.fn(),
+    outboxFailed: vi.fn(),
+  },
+}));
+
+import { prisma } from "../../database/index.js";
+import { appMetrics } from "../../observability/metrics.js";
+import { outboxRepository } from "../outbox.repository.js";
+import { dispatchOutboxEvents } from "../outbox.dispatcher.js";
+
+function claimed(overrides: Partial<ClaimedOutboxEvent> = {}): ClaimedOutboxEvent {
+  return {
+    id: "evt-1",
+    type: "PAYMENT_CONFIRMED",
+    aggregateId: "order-1",
+    payload: { orderId: "order-1", paymentStatus: "PAID", status: "CONFIRMED" },
+    status: "PROCESSING",
+    attempts: 1,
+    availableAt: new Date("2026-09-05T00:00:00.000Z"),
+    claimedAt: new Date("2026-09-05T00:00:01.000Z"),
+    lastError: null,
+    createdAt: new Date("2026-09-05T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("dispatchOutboxEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(outboxRepository.claimBatch).mockResolvedValue([]);
+    vi.mocked(outboxRepository.markPublished).mockResolvedValue(true);
+    vi.mocked(outboxRepository.scheduleRetry).mockResolvedValue(true);
+    vi.mocked(outboxRepository.markFailed).mockResolvedValue(true);
+  });
+
+  it("is a no-op when nothing is claimable", async () => {
+    const result = await dispatchOutboxEvents();
+    expect(result).toEqual({ claimed: 0, published: 0, retried: 0, failed: 0, skipped: 0 });
+    expect(outboxRepository.markPublished).not.toHaveBeenCalled();
+    expect(appMetrics.outboxPublished).not.toHaveBeenCalled();
+  });
+
+  it("publishes a claimed row once and records the metric on the status transition", async () => {
+    vi.mocked(outboxRepository.claimBatch).mockResolvedValue([claimed()]);
+
+    const result = await dispatchOutboxEvents();
+
+    expect(result.published).toBe(1);
+    expect(outboxRepository.markPublished).toHaveBeenCalledWith("evt-1");
+    expect(appMetrics.outboxPublished).toHaveBeenCalledTimes(1);
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  it("does not increment the publish metric when the row is already published", async () => {
+    vi.mocked(outboxRepository.claimBatch).mockResolvedValue([claimed()]);
+    vi.mocked(outboxRepository.markPublished).mockResolvedValue(false);
+
+    const result = await dispatchOutboxEvents();
+
+    expect(result.skipped).toBe(1);
+    expect(result.published).toBe(0);
+    expect(appMetrics.outboxPublished).not.toHaveBeenCalled();
+  });
+
+  it("schedules bounded exponential backoff when the handler throws", async () => {
+    const now = new Date("2026-09-05T12:00:00.000Z");
+    vi.mocked(outboxRepository.claimBatch).mockResolvedValue([claimed({ attempts: 2 })]);
+
+    const result = await dispatchOutboxEvents({
+      now,
+      handle: async () => {
+        throw new Error("handler boom");
+      },
+    });
+
+    expect(result.retried).toBe(1);
+    expect(outboxRepository.scheduleRetry).toHaveBeenCalledWith(
+      "evt-1",
+      new Date(now.getTime() + outboxBackoffDelayMs(2)),
+      "handler boom"
+    );
+    expect(appMetrics.outboxRetry).toHaveBeenCalledTimes(1);
+    expect(outboxRepository.markFailed).not.toHaveBeenCalled();
+  });
+
+  it("marks FAILED after the last attempt and does not retry", async () => {
+    vi.mocked(outboxRepository.claimBatch).mockResolvedValue([
+      claimed({ attempts: OUTBOX_MAX_ATTEMPTS }),
+    ]);
+
+    const result = await dispatchOutboxEvents({
+      handle: async () => {
+        throw new Error("still broken");
+      },
+    });
+
+    expect(result.failed).toBe(1);
+    expect(outboxRepository.markFailed).toHaveBeenCalledWith("evt-1", "still broken");
+    expect(outboxRepository.scheduleRetry).not.toHaveBeenCalled();
+    expect(appMetrics.outboxFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a row already in PUBLISHED without calling the handler", async () => {
+    const handle = vi.fn();
+    vi.mocked(outboxRepository.claimBatch).mockResolvedValue([claimed({ status: "PUBLISHED" })]);
+
+    const result = await dispatchOutboxEvents({ handle });
+
+    expect(handle).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+    expect(outboxRepository.markPublished).not.toHaveBeenCalled();
+  });
+});
+
+describe("outboxBackoffDelayMs", () => {
+  it("doubles from a 1s base and caps at five minutes", () => {
+    expect(outboxBackoffDelayMs(1)).toBe(1_000);
+    expect(outboxBackoffDelayMs(2)).toBe(2_000);
+    expect(outboxBackoffDelayMs(3)).toBe(4_000);
+    expect(outboxBackoffDelayMs(20)).toBe(5 * 60 * 1000);
+  });
+});

--- a/server/src/shared/outbox/__tests__/outbox.sanitize.test.ts
+++ b/server/src/shared/outbox/__tests__/outbox.sanitize.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeOutboxError, sanitizeOutboxPayload } from "../outbox.sanitize.js";
+
+describe("sanitizeOutboxPayload", () => {
+  it("keeps non-secret order confirmation fields", () => {
+    expect(
+      sanitizeOutboxPayload({ orderId: "order-1", paymentStatus: "PAID", status: "CONFIRMED" })
+    ).toEqual({ orderId: "order-1", paymentStatus: "PAID", status: "CONFIRMED" });
+  });
+
+  it("redacts known secret keys and JWT-shaped values", () => {
+    expect(
+      sanitizeOutboxPayload({
+        orderId: "order-1",
+        access_token: "secret-value",
+        note: "eyJhbGciOiJIUzI1NiJ9.payload",
+      })
+    ).toEqual({
+      orderId: "order-1",
+      access_token: "[REDACTED]",
+      note: "[REDACTED]",
+    });
+  });
+});
+
+describe("sanitizeOutboxError", () => {
+  it("truncates long messages and redacts bearer tokens", () => {
+    expect(sanitizeOutboxError(new Error("Bearer abcdefghijklmnop"))).toBe("[REDACTED]");
+    expect(sanitizeOutboxError(new Error("x".repeat(600))).length).toBe(512);
+  });
+});

--- a/server/src/shared/outbox/outbox.dispatcher.ts
+++ b/server/src/shared/outbox/outbox.dispatcher.ts
@@ -1,0 +1,107 @@
+import { logger } from "../logger.js";
+import { prisma } from "../database/index.js";
+import { appMetrics } from "../observability/metrics.js";
+import { withSpan } from "../observability/tracing.js";
+import { OUTBOX_MAX_ATTEMPTS, outboxBackoffDelayMs } from "../config/outbox.js";
+import { outboxRepository } from "./outbox.repository.js";
+import { sanitizeOutboxError } from "./outbox.sanitize.js";
+import type { ClaimedOutboxEvent } from "./outbox.types.js";
+
+export type OutboxHandleFn = (event: ClaimedOutboxEvent) => Promise<void>;
+
+/**
+ * First-slice handler: structured log only.
+ * Does not call confirmPayment, does not write seller ledger, and does not
+ * invent a second payment confirmation. Metrics fire on the PROCESSING →
+ * PUBLISHED transition so a crash-retry of an already published row is a no-op.
+ */
+export async function handleOutboxEvent(event: ClaimedOutboxEvent): Promise<void> {
+  logger.info(
+    {
+      outboxEventId: event.id,
+      type: event.type,
+      aggregateId: event.aggregateId,
+    },
+    "outbox event published"
+  );
+}
+
+export async function dispatchOutboxEvents(options?: {
+  now?: Date;
+  handle?: OutboxHandleFn;
+}) {
+  const now = options?.now ?? new Date();
+  const handle = options?.handle ?? handleOutboxEvent;
+
+  return withSpan("outbox.dispatch", {}, async (span) => {
+    const claimed = await prisma.$transaction((tx) => outboxRepository.claimBatch(tx, now));
+    let published = 0;
+    let retried = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const event of claimed) {
+      const outcome = await processClaimedEvent(event, now, handle);
+      if (outcome === "published") published += 1;
+      else if (outcome === "retried") retried += 1;
+      else if (outcome === "failed") failed += 1;
+      else skipped += 1;
+    }
+
+    span.setAttribute("app.outbox_claimed", claimed.length);
+    span.setAttribute("app.outbox_published", published);
+    span.setAttribute("app.outbox_retried", retried);
+    span.setAttribute("app.outbox_failed", failed);
+    return { claimed: claimed.length, published, retried, failed, skipped };
+  });
+}
+
+async function processClaimedEvent(
+  event: ClaimedOutboxEvent,
+  now: Date,
+  handle: OutboxHandleFn
+): Promise<"published" | "retried" | "failed" | "skipped"> {
+  if (event.status === "PUBLISHED") {
+    return "skipped";
+  }
+
+  try {
+    await handle(event);
+    const moved = await outboxRepository.markPublished(event.id);
+    if (!moved) {
+      logger.info(
+        { outboxEventId: event.id, type: event.type },
+        "outbox event already published"
+      );
+      return "skipped";
+    }
+    appMetrics.outboxPublished();
+    return "published";
+  } catch (err) {
+    const lastError = sanitizeOutboxError(err);
+    if (event.attempts >= OUTBOX_MAX_ATTEMPTS) {
+      await outboxRepository.markFailed(event.id, lastError);
+      appMetrics.outboxFailed();
+      logger.error(
+        { err, outboxEventId: event.id, type: event.type, attempts: event.attempts },
+        "outbox event failed"
+      );
+      return "failed";
+    }
+
+    const delayMs = outboxBackoffDelayMs(event.attempts);
+    await outboxRepository.scheduleRetry(event.id, new Date(now.getTime() + delayMs), lastError);
+    appMetrics.outboxRetry();
+    logger.warn(
+      {
+        err,
+        outboxEventId: event.id,
+        type: event.type,
+        attempts: event.attempts,
+        delayMs,
+      },
+      "outbox event retry scheduled"
+    );
+    return "retried";
+  }
+}

--- a/server/src/shared/outbox/outbox.repository.ts
+++ b/server/src/shared/outbox/outbox.repository.ts
@@ -1,0 +1,106 @@
+import { prisma } from "../database/index.js";
+import {
+  OUTBOX_CLAIM_BATCH_SIZE,
+  OUTBOX_CLAIM_TIMEOUT_MS,
+} from "../config/outbox.js";
+import { sanitizeOutboxPayload } from "./outbox.sanitize.js";
+import type { ClaimedOutboxEvent, OutboxClient, OutboxEnqueueInput } from "./outbox.types.js";
+
+export const outboxRepository = {
+  async enqueue(client: OutboxClient, input: OutboxEnqueueInput) {
+    return client.outboxEvent.create({
+      data: {
+        type: input.type,
+        aggregateId: input.aggregateId,
+        payload: sanitizeOutboxPayload(input.payload),
+        status: "PENDING",
+      },
+    });
+  },
+
+  /**
+   * Claim due PENDING rows, or stale PROCESSING rows (crash after claim).
+   * FOR UPDATE SKIP LOCKED so overlapping API replicas take disjoint sets.
+   */
+  async claimBatch(
+    client: OutboxClient = prisma,
+    now = new Date(),
+    batchSize = OUTBOX_CLAIM_BATCH_SIZE
+  ): Promise<ClaimedOutboxEvent[]> {
+    const staleBefore = new Date(now.getTime() - OUTBOX_CLAIM_TIMEOUT_MS);
+    const rows = await client.$queryRaw<ClaimedOutboxEvent[]>`
+      WITH picked AS (
+        SELECT e.id
+        FROM "OutboxEvent" AS e
+        WHERE e."availableAt" <= ${now}
+          AND (
+            e.status = 'PENDING'::"OutboxEventStatus"
+            OR (
+              e.status = 'PROCESSING'::"OutboxEventStatus"
+              AND e."claimedAt" IS NOT NULL
+              AND e."claimedAt" < ${staleBefore}
+            )
+          )
+        ORDER BY e."createdAt" ASC
+        LIMIT ${batchSize}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE "OutboxEvent" AS o
+      SET
+        status = 'PROCESSING'::"OutboxEventStatus",
+        "claimedAt" = ${now},
+        attempts = o.attempts + 1
+      FROM picked
+      WHERE o.id = picked.id
+      RETURNING
+        o.id,
+        o.type,
+        o."aggregateId",
+        o.payload,
+        o.status,
+        o.attempts,
+        o."availableAt",
+        o."claimedAt",
+        o."lastError",
+        o."createdAt"
+    `;
+    return rows.map((row) => ({
+      ...row,
+      attempts: Number(row.attempts),
+    }));
+  },
+
+  async markPublished(id: string, client: OutboxClient = prisma) {
+    const updated = await client.outboxEvent.updateMany({
+      where: { id, status: "PROCESSING" },
+      data: { status: "PUBLISHED", lastError: null },
+    });
+    return updated.count === 1;
+  },
+
+  async scheduleRetry(
+    id: string,
+    availableAt: Date,
+    lastError: string,
+    client: OutboxClient = prisma
+  ) {
+    const updated = await client.outboxEvent.updateMany({
+      where: { id, status: "PROCESSING" },
+      data: {
+        status: "PENDING",
+        availableAt,
+        claimedAt: null,
+        lastError,
+      },
+    });
+    return updated.count === 1;
+  },
+
+  async markFailed(id: string, lastError: string, client: OutboxClient = prisma) {
+    const updated = await client.outboxEvent.updateMany({
+      where: { id, status: "PROCESSING" },
+      data: { status: "FAILED", lastError },
+    });
+    return updated.count === 1;
+  },
+};

--- a/server/src/shared/outbox/outbox.sanitize.ts
+++ b/server/src/shared/outbox/outbox.sanitize.ts
@@ -1,0 +1,44 @@
+import type { Prisma } from "@prisma/client";
+
+const FORBIDDEN_KEY =
+  /password|passwd|secret|token|authorization|cookie|jwt|signature|credential|paypal-transmission-sig|access_token|refresh_token|client_secret/i;
+
+const FORBIDDEN_VALUE = /bearer\s+[a-z0-9._-]+|eyj[a-z0-9_-]+\.[a-z0-9._-]+|-----begin /i;
+
+const MAX_ERROR_LENGTH = 512;
+
+/**
+ * Defense in depth: outbox payload must be non-secret JSON (ids, statuses).
+ * Known secret keys and JWT/PEM-shaped values are redacted if a caller slips.
+ */
+export function sanitizeOutboxPayload(
+  value: Prisma.InputJsonValue
+): Prisma.InputJsonValue {
+  return redact(value) as Prisma.InputJsonValue;
+}
+
+export function sanitizeOutboxError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  const redacted = FORBIDDEN_VALUE.test(message) ? "[REDACTED]" : message;
+  return redacted.length > MAX_ERROR_LENGTH ? redacted.slice(0, MAX_ERROR_LENGTH) : redacted;
+}
+
+function redact(value: unknown): unknown {
+  if (value == null) return value;
+  if (Array.isArray(value)) return value.map(redact);
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (FORBIDDEN_KEY.test(key)) {
+        out[key] = "[REDACTED]";
+        continue;
+      }
+      out[key] = redact(nested);
+    }
+    return out;
+  }
+  if (typeof value === "string" && FORBIDDEN_VALUE.test(value)) {
+    return "[REDACTED]";
+  }
+  return value;
+}

--- a/server/src/shared/outbox/outbox.types.ts
+++ b/server/src/shared/outbox/outbox.types.ts
@@ -1,0 +1,38 @@
+import type { OutboxEventStatus, Prisma } from "@prisma/client";
+
+export const OutboxEventType = {
+  PAYMENT_CONFIRMED: "PAYMENT_CONFIRMED",
+  ORDER_CONFIRMED: "ORDER_CONFIRMED",
+} as const;
+
+export type OutboxEventTypeName = (typeof OutboxEventType)[keyof typeof OutboxEventType];
+
+export type OutboxEnqueueInput = {
+  type: OutboxEventTypeName;
+  aggregateId: string;
+  payload: Prisma.InputJsonValue;
+};
+
+export type ClaimedOutboxEvent = {
+  id: string;
+  type: string;
+  aggregateId: string;
+  payload: Prisma.JsonValue;
+  status: OutboxEventStatus;
+  attempts: number;
+  availableAt: Date;
+  claimedAt: Date | null;
+  lastError: string | null;
+  createdAt: Date;
+};
+
+export type OutboxClient = {
+  outboxEvent: {
+    create: (args: { data: Prisma.OutboxEventUncheckedCreateInput }) => Promise<unknown>;
+    updateMany: (args: {
+      where: Prisma.OutboxEventWhereInput;
+      data: Prisma.OutboxEventUncheckedUpdateManyInput;
+    }) => Promise<{ count: number }>;
+  };
+  $queryRaw: Prisma.TransactionClient["$queryRaw"];
+};

--- a/server/src/shared/types/__tests__/roles.test.ts
+++ b/server/src/shared/types/__tests__/roles.test.ts
@@ -3,6 +3,7 @@ import {
   ClaimStatus,
   ListingStatus,
   OrderStatus,
+  OutboxEventStatus,
   PaymentProvider,
   PaymentStatus,
   UserRole,
@@ -15,6 +16,7 @@ import {
   CLAIM_STATUSES,
   LISTING_STATUSES,
   ORDER_STATUSES,
+  OUTBOX_EVENT_STATUSES,
   PAYMENT_PROVIDERS,
   PAYMENT_STATUSES,
   REGISTRATION_ROLES,
@@ -35,6 +37,7 @@ describe("Prisma domain enums", () => {
     expect([...CLAIM_STATUSES].sort()).toEqual(labelsOf(ClaimStatus));
     expect([...WEBHOOK_EVENT_STATUSES].sort()).toEqual(labelsOf(WebhookEventStatus));
     expect([...PAYMENT_PROVIDERS].sort()).toEqual(labelsOf(PaymentProvider));
+    expect([...OUTBOX_EVENT_STATUSES].sort()).toEqual(labelsOf(OutboxEventStatus));
   });
 
   it("preserves listing CANCELED vs order CANCELLED spellings", () => {

--- a/server/src/shared/types/roles.ts
+++ b/server/src/shared/types/roles.ts
@@ -7,13 +7,14 @@ import {
   ClaimStatus,
   ListingStatus as PrismaListingStatus,
   OrderStatus as PrismaOrderStatus,
+  OutboxEventStatus,
   PaymentProvider,
   PaymentStatus as PrismaPaymentStatus,
   UserRole,
   WebhookEventStatus,
 } from "@prisma/client";
 
-export { ClaimStatus, PaymentProvider, UserRole, WebhookEventStatus };
+export { ClaimStatus, OutboxEventStatus, PaymentProvider, UserRole, WebhookEventStatus };
 
 export const ROLES = [UserRole.ADMIN, UserRole.SELLER, UserRole.CUSTOMER] as const;
 export type Role = UserRole;
@@ -60,3 +61,10 @@ export const WEBHOOK_EVENT_STATUSES = [
 ] as const;
 
 export const PAYMENT_PROVIDERS = [PaymentProvider.PAYPAL] as const;
+
+export const OUTBOX_EVENT_STATUSES = [
+  OutboxEventStatus.PENDING,
+  OutboxEventStatus.PROCESSING,
+  OutboxEventStatus.PUBLISHED,
+  OutboxEventStatus.FAILED,
+] as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Outbox transacional no PostgreSQL: `PAYMENT_CONFIRMED` e `ORDER_CONFIRMED` entram na mesma transação do `confirmPayment`. Dispatcher in-process (`SKIP LOCKED`, backoff, idempotente). Sem Kafka/SQS.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/46
ADR: `docs/adr/0012-transactional-outbox.md`

## O que muda

- Modelo `OutboxEvent` + unique `(type, aggregateId)`.
- Insert no mesmo TX do confirm; duplicate confirm não duplica evento.
- Job `setInterval` + `unref` ao lado dos outros; handler inicial é log + métrica (não é segundo confirm).
- Payload sem segredos; métricas sem order id.

## Verificação

- `cd server && npx tsc --noEmit` → pass
- `cd server && npm run test:unit` → 231 passed
- `cd server && npm run test:integration` → 90 passed (inclui outbox)

Primeiro consumidor é observabilidade, de propósito. #53 SQS não entra.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

