### PR TITLE
#95 — [UX] Implementar histórico e detalhe de pedidos do comprador

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,9 @@ import ListingDetail from "./pages/ListingDetail";
 import CartPage from "./pages/CartPage";
 import Checkout from "./pages/Checkout";
 import OrderStatusPage from "./pages/OrderStatus";
+import AccountOrdersPage, {
+  AccountOrderDetailRedirect,
+} from "./pages/AccountOrders";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import SellerDashboard from "./pages/SellerDashboard";
@@ -64,6 +67,22 @@ const App = () => (
                     element={
                       <ProtectedRoute>
                         <OrderStatusPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/account/orders"
+                    element={
+                      <ProtectedRoute>
+                        <AccountOrdersPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/account/orders/:id"
+                    element={
+                      <ProtectedRoute>
+                        <AccountOrderDetailRedirect />
                       </ProtectedRoute>
                     }
                   />

--- a/src/api/__tests__/orders.test.ts
+++ b/src/api/__tests__/orders.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createOrder, getOrder } from "../orders";
+import { createOrder, getOrder, listOrders } from "../orders";
 
 const post = vi.fn();
 const get = vi.fn();
@@ -44,5 +44,17 @@ describe("getOrder", () => {
   it("GETs /orders/:id without inventing a paid state", async () => {
     await getOrder("order-1");
     expect(get).toHaveBeenCalledWith("/orders/order-1");
+  });
+});
+
+describe("listOrders", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue([]);
+  });
+
+  it("GETs /orders without a client-side customer filter", async () => {
+    await listOrders();
+    expect(get).toHaveBeenCalledWith("/orders");
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,6 +30,9 @@ export function Header() {
   const navLinks = [
     { to: "/", label: "Home" },
     { to: "/products", label: "Market" },
+    ...(user?.role === "CUSTOMER"
+      ? [{ to: "/account/orders", label: "Pedidos" }]
+      : []),
     ...(user?.role === "SELLER" ? [{ to: "/seller", label: "Dashboard" }] : []),
     ...(user?.role === "ADMIN" ? [{ to: "/admin", label: "Admin" }] : []),
   ];

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -40,6 +40,7 @@ describe("Header", () => {
     expect(screen.getByText("Market")).toBeTruthy();
     expect(screen.getByText("Login")).toBeTruthy();
     expect(screen.queryByText("SKINMARKET")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Pedidos" })).toBeNull();
     expect(screen.getByLabelText("Carrinho")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Menu" })).toHaveAttribute(
       "aria-haspopup",
@@ -58,7 +59,25 @@ describe("Header", () => {
     renderHeader();
     expect(screen.getByText("Dashboard")).toBeTruthy();
     expect(screen.queryByText("Admin")).toBeNull();
+    expect(screen.queryByRole("link", { name: "Pedidos" })).toBeNull();
     expect(screen.getByText("Sair")).toBeTruthy();
+  });
+
+  it("shows Pedidos for an authenticated customer", () => {
+    authState.user = {
+      id: "c1",
+      name: "Buyer",
+      email: "buyer@test.com",
+      role: "CUSTOMER",
+    };
+    authState.isAuthenticated = true;
+    renderHeader();
+    expect(screen.getByRole("link", { name: "Pedidos" })).toHaveAttribute(
+      "href",
+      "/account/orders",
+    );
+    expect(screen.queryByRole("link", { name: "Dashboard" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Admin" })).toBeNull();
   });
 
   it("shows Admin for an admin", () => {
@@ -75,5 +94,6 @@ describe("Header", () => {
       "/admin",
     );
     expect(screen.queryByRole("link", { name: "Dashboard" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Pedidos" })).toBeNull();
   });
 });

--- a/src/pages/AccountOrders.tsx
+++ b/src/pages/AccountOrders.tsx
@@ -1,0 +1,133 @@
+import { Link, Navigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { listOrders } from "@/api/orders";
+import { useAuth } from "@/contexts/AuthContext";
+import { EmptyState, ErrorState, PageSkeleton } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { orderItemLabel, orderTotalAmount } from "@/lib/orderPaymentView";
+import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
+import type { Order } from "@/types/api";
+
+function formatOrderDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR");
+}
+
+function firstItemLabel(order: Order): string {
+  const first = order.items?.[0];
+  return first ? orderItemLabel(first) : "Pedido";
+}
+
+export function AccountOrderDetailRedirect() {
+  const { id } = useParams<{ id: string }>();
+  if (!id) return <Navigate to="/account/orders" replace />;
+  return <Navigate to={`/orders/${id}`} replace />;
+}
+
+export default function AccountOrdersPage() {
+  const { user } = useAuth();
+  const isCustomer = user?.role === "CUSTOMER";
+  const {
+    data: orders = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["account-orders"],
+    queryFn: () => listOrders(),
+    enabled: isCustomer,
+  });
+
+  if (user?.role === "SELLER") {
+    return <Navigate to="/seller/orders" replace />;
+  }
+
+  if (user?.role === "ADMIN") {
+    return <Navigate to="/admin/orders" replace />;
+  }
+
+  if (!isCustomer) {
+    return null;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton label="Carregando pedidos" />;
+  }
+
+  if (isError) {
+    return (
+      <div className="container py-8">
+        <ErrorState
+          title="Erro ao carregar pedidos"
+          error={error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void refetch()}
+            >
+              Tentar novamente
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-2xl py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Pedidos</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Histórico das suas compras neste Market.
+        </p>
+      </div>
+
+      {orders.length === 0 ? (
+        <EmptyState
+          title="Você ainda não comprou"
+          description="Quando você pagar um listing, o pedido aparece aqui."
+          action={
+            <Button asChild>
+              <Link to="/products">Ir ao Market</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <ul className="space-y-2">
+          {orders.map((order) => (
+            <li key={order.id}>
+              <Link
+                to={`/orders/${order.id}`}
+                className="flex flex-col justify-between gap-3 rounded-md border border-border bg-card p-4 transition-colors hover:border-foreground/20 sm:flex-row sm:items-center"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {firstItemLabel(order)}
+                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary">
+                      {orderStatusLabel(order.status)}
+                    </Badge>
+                    <Badge variant="outline">
+                      {paymentStatusLabel(order.paymentStatus)}
+                    </Badge>
+                    {order.createdAt ? (
+                      <span className="text-xs text-muted-foreground">
+                        {formatOrderDate(order.createdAt)}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+                <p className="tabular-price text-lg font-semibold text-foreground sm:text-right">
+                  ${orderTotalAmount(order).toFixed(2)}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { getOrder } from "@/api/orders";
 import { createPaymentLink } from "@/api/payments";
+import { useAuth } from "@/contexts/AuthContext";
 import { ErrorState, PageSkeleton } from "@/components/page-state";
 import { ReservationHold } from "@/components/ReservationHold";
 import { Badge } from "@/components/ui/badge";
@@ -96,7 +97,9 @@ function OrderHeadline({
 export default function OrderStatusPage() {
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
+  const { user } = useAuth();
   const intent = orderPageIntent(location.pathname);
+  const isCustomer = user?.role === "CUSTOMER";
   const [now, setNow] = useState(() => Date.now());
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
@@ -159,9 +162,16 @@ export default function OrderStatusPage() {
           }
           action={
             accessError ? (
-              <Button asChild>
-                <Link to="/products">Ir ao Market</Link>
-              </Button>
+              <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+                {isCustomer ? (
+                  <Button asChild variant="outline">
+                    <Link to="/account/orders">Voltar aos pedidos</Link>
+                  </Button>
+                ) : null}
+                <Button asChild>
+                  <Link to="/products">Ir ao Market</Link>
+                </Button>
+              </div>
             ) : (
               <Button
                 type="button"
@@ -207,8 +217,21 @@ export default function OrderStatusPage() {
     }
   };
 
+  const trackingCode = order.trackingCode?.trim();
+  const trackingCarrier = order.trackingCarrier?.trim();
+
   return (
     <div className="container max-w-2xl py-8">
+      {isCustomer ? (
+        <p className="mb-4">
+          <Link
+            to="/account/orders"
+            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Voltar aos pedidos
+          </Link>
+        </p>
+      ) : null}
       <div className="mb-8 space-y-4">
         <OrderHeadline order={order} intent={intent} expired={expired} />
         {!paid ? (
@@ -229,15 +252,41 @@ export default function OrderStatusPage() {
         <ul className="space-y-2">
           {(order.items ?? []).map((item) => (
             <li key={item.id} className="flex justify-between gap-4 text-sm">
-              <span className="min-w-0 truncate text-foreground">
-                {orderItemLabel(item)}
-              </span>
+              {item.listingId ? (
+                <Link
+                  to={`/listing/${item.listingId}`}
+                  className="min-w-0 truncate text-foreground underline-offset-4 hover:underline"
+                >
+                  {orderItemLabel(item)}
+                </Link>
+              ) : (
+                <span className="min-w-0 truncate text-foreground">
+                  {orderItemLabel(item)}
+                </span>
+              )}
               <span className="shrink-0 tabular-price text-muted-foreground">
                 ${Number(item.priceSnapshot).toFixed(2)}
               </span>
             </li>
           ))}
         </ul>
+
+        {trackingCode || trackingCarrier ? (
+          <dl className="space-y-1 border-t border-border pt-3 text-sm">
+            {trackingCarrier ? (
+              <div className="flex justify-between gap-4">
+                <dt className="text-muted-foreground">Transportadora</dt>
+                <dd className="text-foreground">{trackingCarrier}</dd>
+              </div>
+            ) : null}
+            {trackingCode ? (
+              <div className="flex justify-between gap-4">
+                <dt className="text-muted-foreground">Rastreio</dt>
+                <dd className="tabular-nums text-foreground">{trackingCode}</dd>
+              </div>
+            ) : null}
+          </dl>
+        ) : null}
 
         <dl className="space-y-1 border-t border-border pt-3 text-sm">
           <div className="flex justify-between pt-1 text-base font-medium text-foreground">

--- a/src/pages/__tests__/AccountOrders.test.tsx
+++ b/src/pages/__tests__/AccountOrders.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AccountOrdersPage, {
+  AccountOrderDetailRedirect,
+} from "../AccountOrders";
+import type { Order, Role, User } from "@/types/api";
+import { USER_FACING_NETWORK } from "@/lib/userFacingApiError";
+
+const listOrders = vi.fn();
+const updateOrderStatus = vi.fn();
+const authState = {
+  user: {
+    id: "customer-1",
+    name: "Buyer",
+    email: "buyer@test.com",
+    role: "CUSTOMER",
+  } as User,
+};
+
+vi.mock("@/api/orders", () => ({
+  listOrders: (...args: unknown[]) => listOrders(...args),
+  updateOrderStatus: (...args: unknown[]) => updateOrderStatus(...args),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+const CREATED_AT = "2026-03-20T15:00:00.000Z";
+
+function order(overrides: Partial<Order> = {}): Order {
+  return {
+    id: "order-1",
+    totalAmount: 105,
+    status: "CONFIRMED",
+    paymentStatus: "PAID",
+    createdAt: CREATED_AT,
+    updatedAt: CREATED_AT,
+    items: [
+      {
+        id: "item-1",
+        listingId: "listing-ak",
+        sellerId: "seller-1",
+        priceSnapshot: 105,
+        listing: {
+          id: "listing-ak",
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function setRole(role: Role) {
+  authState.user = {
+    id: `${role.toLowerCase()}-user`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
+}
+
+function renderPage(path = "/account/orders") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/account/orders" element={<AccountOrdersPage />} />
+          <Route
+            path="/account/orders/:id"
+            element={<AccountOrderDetailRedirect />}
+          />
+          <Route path="/orders/:id" element={<div>Pedido destino</div>} />
+          <Route path="/seller/orders" element={<div>seller-orders</div>} />
+          <Route path="/admin/orders" element={<div>admin-orders</div>} />
+          <Route path="/products" element={<div>Market</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AccountOrdersPage", () => {
+  beforeEach(() => {
+    listOrders.mockReset();
+    updateOrderStatus.mockReset();
+    setRole("CUSTOMER");
+  });
+
+  it("shows a skeleton while orders load", () => {
+    listOrders.mockImplementation(() => new Promise(() => {}));
+    renderPage();
+    expect(
+      screen.getByRole("status", { name: "Carregando pedidos" }),
+    ).toBeTruthy();
+  });
+
+  it("lists the customer orders returned by GET /orders without a client filter", async () => {
+    listOrders.mockResolvedValue([order()]);
+    renderPage();
+
+    expect(
+      await screen.findByRole("heading", { name: "Pedidos" }),
+    ).toBeTruthy();
+    expect(listOrders).toHaveBeenCalledWith();
+    expect(
+      screen.getByRole("link", { name: /AK-47 \| Redline \(Field-Tested\)/ }),
+    ).toHaveAttribute("href", "/orders/order-1");
+    expect(screen.getByText("Confirmado")).toBeTruthy();
+    expect(screen.getByText("Pago")).toBeTruthy();
+    expect(screen.getByText("$105.00")).toBeTruthy();
+    expect(
+      screen.getByText(new Date(CREATED_AT).toLocaleDateString("pt-BR")),
+    ).toBeTruthy();
+    expect(updateOrderStatus).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /atualizar status|enviar/i }),
+    ).toBeNull();
+  });
+
+  it("shows the empty buyer copy and a Market CTA", async () => {
+    listOrders.mockResolvedValue([]);
+    renderPage();
+
+    expect(await screen.findByText("Você ainda não comprou")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Ir ao Market" })).toHaveAttribute(
+      "href",
+      "/products",
+    );
+    expect(screen.queryByText("seller-orders")).toBeNull();
+    expect(screen.queryByText("admin-orders")).toBeNull();
+  });
+
+  it("maps a network failure to PT copy with retry", async () => {
+    listOrders.mockRejectedValue(
+      new Error(
+        "Could not reach API at http://localhost:3001/orders: Failed to fetch",
+      ),
+    );
+    renderPage();
+
+    expect(await screen.findByText("Erro ao carregar pedidos")).toBeTruthy();
+    expect(screen.getByText(USER_FACING_NETWORK)).toBeTruthy();
+    expect(screen.queryByText(/localhost/i)).toBeNull();
+    listOrders.mockResolvedValue([order()]);
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    expect(
+      await screen.findByRole("link", {
+        name: /AK-47 \| Redline \(Field-Tested\)/,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("redirects SELLER to the seller order dashboard without calling listOrders", async () => {
+    setRole("SELLER");
+    listOrders.mockResolvedValue([order()]);
+    renderPage();
+
+    expect(await screen.findByText("seller-orders")).toBeTruthy();
+    expect(screen.queryByText("Você ainda não comprou")).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Pedidos" })).toBeNull();
+    expect(listOrders).not.toHaveBeenCalled();
+  });
+
+  it("redirects ADMIN to the admin order dashboard without calling listOrders", async () => {
+    setRole("ADMIN");
+    listOrders.mockResolvedValue([order()]);
+    renderPage();
+
+    expect(await screen.findByText("admin-orders")).toBeTruthy();
+    expect(screen.queryByText("Você ainda não comprou")).toBeNull();
+    expect(listOrders).not.toHaveBeenCalled();
+  });
+
+  it("reuses /orders/:id for account detail so PayPal return URLs stay put", async () => {
+    renderPage("/account/orders/order-1");
+    expect(await screen.findByText("Pedido destino")).toBeTruthy();
+  });
+});

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -12,15 +12,30 @@ import {
   USER_FACING_NETWORK,
   USER_FACING_ORDER_CANCELLED,
 } from "@/lib/userFacingApiError";
+import type { Role, User } from "@/types/api";
 
 const getOrder = vi.fn();
 const createPaymentLink = vi.fn();
 const createOrder = vi.fn();
 const redirectToExternal = vi.fn();
+const updateOrderStatus = vi.fn();
+const authState = {
+  user: {
+    id: "customer-1",
+    name: "Buyer",
+    email: "buyer@test.com",
+    role: "CUSTOMER",
+  } as User,
+};
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
 
 vi.mock("@/api/orders", () => ({
   getOrder: (...args: unknown[]) => getOrder(...args),
   createOrder: (...args: unknown[]) => createOrder(...args),
+  updateOrderStatus: (...args: unknown[]) => updateOrderStatus(...args),
 }));
 
 vi.mock("@/api/payments", () => ({
@@ -74,6 +89,8 @@ function renderPage(path: string) {
           <Route path="/orders/:id" element={<OrderStatusPage />} />
           <Route path="/orders/:id/return" element={<OrderStatusPage />} />
           <Route path="/orders/:id/cancel" element={<OrderStatusPage />} />
+          <Route path="/account/orders" element={<div>Histórico</div>} />
+          <Route path="/listing/:id" element={<div>Listing</div>} />
           <Route path="/products" element={<div>Market</div>} />
         </Routes>
       </MemoryRouter>
@@ -87,6 +104,13 @@ describe("OrderStatusPage", () => {
     createPaymentLink.mockReset();
     createOrder.mockReset();
     redirectToExternal.mockReset();
+    updateOrderStatus.mockReset();
+    authState.user = {
+      id: "customer-1",
+      name: "Buyer",
+      email: "buyer@test.com",
+      role: "CUSTOMER",
+    };
   });
 
   afterEach(() => {
@@ -169,6 +193,12 @@ describe("OrderStatusPage", () => {
     renderPage("/orders/order-missing");
 
     expect(await screen.findByText("Pedido não encontrado")).toBeTruthy();
+    expect(
+      screen.getByText("Este pedido não existe ou não pertence à sua conta."),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Voltar aos pedidos" }),
+    ).toHaveAttribute("href", "/account/orders");
     expect(screen.getByRole("link", { name: "Ir ao Market" })).toBeTruthy();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
   });
@@ -309,5 +339,43 @@ describe("OrderStatusPage", () => {
     expect(await screen.findByText(USER_FACING_ORDER_CANCELLED)).toBeTruthy();
     expect(createOrder).not.toHaveBeenCalled();
     expect(screen.queryByText("Pagamento confirmado.")).toBeNull();
+  });
+
+  it("links items to the listing and returns CUSTOMER to the order history", async () => {
+    getOrder.mockResolvedValue(
+      pendingOrder({
+        trackingCode: "BR123456789",
+        trackingCarrier: "Correios",
+      }),
+    );
+    renderPage("/orders/order-1");
+
+    expect(
+      await screen.findByRole("link", {
+        name: "AK-47 | Redline (Field-Tested)",
+      }),
+    ).toHaveAttribute("href", "/listing/listing-ak");
+    expect(
+      screen.getByRole("link", { name: "Voltar aos pedidos" }),
+    ).toHaveAttribute("href", "/account/orders");
+    expect(screen.getByText("Transportadora")).toBeTruthy();
+    expect(screen.getByText("Correios")).toBeTruthy();
+    expect(screen.getByText("Rastreio")).toBeTruthy();
+    expect(screen.getByText("BR123456789")).toBeTruthy();
+    expect(updateOrderStatus).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: /atualizar status|enviar/i }),
+    ).toBeNull();
+  });
+
+  it("does not show the buyer history shortcut for SELLER or ADMIN", async () => {
+    authState.user.role = "SELLER" as Role;
+    getOrder.mockResolvedValue(pendingOrder());
+    renderPage("/orders/order-1");
+
+    expect(await screen.findByText("Pedido Pendente")).toBeTruthy();
+    expect(
+      screen.queryByRole("link", { name: "Voltar aos pedidos" }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Histórico de pedidos do comprador em `/account/orders`, usando `GET /orders` já existente. O detalhe continua em `/orders/:id` (PayPal return/cancel e checkout intactos).

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/95

## O que muda

- Lista CUSTOMER: data, total, status, paymentStatus, primeiro item.
- Header “Pedidos” só para CUSTOMER. SELLER/ADMIN na lista vão aos dashboards deles.
- Detalhe: links de listing, tracking, “Voltar aos pedidos”, 403/404 em PT.
- Sem patch de status pelo comprador. Sem filtro client-side por `customerId`.

## Verificação

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → 39 files, 210 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

