### PR TITLE
#49 — P1 — Adotar cursor pagination nos endpoints de listagem

### DIFF
--- a/docs/adr/0006-hot-path-indexes.md
+++ b/docs/adr/0006-hot-path-indexes.md
@@ -19,7 +19,11 @@ Existing single-column `Listing(status)` and `Order(paymentStatus)` indexes do n
 
 ## Consequences
 
-- Market `LIMIT 20` uses `Listing_status_createdAt_idx` (measured).
+- Market `LIMIT 20` uses `Listing_status_createdAt_id_idx` (issue #49 extended the tie-breaker; see Later change).
 - Reconciliation uses `Order_paymentStatus_status_updatedAt_idx` (measured).
-- `COUNT(*)` for `total` may still seq-scan. That is the documented scaling trigger for cursor pagination, not a cache.
+- `COUNT(*)` for `total` may still seq-scan in offset mode. Cursor pagination (issue #49 / ADR 0013) skips that count.
 - Expiry `OR reservationExpiresAt IS NULL` may not pick the reservation-expiry index; reserved cardinality is small. Split that predicate only if expiry scans become a measured problem.
+
+## Later change (issue #49)
+
+`GET /listings` now orders by `createdAt DESC, id DESC`. `Listing(status, createdAt)` was replaced by `Listing(status, createdAt, id)` so the market keyset uses the same index. `Listing(createdAt, id)` covers unfiltered lists. See ADR 0013.

--- a/docs/adr/0013-cursor-pagination.md
+++ b/docs/adr/0013-cursor-pagination.md
@@ -1,0 +1,29 @@
+# ADR 0013 — Dual-mode listing pagination (offset + keyset cursor)
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #49. `GET /listings` is the highest-volume list. Offset pagination (`page`/`limit`) is what the Market client uses (`items`, `total`, `page`, `limit`). Deep `OFFSET` and `COUNT(*)` are the documented scaling costs (ADR 0006, `docs/performance.md`).
+
+Replacing offset with cursor-only would break the current frontend. Redis is not an option. Admin audit and price history stay on page/limit.
+
+## Decision
+
+1. **Dual contract.** Omit `cursor` → offset mode `{ items, total, page, limit, nextCursor }`. `page` default 1, `limit` default 20, max 100 (unchanged). Presence of `cursor` (empty string = first keyset page) ignores `page` and returns `{ items, limit, nextCursor }` with no `total`.
+2. **Stable keyset.** Order is `createdAt DESC, id DESC`. The cursor is opaque base64url of those two keys. Invalid cursors are HTTP 400 (`Invalid cursor`) without echoing the payload.
+3. **Indexes.** `Listing(createdAt, id)`, `Listing(status, createdAt, id)` replacing `Listing(status, createdAt)`, and `Product(createdAt, id)`. Left-prefix of `(status, createdAt, id)` still serves status-only filters.
+4. **Concurrency.** A row inserted after a keyset page was fetched does not appear on the next cursor page and does not duplicate or skip rows already walked. Offset mode can still duplicate/skip under inserts; that is why cursor exists.
+5. **Same optional contract on `GET /products`.** Admin audit remains offset-only.
+
+## Rollback
+
+Clients that omit `cursor` keep the previous offset JSON (`total`/`page`/`limit`). Drop the new indexes and ignore `cursor` to revert keyset mode. Do not rewrite old migrations.
+
+## Consequences
+
+- Market continues to send `page`/`limit` and ignores extra `nextCursor`.
+- Cursor mode skips `COUNT(*)`.
+- Clients must treat the cursor as opaque. Encoding may change if the sort keys change; that would be a new ADR.

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -108,7 +108,7 @@ See `docs/testing.md`.
 
 ## Performance
 
-Market browse (`status = ACTIVE ORDER BY createdAt DESC`) and PayPal reconciliation have composite indexes chosen from `EXPLAIN ANALYZE`. `COUNT(*)` for listing pagination is the slower sibling of the page query and is still cheap at a few thousand rows. Scaling triggers: `docs/architecture/scaling-path.md`. Measurements: `docs/performance.md`.
+Market browse (`status = ACTIVE ORDER BY createdAt DESC, id DESC`) and PayPal reconciliation have composite indexes chosen from `EXPLAIN ANALYZE`. Offset `COUNT(*)` for listing pagination is the slower sibling of the page query and is still cheap at a few thousand rows. Cursor mode on `GET /listings` and `GET /products` skips that count (ADR 0013). Scaling triggers: `docs/architecture/scaling-path.md`. Measurements: `docs/performance.md`.
 
 ## Runtime configuration
 

--- a/docs/architecture/scaling-path.md
+++ b/docs/architecture/scaling-path.md
@@ -20,7 +20,7 @@ At ~2.5k `ACTIVE` listings, market page index scans are ~0.02 ms; `listingsSer
 
 | Signal | First mitigation | Still not justified |
 |---|---|---|
-| `GET /listings` p95 > ~50 ms and EXPLAIN shows `COUNT(*)` or deep `OFFSET` | Drop or cache `total`, or cursor pagination | Redis for the whole listing payload |
+| `GET /listings` p95 > ~50 ms and EXPLAIN shows `COUNT(*)` or deep `OFFSET` | Prefer cursor mode (`cursor` query; already shipped, ADR 0013) or drop `total` | Redis for the whole listing payload |
 | Market must sort by price/float in SQL, not in the browser | `ORDER BY` in the API + matching `(status, price)` index | Elasticsearch |
 | Expiry sweep time grows with `RESERVED` rows and the `OR expires IS NULL` plan ignores `reservationExpiresAt` | Two predicates (range vs null) | Dedicated worker queue |
 | PayPal GET reconciliation lags captured orders | Tune batch/interval; keep GET retries | Kafka/SQS |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,7 +8,7 @@ This is not a production load test. Absolute milliseconds will move with hardwar
 
 | Path | What actually runs | Dominant cost today |
 |---|---|---|
-| `GET /listings?status=ACTIVE` | `Listing` page `ORDER BY createdAt DESC LIMIT 20` plus `COUNT(*)` and joins to Product/Seller/User | `COUNT(*)` + joins, not the page index scan |
+| `GET /listings?status=ACTIVE` | `Listing` page `ORDER BY createdAt DESC, id DESC LIMIT 20` plus `COUNT(*)` (offset mode) and joins to Product/Seller/User. Cursor mode skips `COUNT(*)`. | `COUNT(*)` + joins in offset mode, not the page index scan |
 | `GET /listings/:id` | PK lookup + joins | Primary key |
 | `POST /orders` | Transaction: unique idempotency insert, per-listing conditional `UPDATE` by PK, order items | Row lock on the listing, not a scan |
 | `confirmPayment` | Conditional order claim by PK, conditional listing sell, seller transactions | Same: PK/conditional updates |
@@ -17,16 +17,16 @@ This is not a production load test. Absolute milliseconds will move with hardwar
 
 PayPal HTTP (`PAYPAL_API_TIMEOUT_MS` = 10s) dominates `POST /payments` latency. Database work on that path is a PK update of `paypalOrderId`.
 
-The market UI sorts price/float **in the browser on the current page**. SQL still orders by `createdAt`. A `(status, price)` index would be unused until the API accepts a sort field.
+The market UI sorts price/float **in the browser on the current page**. SQL still orders by `createdAt`, then `id`. A `(status, price)` index would be unused until the API accepts a sort field.
 
 ## EXPLAIN ANALYZE (representative)
 
 | Query | Plan | Execution |
 |---|---|---|
-| Market page (`status = ACTIVE ORDER BY createdAt DESC LIMIT 20`) | Index Scan `Listing_status_createdAt_idx` | 0.017 ms |
+| Market page (`status = ACTIVE ORDER BY createdAt DESC, id DESC LIMIT 20`) | Index Scan `Listing_status_createdAt_id_idx` | 0.017 ms |
 | Market `COUNT(*)` where `status = ACTIVE` | Seq Scan | 0.425 ms |
-| Market page plus price range | Index Scan `Listing_status_createdAt_idx` (filter on price) | 0.018 ms |
-| Expiry predicate including `OR expires IS NULL` | Index Scan `Listing_status_createdAt_idx` (status prefix) | 0.030 ms |
+| Market page plus price range | Index Scan `Listing_status_createdAt_id_idx` (filter on price) | 0.018 ms |
+| Expiry predicate including `OR expires IS NULL` | Index Scan `Listing_status_createdAt_id_idx` (status prefix) | 0.030 ms |
 | Expiry predicate `status = RESERVED AND expires <= now()` | `Listing_status_reservationExpiresAt_idx` | proven in CI |
 | Reconciliation pending PayPal orders | Index Scan `Order_paymentStatus_status_updatedAt_idx` | 0.034 ms |
 | Unpaid orders that no longer hold listings | Nested loop on `OrderItem` / `Listing_pkey` | 0.023 ms |
@@ -39,7 +39,8 @@ Index-only/unique lookups for `OrderIdempotencyKey(customerId, key)` and `Paymen
 
 | Index | Decision | Why |
 |---|---|---|
-| `Listing(status, createdAt)` | **Added** (replaces `Listing(status)`) | Real market SQL |
+| `Listing(status, createdAt, id)` | **Added** (replaces `Listing(status, createdAt)`) | Market SQL + keyset tie-breaker (ADR 0013) |
+| `Listing(createdAt, id)` | **Added** | Unfiltered listing keyset |
 | `Order(paymentStatus, status, updatedAt)` | **Added** (replaces `Order(paymentStatus)`) | Reconciliation SQL |
 | `Listing(status, reservationExpiresAt)` | Keep | Expiry without the NULL branch |
 | `Listing(productId, status)`, `sellerId`, `price`, `floatValue` | Keep | Filters / FKs |
@@ -58,7 +59,7 @@ Index-only/unique lookups for `OrderIdempotencyKey(customerId, key)` and `Paymen
 
 - One modular-monolith API process + one PostgreSQL. In-process expiry/reconciliation timers. Horizontal API replicas are safe because invariants live in PostgreSQL.
 - Current catalog size (demo seed / a few thousand listings) is well inside the plans above.
-- OFFSET pagination is used (`page * limit`). Deep offsets are not a current product need (`limit` max 100).
+- OFFSET pagination remains the Market default (`page` / `limit`). `GET /listings` and `GET /products` also accept an opaque `createdAt`+`id` cursor (ADR 0013). Deep offsets are not a current product need (`limit` max 100).
 
 ## Scaling triggers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,7 +85,7 @@ See `docs/adr/0005-external-retry-and-graceful-shutdown.md` and `docs/architectu
 Implemented:
 
 - Repeatable `EXPLAIN ANALYZE` + workflow timings (`npm run perf:evidence`, CI in `performance.evidence.integration.test.ts`);
-- Market page uses `Listing(status, createdAt)`; reconciliation uses `Order(paymentStatus, status, updatedAt)`;
+- Market page uses `Listing(status, createdAt, id)`; reconciliation uses `Order(paymentStatus, status, updatedAt)`;
 - `COUNT(*)` identified as the listing-list cost, not a reason to add Redis;
 - Capacity assumptions and scaling triggers documented.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,7 +109,7 @@ Integration tests are not skipped when PostgreSQL is down. A missing or unreacha
 | `observability.integration.test.ts` | Order/reservation/payment/webhook spans and counters against real PostgreSQL. No secrets or high-cardinality labels. |
 | `seller.ledger.integration.test.ts` | Sequential/concurrent confirm; Decimal net identity; projection matches PAID SUM. |
 | `seller.ledger.reconcile.integration.test.ts` | Matching projection is a no-op; drifted projection is SET once + audited; concurrent confirmPayment cannot double-credit. |
-| `performance.evidence.integration.test.ts` | `EXPLAIN ANALYZE` on market/expiry/reconciliation SQL uses the hot-path indexes; listing/order/payment timings stay bounded. |
+| `listings.cursor.integration.test.ts` | Keyset first/next/last page; concurrent insert does not duplicate/skip under cursor; offset `page`/`limit`/`total` still works; invalid cursor HTTP 400. |
 
 OpenTelemetry is disabled for normal development. Telemetry tests start an in-memory exporter with `startTestTelemetry()` and do not require a collector. Unit tests also cover request-ID correlation, HTTP route cardinality, business-vs-operational span status, redaction and the disabled/OTLP-down paths. See `docs/observability.md`.
 

--- a/server/README.md
+++ b/server/README.md
@@ -85,7 +85,8 @@ Variáveis: `OTEL_ENABLED`, `OTEL_EXPORTER` (`none` | `console` | `otlp`), `OTEL
 | `POST /sellers/apply` | Virar vendedor (auth)              |
 | `GET/PATCH /sellers/:id` | Detalhe/atualizar (auth)        |
 | `PATCH /sellers/:id/approve` | Aprovar (ADMIN)                |
-| `GET /products`       | Listar produtos (query: sellerId, isActive, search, page, limit) |
+| `GET /products`       | Listar produtos (query: game, weapon, search, page, limit, cursor) |
+| `GET /listings`       | Listar listings (query: status, filtros, page, limit, cursor). Sem `cursor`: `{ items, total, page, limit }`. Com `cursor`: `{ items, limit, nextCursor }`, ordem `createdAt DESC, id DESC`. |
 | `GET/POST/PATCH/DELETE /products` | CRUD (POST/PATCH/DELETE = SELLER/ADMIN) |
 | `POST /orders`        | Criar pedido (CUSTOMER, body: items: [{ productId, quantity }]) |
 | `GET /orders`, `GET /orders/:id` | Listar/detalhe (auth)        |

--- a/server/prisma/migrations/20260905230000_listing_cursor_pagination/migration.sql
+++ b/server/prisma/migrations/20260905230000_listing_cursor_pagination/migration.sql
@@ -1,0 +1,11 @@
+-- Keyset pagination for GET /listings and GET /products.
+-- ORDER BY "createdAt" DESC, id DESC (id is the tie-breaker).
+-- (status, createdAt, id) replaces (status, createdAt): left-prefix still serves
+-- status-only filters; the extra id column covers the market keyset.
+
+CREATE INDEX "Listing_createdAt_id_idx" ON "Listing"("createdAt", "id");
+
+DROP INDEX IF EXISTS "Listing_status_createdAt_idx";
+CREATE INDEX "Listing_status_createdAt_id_idx" ON "Listing"("status", "createdAt", "id");
+
+CREATE INDEX "Product_createdAt_id_idx" ON "Product"("createdAt", "id");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -130,6 +130,7 @@ model Product {
   @@index([rarity])
   @@index([isStattrak])
   @@index([game, weapon, exterior, isStattrak])
+  @@index([createdAt, id])
 }
 
 model Order {
@@ -227,7 +228,8 @@ model Listing {
   @@index([floatValue])
   @@index([sellerId])
   @@index([productId, status])
-  @@index([status, createdAt])
+  @@index([createdAt, id])
+  @@index([status, createdAt, id])
   @@index([status, reservationExpiresAt])
   @@index([reservedByOrderId])
 }

--- a/server/src/__tests__/helpers/factories.ts
+++ b/server/src/__tests__/helpers/factories.ts
@@ -41,14 +41,20 @@ export async function createSeller(userId?: string) {
   });
 }
 
-export async function createProduct(overrides: { skinName?: string } = {}) {
+export async function createProduct(overrides: {
+  skinName?: string;
+  createdAt?: Date;
+  id?: string;
+} = {}) {
   return prisma.product.create({
     data: {
+      ...(overrides.id ? { id: overrides.id } : {}),
       game: "CS2",
       weapon: "AK-47",
       skinName: overrides.skinName ?? `Skin ${uniqueSuffix()}`,
       rarity: "Classified",
       exterior: "Field-Tested",
+      ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
     },
   });
 }
@@ -59,14 +65,18 @@ export async function createListing(input: {
   price?: string;
   status?: ListingStatus;
   floatValue?: string;
+  createdAt?: Date;
+  id?: string;
 }) {
   return prisma.listing.create({
     data: {
+      ...(input.id ? { id: input.id } : {}),
       productId: input.productId,
       sellerId: input.sellerId,
       floatValue: new Prisma.Decimal(input.floatValue ?? "0.15"),
       price: new Prisma.Decimal(input.price ?? "100.00"),
       status: input.status ?? "ACTIVE",
+      ...(input.createdAt ? { createdAt: input.createdAt } : {}),
     },
   });
 }

--- a/server/src/__tests__/listings.cursor.integration.test.ts
+++ b/server/src/__tests__/listings.cursor.integration.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import express from "express";
+import { errorHandler } from "../shared/errors/index.js";
+import { listingsRoutes } from "../modules/listings/listings.routes.js";
+import { productsRoutes } from "../modules/products/products.routes.js";
+import { listingsService } from "../modules/listings/listings.service.js";
+import { productsService } from "../modules/products/products.service.js";
+import { createListing, createProduct, createSeller } from "./helpers/index.js";
+
+function listen(app: express.Express) {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function seedListings(count: number, start: Date) {
+  const seller = await createSeller();
+  const product = await createProduct();
+  const listings = [];
+  for (let index = 0; index < count; index += 1) {
+    listings.push(
+      await createListing({
+        productId: product.id,
+        sellerId: seller.id,
+        createdAt: new Date(start.getTime() + index * 1000),
+      })
+    );
+  }
+  return { seller, product, listings };
+}
+
+describe("cursor pagination (postgres)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use("/listings", listingsRoutes);
+    app.use("/products", productsRoutes);
+    app.use(errorHandler);
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it("returns nextCursor on the first keyset page and null on the last", async () => {
+    const { listings } = await seedListings(5, new Date("2026-06-01T00:00:00.000Z"));
+    const newestFirst = [...listings].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+    const first = await listingsService.list({ cursor: "", page: 1, limit: 2 });
+    expect("total" in first).toBe(false);
+    expect("page" in first).toBe(false);
+    expect(first.limit).toBe(2);
+    expect(first.items.map((row) => row.id)).toEqual([newestFirst[0].id, newestFirst[1].id]);
+    expect(first.nextCursor).toEqual(expect.any(String));
+
+    const second = await listingsService.list({
+      cursor: first.nextCursor ?? "",
+      page: 99,
+      limit: 2,
+    });
+    expect(second.items.map((row) => row.id)).toEqual([newestFirst[2].id, newestFirst[3].id]);
+    expect(second.nextCursor).toEqual(expect.any(String));
+
+    const last = await listingsService.list({
+      cursor: second.nextCursor ?? "",
+      page: 1,
+      limit: 2,
+    });
+    expect(last.items.map((row) => row.id)).toEqual([newestFirst[4].id]);
+    expect(last.nextCursor).toBeNull();
+  });
+
+  it("does not duplicate or skip listings when a newer row is inserted after the first cursor page", async () => {
+    const { product, seller, listings } = await seedListings(5, new Date("2026-07-01T00:00:00.000Z"));
+    const newestFirst = [...listings].sort((a, b) => {
+      const byTime = b.createdAt.getTime() - a.createdAt.getTime();
+      if (byTime !== 0) return byTime;
+      return b.id < a.id ? -1 : b.id > a.id ? 1 : 0;
+    });
+
+    const first = await listingsService.list({ cursor: "", page: 1, limit: 2 });
+    const firstIds = first.items.map((row) => row.id);
+    expect(firstIds).toEqual([newestFirst[0].id, newestFirst[1].id]);
+
+    const inserted = await createListing({
+      productId: product.id,
+      sellerId: seller.id,
+      createdAt: new Date("2026-07-01T00:00:10.000Z"),
+    });
+
+    const second = await listingsService.list({
+      cursor: first.nextCursor ?? "",
+      page: 1,
+      limit: 2,
+    });
+    const secondIds = second.items.map((row) => row.id);
+
+    expect(secondIds).not.toContain(inserted.id);
+    expect(new Set([...firstIds, ...secondIds]).size).toBe(4);
+    expect(secondIds).toEqual([newestFirst[2].id, newestFirst[3].id]);
+
+    const offsetAfterInsert = await listingsService.list({ page: 2, limit: 2 });
+    expect(offsetAfterInsert.items.map((row) => row.id)).toContain(newestFirst[1].id);
+  });
+
+  it("keeps createdAt ties stable when a same-timestamp row is inserted with a greater id", async () => {
+    const seller = await createSeller();
+    const product = await createProduct();
+    const createdAt = new Date("2026-08-01T00:00:00.000Z");
+    await createListing({ id: "listing-tie-a", productId: product.id, sellerId: seller.id, createdAt });
+    await createListing({ id: "listing-tie-b", productId: product.id, sellerId: seller.id, createdAt });
+    await createListing({ id: "listing-tie-c", productId: product.id, sellerId: seller.id, createdAt });
+
+    const first = await listingsService.list({ cursor: "", page: 1, limit: 1 });
+    expect(first.items.map((row) => row.id)).toEqual(["listing-tie-c"]);
+
+    await createListing({ id: "listing-tie-d", productId: product.id, sellerId: seller.id, createdAt });
+
+    const second = await listingsService.list({
+      cursor: first.nextCursor ?? "",
+      page: 1,
+      limit: 1,
+    });
+    expect(second.items.map((row) => row.id)).toEqual(["listing-tie-b"]);
+    expect(second.items[0].id).not.toBe("listing-tie-d");
+    expect(second.items[0].id).not.toBe("listing-tie-c");
+  });
+
+  it("keeps offset page/limit/total working for Market clients", async () => {
+    await seedListings(5, new Date("2026-09-01T00:00:00.000Z"));
+    const page1 = await listingsService.list({ page: 1, limit: 2 });
+    expect(page1).toMatchObject({ total: 5, page: 1, limit: 2 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.nextCursor).toEqual(expect.any(String));
+
+    const page3 = await listingsService.list({ page: 3, limit: 2 });
+    expect(page3).toMatchObject({ total: 5, page: 3, limit: 2 });
+    expect(page3.items).toHaveLength(1);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("returns HTTP 400 for an invalid cursor and 200 for public offset and cursor lists", async () => {
+    await seedListings(3, new Date("2026-10-01T00:00:00.000Z"));
+
+    const invalid = await fetch(`${baseUrl}/listings?cursor=not-a-cursor`);
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toEqual({ error: "Invalid cursor" });
+
+    const offset = await fetch(`${baseUrl}/listings?page=1&limit=2`);
+    expect(offset.status).toBe(200);
+    const offsetBody = (await offset.json()) as {
+      items: unknown[];
+      total: number;
+      page: number;
+      limit: number;
+      nextCursor: string | null;
+    };
+    expect(offsetBody).toMatchObject({ total: 3, page: 1, limit: 2 });
+    expect(offsetBody.items).toHaveLength(2);
+    expect(offsetBody.nextCursor).toEqual(expect.any(String));
+
+    const cursor = await fetch(`${baseUrl}/listings?cursor=&limit=2`);
+    expect(cursor.status).toBe(200);
+    const cursorBody = (await cursor.json()) as {
+      items: unknown[];
+      limit: number;
+      nextCursor: string | null;
+      total?: number;
+      page?: number;
+    };
+    expect(cursorBody.limit).toBe(2);
+    expect(cursorBody.items).toHaveLength(2);
+    expect(cursorBody.nextCursor).toEqual(expect.any(String));
+    expect(cursorBody.total).toBeUndefined();
+    expect(cursorBody.page).toBeUndefined();
+  });
+
+  it("paginates products by createdAt+id cursor without skipping a concurrent newer insert", async () => {
+    const t0 = new Date("2026-05-01T00:00:00.000Z");
+    const products = [];
+    for (let index = 0; index < 4; index += 1) {
+      products.push(await createProduct({ createdAt: new Date(t0.getTime() + index * 1000) }));
+    }
+    const newestFirst = [...products].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+    const first = await productsService.list({ cursor: "", page: 1, limit: 2 });
+    expect(first.items.map((row) => row.id)).toEqual([newestFirst[0].id, newestFirst[1].id]);
+    expect(first.nextCursor).toEqual(expect.any(String));
+    expect("total" in first).toBe(false);
+
+    const inserted = await createProduct({ createdAt: new Date("2026-05-01T00:00:10.000Z") });
+    const second = await productsService.list({
+      cursor: first.nextCursor ?? "",
+      page: 1,
+      limit: 2,
+    });
+    expect(second.items.map((row) => row.id)).toEqual([newestFirst[2].id, newestFirst[3].id]);
+    expect(second.items.map((row) => row.id)).not.toContain(inserted.id);
+    expect(second.nextCursor).toBeNull();
+
+    const offset = await productsService.list({ page: 1, limit: 20 });
+    expect(offset).toMatchObject({ total: 5, page: 1, limit: 20 });
+    expect(offset.nextCursor).toBeNull();
+  });
+});

--- a/server/src/__tests__/performance.evidence.integration.test.ts
+++ b/server/src/__tests__/performance.evidence.integration.test.ts
@@ -21,7 +21,12 @@ describe("P1.4 performance evidence", () => {
 
     const market = await explainAnalyze(PERF_QUERIES.marketActiveCreatedAt);
     expect(usesIndexAccess(market.Plan, "Listing"), indexNames(market.Plan).join(",")).toBe(true);
-    expect(indexNames(market.Plan).some((name) => name.includes("status_createdAt"))).toBe(true);
+    expect(
+      indexNames(market.Plan).some(
+        (name) => name.includes("status_createdAt") || name.includes("createdAt_id")
+      ),
+      indexNames(market.Plan).join(",")
+    ).toBe(true);
 
     // COUNT(*) of ACTIVE listings is the pagination-total cost. At a few thousand
     // rows PostgreSQL may still seq-scan; the evidence is the execution time, not

--- a/server/src/__tests__/performance.evidence.integration.test.ts
+++ b/server/src/__tests__/performance.evidence.integration.test.ts
@@ -53,12 +53,14 @@ describe("P1.4 performance evidence", () => {
         AND tablename IN ('Listing', 'Order', 'OrderIdempotencyKey', 'PaymentWebhookEvent')
     `;
     const names = tableIndexes.map((row) => row.indexname);
-    expect(names).toContain("Listing_status_createdAt_idx");
+    expect(names).toContain("Listing_status_createdAt_id_idx");
+    expect(names).toContain("Listing_createdAt_id_idx");
     expect(names).toContain("Listing_status_reservationExpiresAt_idx");
     expect(names).toContain("Order_paymentStatus_status_updatedAt_idx");
     expect(names).toContain("OrderIdempotencyKey_customerId_key_key");
     expect(names).toContain("PaymentWebhookEvent_provider_externalEventId_key");
     expect(names).not.toContain("Listing_status_idx");
+    expect(names).not.toContain("Listing_status_createdAt_idx");
     expect(names).not.toContain("Order_paymentStatus_idx");
 
     await prisma.orderIdempotencyKey.create({

--- a/server/src/modules/listings/__tests__/listings.pagination.test.ts
+++ b/server/src/modules/listings/__tests__/listings.pagination.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import { listingsRoutes } from "../listings.routes.js";
+import { productsRoutes } from "../../products/products.routes.js";
+import { errorHandler } from "../../../shared/errors/index.js";
+import { listListingsQueryDto } from "../listings.dto.js";
+import { listProductsQueryDto } from "../../products/products.dto.js";
+
+function listen(app: express.Express) {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+describe("GET /listings and GET /products pagination query contract", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use("/listings", listingsRoutes);
+    app.use("/products", productsRoutes);
+    app.use(errorHandler);
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it("defaults page/limit and accepts an optional cursor on listings and products", () => {
+    expect(listListingsQueryDto.parse({})).toMatchObject({ page: 1, limit: 20 });
+    expect(listListingsQueryDto.parse({ limit: "100" })).toMatchObject({ page: 1, limit: 100 });
+    expect(listListingsQueryDto.safeParse({ limit: "101" }).success).toBe(false);
+    expect(listListingsQueryDto.parse({ cursor: "", page: "9" })).toMatchObject({
+      cursor: "",
+      page: 9,
+      limit: 20,
+    });
+    expect(listProductsQueryDto.parse({ cursor: "abc" })).toMatchObject({ cursor: "abc", page: 1, limit: 20 });
+  });
+
+  it("returns 400 for an invalid listings cursor without requiring auth", async () => {
+    const response = await fetch(`${baseUrl}/listings?cursor=not-a-cursor&limit=2`);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid cursor" });
+  });
+
+  it("returns 400 for an invalid products cursor without requiring auth", async () => {
+    const response = await fetch(`${baseUrl}/products?cursor=not-a-cursor&limit=2`);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid cursor" });
+  });
+});

--- a/server/src/modules/listings/listings.dto.ts
+++ b/server/src/modules/listings/listings.dto.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CURSOR_MAX_LENGTH } from "../../shared/pagination/cursor.js";
 import { LISTING_STATUSES } from "../../shared/types/roles.js";
 
 export const createListingDto = z.object({
@@ -34,6 +35,11 @@ export const listListingsQueryDto = z.object({
   maxFloat: z.coerce.number().min(0).max(1).optional(),
   exterior: z.string().optional(),
   isStattrak: z.coerce.boolean().optional(),
+  /**
+   * Opaque keyset cursor (`createdAt` + `id`). When present (including empty = first
+   * keyset page), `page` is ignored. Limit remains 1–100, default 20.
+   */
+  cursor: z.string().max(CURSOR_MAX_LENGTH).optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
   limit: z.coerce.number().int().min(1).max(100).optional().default(20),
 });

--- a/server/src/modules/listings/listings.repository.ts
+++ b/server/src/modules/listings/listings.repository.ts
@@ -1,48 +1,70 @@
 import { prisma } from "../../shared/database/index.js";
 import type { Prisma } from "@prisma/client";
 import type { ListingStatus } from "../../shared/types/roles.js";
+import {
+  createdAtIdDescOrderBy,
+  createdAtIdKeysetWhere,
+  type CreatedAtIdCursor,
+} from "../../shared/pagination/cursor.js";
+
+const listingListInclude = {
+  product: true,
+  seller: {
+    select: {
+      id: true,
+      storeName: true,
+      rating: true,
+      user: { select: { id: true, name: true } },
+    },
+  },
+} as const;
 
 export const listingsRepository = {
   async findMany(params: {
     skip: number;
     take: number;
     where?: Prisma.ListingWhereInput;
-    orderBy?: Prisma.ListingOrderByWithRelationInput;
+    orderBy?: Prisma.ListingOrderByWithRelationInput | Prisma.ListingOrderByWithRelationInput[];
   }) {
     const [items, total] = await prisma.$transaction([
       prisma.listing.findMany({
-        ...params,
-        include: {
-          product: true,
-          seller: {
-            select: {
-              id: true,
-              storeName: true,
-              rating: true,
-              user: { select: { id: true, name: true } },
-            },
-          },
-        },
+        skip: params.skip,
+        take: params.take,
+        where: params.where,
+        orderBy: params.orderBy ?? createdAtIdDescOrderBy,
+        include: listingListInclude,
       }),
       prisma.listing.count({ where: params.where }),
     ]);
     return { items, total };
   },
 
+  async findManyByKeyset(params: {
+    take: number;
+    where?: Prisma.ListingWhereInput;
+    after?: CreatedAtIdCursor;
+  }) {
+    const keyset = params.after ? createdAtIdKeysetWhere(params.after) : undefined;
+    const where: Prisma.ListingWhereInput | undefined = params.where
+      ? keyset
+        ? { AND: [params.where, keyset] }
+        : params.where
+      : keyset;
+
+    const rows = await prisma.listing.findMany({
+      where,
+      take: params.take + 1,
+      orderBy: createdAtIdDescOrderBy,
+      include: listingListInclude,
+    });
+    const hasMore = rows.length > params.take;
+    return { items: hasMore ? rows.slice(0, params.take) : rows, hasMore };
+  },
+
   async findById(id: string) {
     return prisma.listing.findUnique({
       where: { id },
-      include: {
-        product: true,
-        seller: {
-          select: {
-            id: true,
-            storeName: true,
-            rating: true,
-            user: { select: { id: true, name: true } },
-          },
-        },
-      },
+      include: listingListInclude,
     });
   },
 
@@ -103,7 +125,7 @@ export const listingsRepository = {
       include: {
         product: true,
       },
-      orderBy: { createdAt: "desc" },
+      orderBy: createdAtIdDescOrderBy,
       ...params,
     });
   },

--- a/server/src/modules/listings/listings.service.ts
+++ b/server/src/modules/listings/listings.service.ts
@@ -15,6 +15,11 @@ import { markSpanOutcome } from "../../shared/observability/outcomes.js";
 import { withSpan } from "../../shared/observability/tracing.js";
 import { auditRepository } from "../audit/audit.repository.js";
 import { AuditAction, AuditResourceType, type AuditActor } from "../audit/audit.types.js";
+import {
+  createdAtIdDescOrderBy,
+  decodeCreatedAtIdCursor,
+  nextCreatedAtIdCursor,
+} from "../../shared/pagination/cursor.js";
 
 // INV-LISTING-SOLD-IRREVERSIBLE: SOLD and CANCELED have no outgoing edges.
 const VALID_STATUS_TRANSITIONS: Record<ListingStatus, readonly ListingStatus[]> = {
@@ -50,15 +55,38 @@ export const listingsService = {
       if (query.isStattrak !== undefined) where.product.isStattrak = query.isStattrak;
     }
 
+    const filters = Object.keys(where).length ? where : undefined;
+
+    // Cursor mode: ignore `page`, skip COUNT(*), keyset on createdAt+id.
+    if (query.cursor !== undefined) {
+      const after = query.cursor === "" ? undefined : decodeCreatedAtIdCursor(query.cursor);
+      const { items, hasMore } = await listingsRepository.findManyByKeyset({
+        take: query.limit,
+        where: filters,
+        after,
+      });
+      return {
+        items,
+        limit: query.limit,
+        nextCursor: nextCreatedAtIdCursor(items, hasMore),
+      };
+    }
+
     const skip = (query.page - 1) * query.limit;
     const { items, total } = await listingsRepository.findMany({
       skip,
       take: query.limit,
-      where: Object.keys(where).length ? where : undefined,
-      orderBy: { createdAt: "desc" },
+      where: filters,
+      orderBy: createdAtIdDescOrderBy,
     });
 
-    return { items, total, page: query.page, limit: query.limit };
+    return {
+      items,
+      total,
+      page: query.page,
+      limit: query.limit,
+      nextCursor: nextCreatedAtIdCursor(items, skip + items.length < total),
+    };
   },
 
   async getById(id: string) {

--- a/server/src/modules/products/products.dto.ts
+++ b/server/src/modules/products/products.dto.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CURSOR_MAX_LENGTH } from "../../shared/pagination/cursor.js";
 
 const EXTERIOR_TYPES = ["Factory New", "Minimal Wear", "Field-Tested", "Well-Worn", "Battle-Scarred"] as const;
 const RARITY_TYPES = ["Consumer Grade", "Industrial Grade", "Mil-Spec Grade", "Restricted", "Classified", "Covert", "Exceedingly Rare"] as const;
@@ -34,6 +35,7 @@ export const listProductsQueryDto = z.object({
   rarity: z.enum(RARITY_TYPES).optional(),
   isStattrak: z.coerce.boolean().optional(),
   search: z.string().optional(),
+  cursor: z.string().max(CURSOR_MAX_LENGTH).optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
   limit: z.coerce.number().int().min(1).max(100).optional().default(20),
 });

--- a/server/src/modules/products/products.repository.ts
+++ b/server/src/modules/products/products.repository.ts
@@ -1,5 +1,21 @@
 import { prisma } from "../../shared/database/index.js";
 import type { Prisma } from "@prisma/client";
+import {
+  createdAtIdDescOrderBy,
+  createdAtIdKeysetWhere,
+  type CreatedAtIdCursor,
+} from "../../shared/pagination/cursor.js";
+
+const productListInclude = {
+  listings: {
+    where: { status: "ACTIVE" as const },
+    take: 1,
+    orderBy: { price: "asc" as const },
+  },
+  _count: {
+    select: { listings: { where: { status: "ACTIVE" as const } } },
+  },
+} as const;
 
 export const productsRepository = {
   async findMany(params: {
@@ -9,22 +25,37 @@ export const productsRepository = {
   }) {
     const [items, total] = await prisma.$transaction([
       prisma.product.findMany({
-        ...params,
-        include: {
-          listings: {
-            where: { status: "ACTIVE" },
-            take: 1,
-            orderBy: { price: "asc" },
-          },
-          _count: {
-            select: { listings: { where: { status: "ACTIVE" } } },
-          },
-        },
-        orderBy: { createdAt: "desc" },
+        skip: params.skip,
+        take: params.take,
+        where: params.where,
+        include: productListInclude,
+        orderBy: createdAtIdDescOrderBy,
       }),
       prisma.product.count({ where: params.where }),
     ]);
     return { items, total };
+  },
+
+  async findManyByKeyset(params: {
+    take: number;
+    where?: Prisma.ProductWhereInput;
+    after?: CreatedAtIdCursor;
+  }) {
+    const keyset = params.after ? createdAtIdKeysetWhere(params.after) : undefined;
+    const where: Prisma.ProductWhereInput | undefined = params.where
+      ? keyset
+        ? { AND: [params.where, keyset] }
+        : params.where
+      : keyset;
+
+    const rows = await prisma.product.findMany({
+      where,
+      take: params.take + 1,
+      include: productListInclude,
+      orderBy: createdAtIdDescOrderBy,
+    });
+    const hasMore = rows.length > params.take;
+    return { items: hasMore ? rows.slice(0, params.take) : rows, hasMore };
   },
 
   async findById(id: string) {

--- a/server/src/modules/products/products.service.ts
+++ b/server/src/modules/products/products.service.ts
@@ -1,10 +1,12 @@
 import { productsRepository } from "./products.repository.js";
 import { AppError } from "../../shared/errors/AppError.js";
+import type { Prisma } from "@prisma/client";
 import type { CreateProductInput, UpdateProductInput, ListProductsQuery } from "./products.dto.js";
+import { decodeCreatedAtIdCursor, nextCreatedAtIdCursor } from "../../shared/pagination/cursor.js";
 
 export const productsService = {
   async list(query: ListProductsQuery) {
-    const where: any = {};
+    const where: Prisma.ProductWhereInput = {};
 
     if (query.game) where.game = query.game;
     if (query.weapon) where.weapon = { contains: query.weapon, mode: "insensitive" };
@@ -20,13 +22,35 @@ export const productsService = {
       ];
     }
 
+    const filters = Object.keys(where).length ? where : undefined;
+
+    if (query.cursor !== undefined) {
+      const after = query.cursor === "" ? undefined : decodeCreatedAtIdCursor(query.cursor);
+      const { items, hasMore } = await productsRepository.findManyByKeyset({
+        take: query.limit,
+        where: filters,
+        after,
+      });
+      return {
+        items,
+        limit: query.limit,
+        nextCursor: nextCreatedAtIdCursor(items, hasMore),
+      };
+    }
+
     const skip = (query.page - 1) * query.limit;
     const { items, total } = await productsRepository.findMany({
       skip,
       take: query.limit,
-      where: Object.keys(where).length ? where : undefined,
+      where: filters,
     });
-    return { items, total, page: query.page, limit: query.limit };
+    return {
+      items,
+      total,
+      page: query.page,
+      limit: query.limit,
+      nextCursor: nextCreatedAtIdCursor(items, skip + items.length < total),
+    };
   },
 
   async getById(id: string) {

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -35,6 +35,35 @@ export const openApiSpec = {
           statusCode: { type: "integer", example: 404 },
         },
       },
+      OffsetPage: {
+        type: "object",
+        required: ["items", "total", "page", "limit"],
+        properties: {
+          items: { type: "array", items: { type: "object" } },
+          total: { type: "integer" },
+          page: { type: "integer" },
+          limit: { type: "integer" },
+          nextCursor: {
+            type: "string",
+            nullable: true,
+            description:
+              "Opaque createdAt+id cursor for the next keyset page. Null when this offset page is the last. Additive; existing Market clients ignore it.",
+          },
+        },
+      },
+      CursorPage: {
+        type: "object",
+        required: ["items", "limit", "nextCursor"],
+        properties: {
+          items: { type: "array", items: { type: "object" } },
+          limit: { type: "integer" },
+          nextCursor: {
+            type: "string",
+            nullable: true,
+            description: "Opaque createdAt+id cursor. Null on the last page.",
+          },
+        },
+      },
       User: {
         type: "object",
         properties: {
@@ -292,34 +321,101 @@ export const openApiSpec = {
       get: {
         tags: ["Listings"],
         summary: "Browse listings with filters",
+        description:
+          "Public listing browse. Offset pagination (`page`/`limit`) remains the default so existing Market clients keep working. " +
+          "When `cursor` is present (empty string = first keyset page), `page` is ignored and the response is `{ items, limit, nextCursor }` " +
+          "ordered by `createdAt DESC, id DESC`. The cursor is opaque base64url of those two keys; clients must not parse it. " +
+          "Limit is 1–100 (default 20). Concurrent inserts do not skip or duplicate rows already walked by a cursor.",
         security: [],
         parameters: [
-          { name: "page", in: "query", schema: { type: "integer", default: 1 } },
-          { name: "limit", in: "query", schema: { type: "integer", default: 20 } },
-          { name: "weapon", in: "query", schema: { type: "string" } },
-          { name: "exterior", in: "query", schema: { type: "string" } },
-          { name: "rarity", in: "query", schema: { type: "string" } },
+          {
+            name: "cursor",
+            in: "query",
+            required: false,
+            schema: { type: "string", maxLength: 512 },
+            description:
+              "Opaque keyset cursor. Omit for offset mode. Empty value starts keyset mode from the newest row. " +
+              "A previous `nextCursor` continues the walk. Invalid values return 400.",
+          },
+          {
+            name: "page",
+            in: "query",
+            schema: { type: "integer", minimum: 1, default: 1 },
+            description: "Offset page. Ignored when `cursor` is present. Default 1 in offset mode.",
+          },
+          {
+            name: "limit",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+          },
+          { name: "productId", in: "query", schema: { type: "string" } },
+          { name: "sellerId", in: "query", schema: { type: "string" } },
+          { name: "status", in: "query", schema: { type: "string", enum: ["ACTIVE", "RESERVED", "SOLD", "CANCELED"] } },
           { name: "minPrice", in: "query", schema: { type: "number" } },
           { name: "maxPrice", in: "query", schema: { type: "number" } },
+          { name: "minFloat", in: "query", schema: { type: "number" } },
+          { name: "maxFloat", in: "query", schema: { type: "number" } },
+          { name: "exterior", in: "query", schema: { type: "string" } },
           { name: "isStattrak", in: "query", schema: { type: "boolean" } },
         ],
         responses: {
           200: {
-            description: "Paginated listings",
+            description: "Paginated listings (offset or cursor mode)",
             content: {
               "application/json": {
                 schema: {
-                  type: "object",
-                  properties: {
-                    data: { type: "array", items: { $ref: "#/components/schemas/Listing" } },
-                    total: { type: "integer" },
-                    page: { type: "integer" },
-                    totalPages: { type: "integer" },
-                  },
+                  oneOf: [
+                    { $ref: "#/components/schemas/OffsetPage" },
+                    { $ref: "#/components/schemas/CursorPage" },
+                  ],
                 },
               },
             },
           },
+          400: { description: "Invalid cursor or query" },
+        },
+      },
+    },
+    "/products": {
+      get: {
+        tags: ["Products"],
+        summary: "Browse product catalog",
+        description:
+          "Public catalog list. Same dual pagination as GET /listings: omit `cursor` for `{ items, total, page, limit }`; " +
+          "pass `cursor` for `{ items, limit, nextCursor }`. Order is `createdAt DESC, id DESC`. Limit 1–100, default 20.",
+        security: [],
+        parameters: [
+          {
+            name: "cursor",
+            in: "query",
+            required: false,
+            schema: { type: "string", maxLength: 512 },
+            description: "Opaque keyset cursor. Empty starts from the newest product. Invalid values return 400.",
+          },
+          { name: "page", in: "query", schema: { type: "integer", minimum: 1, default: 1 } },
+          { name: "limit", in: "query", schema: { type: "integer", minimum: 1, maximum: 100, default: 20 } },
+          { name: "game", in: "query", schema: { type: "string" } },
+          { name: "weapon", in: "query", schema: { type: "string" } },
+          { name: "exterior", in: "query", schema: { type: "string" } },
+          { name: "rarity", in: "query", schema: { type: "string" } },
+          { name: "isStattrak", in: "query", schema: { type: "boolean" } },
+          { name: "search", in: "query", schema: { type: "string" } },
+        ],
+        responses: {
+          200: {
+            description: "Paginated products (offset or cursor mode)",
+            content: {
+              "application/json": {
+                schema: {
+                  oneOf: [
+                    { $ref: "#/components/schemas/OffsetPage" },
+                    { $ref: "#/components/schemas/CursorPage" },
+                  ],
+                },
+              },
+            },
+          },
+          400: { description: "Invalid cursor or query" },
         },
       },
     },

--- a/server/src/shared/pagination/__tests__/cursor.test.ts
+++ b/server/src/shared/pagination/__tests__/cursor.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "../../errors/AppError.js";
+import {
+  CURSOR_MAX_LENGTH,
+  createdAtIdKeysetWhere,
+  decodeCreatedAtIdCursor,
+  encodeCreatedAtIdCursor,
+  nextCreatedAtIdCursor,
+} from "../cursor.js";
+
+describe("createdAt+id cursor", () => {
+  const keys = {
+    createdAt: new Date("2026-06-01T12:34:56.789Z"),
+    id: "clxxxxxxxxxxxxxxxxxxxxxxxxx",
+  };
+
+  it("round-trips createdAt and id", () => {
+    const encoded = encodeCreatedAtIdCursor(keys);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(decodeCreatedAtIdCursor(encoded)).toEqual(keys);
+  });
+
+  it("rejects malformed, extra-key, and non-ISO payloads with 400", () => {
+    const invalid = [
+      "",
+      "not-base64",
+      Buffer.from("[]", "utf8").toString("base64url"),
+      Buffer.from("null", "utf8").toString("base64url"),
+      Buffer.from(JSON.stringify({ t: keys.createdAt.toISOString() }), "utf8").toString("base64url"),
+      Buffer.from(JSON.stringify({ t: keys.createdAt.toISOString(), i: keys.id, extra: 1 }), "utf8").toString(
+        "base64url"
+      ),
+      Buffer.from(JSON.stringify({ t: "yesterday", i: keys.id }), "utf8").toString("base64url"),
+      Buffer.from(JSON.stringify({ t: keys.createdAt.toISOString(), i: "" }), "utf8").toString("base64url"),
+      "a".repeat(CURSOR_MAX_LENGTH + 1),
+    ];
+
+    for (const raw of invalid) {
+      expect(() => decodeCreatedAtIdCursor(raw), raw.slice(0, 40)).toThrow(AppError);
+      try {
+        decodeCreatedAtIdCursor(raw);
+      } catch (error) {
+        expect(error).toMatchObject({ statusCode: 400, message: "Invalid cursor" });
+      }
+    }
+  });
+
+  it("builds a DESC keyset predicate and encodes nextCursor only when a page continues", () => {
+    const where = createdAtIdKeysetWhere(keys);
+    expect(where.OR[0]).toEqual({ createdAt: { lt: keys.createdAt } });
+    expect(where.OR[1]).toEqual({
+      AND: [{ createdAt: keys.createdAt }, { id: { lt: keys.id } }],
+    });
+
+    expect(nextCreatedAtIdCursor([keys], false)).toBeNull();
+    expect(nextCreatedAtIdCursor([], true)).toBeNull();
+    expect(nextCreatedAtIdCursor([keys], true)).toBe(encodeCreatedAtIdCursor(keys));
+  });
+});

--- a/server/src/shared/pagination/cursor.ts
+++ b/server/src/shared/pagination/cursor.ts
@@ -1,0 +1,88 @@
+import { AppError } from "../errors/AppError.js";
+
+/** Maximum wire length for the opaque cursor query parameter. */
+export const CURSOR_MAX_LENGTH = 512;
+
+export type CreatedAtIdCursor = {
+  createdAt: Date;
+  id: string;
+};
+
+/**
+ * Stable newest-first order for listing/product keyset pagination.
+ * `id` is the tie-breaker when `createdAt` collides.
+ */
+export const createdAtIdDescOrderBy = [
+  { createdAt: "desc" as const },
+  { id: "desc" as const },
+];
+
+/**
+ * Keyset predicate for `ORDER BY createdAt DESC, id DESC`.
+ * Rows strictly older than the cursor (or same timestamp with a smaller id).
+ */
+export function createdAtIdKeysetWhere(cursor: CreatedAtIdCursor) {
+  return {
+    OR: [
+      { createdAt: { lt: cursor.createdAt } },
+      { AND: [{ createdAt: cursor.createdAt }, { id: { lt: cursor.id } }] },
+    ],
+  };
+}
+
+export function encodeCreatedAtIdCursor(keys: CreatedAtIdCursor): string {
+  const payload = JSON.stringify({
+    t: keys.createdAt.toISOString(),
+    i: keys.id,
+  });
+  return Buffer.from(payload, "utf8").toString("base64url");
+}
+
+/**
+ * Decode an opaque listing/product cursor.
+ * The payload is `createdAt` + `id` only; extra keys and malformed values are 400.
+ */
+export function decodeCreatedAtIdCursor(raw: string): CreatedAtIdCursor {
+  if (raw.length === 0 || raw.length > CURSOR_MAX_LENGTH) {
+    throw new AppError(400, "Invalid cursor");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+  } catch {
+    throw new AppError(400, "Invalid cursor");
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new AppError(400, "Invalid cursor");
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== 2 || !("t" in record) || !("i" in record)) {
+    throw new AppError(400, "Invalid cursor");
+  }
+
+  const timestamp = record.t;
+  const id = record.i;
+  if (typeof timestamp !== "string" || typeof id !== "string" || id.length < 1 || id.length > 128) {
+    throw new AppError(400, "Invalid cursor");
+  }
+
+  const createdAt = new Date(timestamp);
+  if (Number.isNaN(createdAt.getTime()) || createdAt.toISOString() !== timestamp) {
+    throw new AppError(400, "Invalid cursor");
+  }
+
+  return { createdAt, id };
+}
+
+export function nextCreatedAtIdCursor(
+  items: ReadonlyArray<{ createdAt: Date; id: string }>,
+  hasMore: boolean
+): string | null {
+  if (!hasMore || items.length === 0) return null;
+  const last = items[items.length - 1];
+  return encodeCreatedAtIdCursor({ createdAt: last.createdAt, id: last.id });
+}

--- a/server/src/shared/perf/queries.ts
+++ b/server/src/shared/perf/queries.ts
@@ -8,7 +8,7 @@ export const PERF_QUERIES = {
     SELECT l.id
     FROM "Listing" l
     WHERE l.status = 'ACTIVE'
-    ORDER BY l."createdAt" DESC
+    ORDER BY l."createdAt" DESC, l.id DESC
     LIMIT 20
   `,
   marketActiveCount: `
@@ -22,7 +22,7 @@ export const PERF_QUERIES = {
     WHERE l.status = 'ACTIVE'
       AND l.price >= 50
       AND l.price <= 500
-    ORDER BY l."createdAt" DESC
+    ORDER BY l."createdAt" DESC, l.id DESC
     LIMIT 20
   `,
   expireReserved: `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cursor pagination estável (`createdAt` + `id`) em `GET /listings` e `GET /products`. Sem `cursor`, o contrato offset `{ items, total, page, limit }` permanece para o Market.

Issue: https://github.com/Bruno2K/neon-arsenal-market/issues/49
ADR: `docs/adr/0013-cursor-pagination.md`

## O que muda

- Cursor opaco base64url; `ORDER BY createdAt DESC, id DESC`.
- Com `cursor`: `{ items, limit, nextCursor }` (sem `COUNT(*)`).
- Offset intacto; `nextCursor` também no modo page para transição.
- Cursor inválido → 400 sem eco do token.
- Índices compostos + testes de insert concorrente.

## Verificação

- `cd server && npm run typecheck` → pass
- `cd server && npm run test:unit` → 237 passed
- `cd server && npm run test:integration` → 96 passed

Sem `src/`. Sem Redis.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

