### PR TITLE
feat(catalog): import cs2.sh on Render without a shell

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@ NODE_ENV=production
 FRONTEND_URL=https://your-frontend-domain.com
 SEED_DEMO_DATA=false
 
-# cs2.sh catalog import (optional). Never commit a real key.
+# cs2.sh catalog import (optional). Never commit a real key. Render: Dashboard env + ADMIN POST.
 # CS2SH_API_KEY=
 # CS2SH_API_BASE_URL=https://api.cs2.sh
 # CS2SH_API_TIMEOUT_MS=60000

--- a/docs/adr/0014-cs2sh-catalog-import.md
+++ b/docs/adr/0014-cs2sh-catalog-import.md
@@ -18,11 +18,11 @@ A periodic in-process job hitting the full schema/prices snapshot is not justifi
 2. **Natural key.** `Product.marketHashName` is unique and nullable so existing demo products without a Steam name stay valid. Re-runs upsert on that key.
 3. **USD is reference-only.** `Product.referencePriceUsd` stores the documented ask order: `steam.ask`, else `csfloat.ask`, else `skinport.ask`. No average, no FX. PayPal and the seller ledger stay BRL. Demo listing `price` copies the USD string with `currency: "USD"` (same as the existing seed). Checkout still sends the listing Decimal as BRL — a pre-existing mismatch, not introduced here.
 4. **Operator-triggered HTTP.** `GET /v1/schema` then `GET /v1/prices/latest` complete before any database write. Bearer + `Accept-Encoding: gzip`. Timeout default 60s. GETs retry 5xx/429/timeout/network (max 3, ADR 0005). Missing `CS2SH_API_KEY` is a no-op on boot (`CS2SH_IMPORT=true`) and a non-zero CLI exit. The API process does not crash on import failure.
-5. **No periodic sync job.** `npm run import:cs2sh` or boot when `CS2SH_IMPORT=true`. Demo listing re-runs update price/float but never change `status`, so they cannot revive `SOLD`/`RESERVED` rows.
+5. **No periodic sync job; no Render shell.** Production import is `POST /admin/catalog/cs2sh-import` (ADMIN, 202, in-process lock, 409 if already running) or boot after listen when `CS2SH_IMPORT=true`. `/ready` must not wait on cs2.sh. `npm run import:cs2sh` is local/CI only. Demo listing re-runs update price/float but never change `status`, so they cannot revive `SOLD`/`RESERVED` rows.
 
 ## Rollback
 
-Stop setting `CS2SH_IMPORT` / stop running the script. Drop the three Product columns with a new forward migration. Hand-seeded products and listings are unchanged.
+Stop setting `CS2SH_IMPORT`, do not POST the admin import route, and stop running the script. Drop the three Product columns with a new forward migration. Hand-seeded products and listings are unchanged.
 
 ## Consequences
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -9,7 +9,7 @@ API service: `neon-arsenal-api` (Docker, `server/Dockerfile`, context `server/`)
 1. Render builds the image, then starts the container.
 2. `server/entrypoint.sh` runs `prisma migrate deploy`.
 3. If `SEED_DEMO_DATA=true`, the entrypoint also runs `npm run db:seed`.
-4. `node dist/index.js` starts. It binds **`0.0.0.0:$PORT`** (`PORT` is `3001` in the Blueprint). If `SEED_DEMO_DATA=true`, `index.ts` seeds again. Both passes upsert; they do not overwrite existing rows. If `CS2SH_IMPORT=true`, `index.ts` then runs the cs2.sh catalog import **after** seed. Missing `CS2SH_API_KEY` logs and skips; a failed import does not prevent listen.
+4. `node dist/index.js` starts. It binds **`0.0.0.0:$PORT`** (`PORT` is `3001` in the Blueprint). If `SEED_DEMO_DATA=true`, `index.ts` seeds again. Both passes upsert; they do not overwrite existing rows. If `CS2SH_IMPORT=true` and `CS2SH_API_KEY` is set, `index.ts` schedules the cs2.sh catalog import **after** `app.listen` so Render `GET /ready` is not blocked. Missing key logs and skips; a failed import does not prevent listen.
 5. In-process jobs start after listen: reservation expiry (30s), PayPal GET reconciliation (60s), and seller ledger reconciliation (60s).
 
 The Blueprint also defines static `neon-arsenal-web`. The public demo often uses Vercel for the Vite client and Render only for the API; set `FRONTEND_URL` on the API and `API_URL` on the frontend. Do not invent env vars.
@@ -60,14 +60,24 @@ Re-running seed is idempotent. It still touches the database on every deploy whe
 
 ## cs2.sh catalog import (`CS2SH_IMPORT` / `CS2SH_API_KEY`)
 
-Optional. Populates `Product` from `GET https://api.cs2.sh/v1/schema` (tradable skins) and USD reference asks from `GET /v1/prices/latest`. State lives in PostgreSQL; the Render disk is irrelevant.
+Optional. Populates `Product` from `GET https://api.cs2.sh/v1/schema` (tradable skins) and USD reference asks from `GET /v1/prices/latest`. State lives in PostgreSQL; the Render disk is ephemeral and irrelevant.
+
+Render **web services have no SSH/shell**. Do not plan on `npm run import:cs2sh` in production. Use Dashboard env + HTTP:
+
+1. Render Dashboard → `neon-arsenal-api` → Environment → set `CS2SH_API_KEY` (sync: false). Redeploy if the instance started without the key.
+2. Trigger import without a shell:
+   - Log in as **ADMIN** and click **Importar catálogo** on `/admin`, or `POST /admin/catalog/cs2sh-import` (202, runs in the background).
+   - Or set `CS2SH_IMPORT=true` and redeploy. Boot schedules the same work **after listen** so `/ready` stays fast.
+3. Poll `GET /admin/catalog/cs2sh-import` (or the admin card) until `running` is false.
 
 | Env | Effect |
 |---|---|
 | `CS2SH_API_KEY` | Bearer token. Required for import. Never commit. |
-| `CS2SH_IMPORT=true` | `index.ts` imports after demo seed. Without a key, logs and skips. |
-| unset / not `true` | No boot import. Operators can run `cd server && npm run import:cs2sh`. |
+| `CS2SH_IMPORT=true` | After listen, start one in-process import. Without a key, logs and skips. Does not block `/ready`. |
+| unset / not `true` | No boot import. Use ADMIN POST (Render) or `cd server && npm run import:cs2sh` (local). |
 | `CS2SH_DEMO_LISTING_COUNT` | How many demo listings to upsert (default 24, max 100). |
+
+`POST` without a key is **503**. A second `POST` while this process is still importing is **409**. Restart loses in-process status; catalog rows in Postgres remain.
 
 `referencePriceUsd` is **not** a PayPal/ledger amount (ADR 0014). Re-running the import upserts products and refreshes demo listing prices without changing listing `status`.
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -66,7 +66,7 @@ Render **web services have no SSH/shell**. Do not plan on `npm run import:cs2sh`
 
 1. Render Dashboard → `neon-arsenal-api` → Environment → set `CS2SH_API_KEY` (sync: false). Redeploy if the instance started without the key.
 2. Trigger import without a shell:
-   - Log in as **ADMIN** and click **Importar catálogo** on `/admin`, or `POST /admin/catalog/cs2sh-import` (202, runs in the background).
+   - Log in as **ADMIN** and open **Catálogo** (`/admin/catalog`), or click **Importar catálogo** on `/admin`, or `POST /admin/catalog/cs2sh-import` (202, runs in the background).
    - Or set `CS2SH_IMPORT=true` and redeploy. Boot schedules the same work **after listen** so `/ready` stays fast.
 3. Poll `GET /admin/catalog/cs2sh-import` (or the admin card) until `running` is false.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,7 @@ From `server/`:
 | `npm run test:all` | Unit tests, then integration tests. |
 | `npm run test:db:prepare` | `prisma migrate deploy` against `DATABASE_URL`. |
 | `npm run perf:evidence` | Seed a disposable catalog, print `EXPLAIN ANALYZE` + `listingsService.list` timings. |
-| `npm run import:cs2sh` | Upsert Product catalog from cs2.sh. Needs `CS2SH_API_KEY`. Live API is not used in CI. |
+| `npm run import:cs2sh` | Local upsert of Product catalog from cs2.sh. Needs `CS2SH_API_KEY`. Not available on Render (no shell); use ADMIN `POST /admin/catalog/cs2sh-import`. Live API is not used in CI. |
 
 Frontend unit tests remain `npm test` at the repository root.
 

--- a/render.yaml
+++ b/render.yaml
@@ -48,6 +48,16 @@ services:
         value: "10000"
       - key: FRONTEND_URL
         sync: false
+      - key: CS2SH_API_KEY
+        # Bearer token from https://cs2.sh. Set in the Render Dashboard.
+        # Never commit. Without it, POST /admin/catalog/cs2sh-import returns 503.
+        sync: false
+      - key: CS2SH_IMPORT
+        # "true" schedules catalog import after listen (does not block /ready).
+        # Prefer the ADMIN POST on a running instance — Render has no SSH/shell.
+        value: "false"
+      - key: CS2SH_DEMO_LISTING_COUNT
+        value: "24"
     # Render has a single probe. Use readiness: Postgres reachable and not draining.
     # Docker HEALTHCHECK in server/Dockerfile stays on /health (liveness) so a
     # SIGTERM drain does not look like a dead container.

--- a/server/.env.example
+++ b/server/.env.example
@@ -27,11 +27,12 @@ EMAIL_FROM="SkinMarket <noreply@your-domain.com>"
 EMAIL_API_TIMEOUT_MS=10000
 
 # ─── cs2.sh catalog (optional; never commit a real key) ───────────────────────
-# Bearer token from https://cs2.sh — used only by npm run import:cs2sh / boot import.
+# Bearer token from https://cs2.sh — Render has no shell; set this in the Dashboard
+# and POST /admin/catalog/cs2sh-import (ADMIN) or set CS2SH_IMPORT=true (after listen).
 # CS2SH_API_KEY=
 # CS2SH_API_BASE_URL=https://api.cs2.sh
 # CS2SH_API_TIMEOUT_MS=60000
-# Set true to import after demo seed on API boot. Skips (does not crash) without a key.
+# Set true to import after listen on API boot. Skips (does not crash) without a key.
 # CS2SH_IMPORT=false
 # CS2SH_DEMO_LISTING_COUNT=24
 

--- a/server/README.md
+++ b/server/README.md
@@ -24,7 +24,7 @@ Para desenvolvimento iterativo de schema, use `npm run db:migrate`.
 
 ## Catálogo cs2.sh (opcional)
 
-`npm run import:cs2sh` busca o schema e o snapshot de preços da [cs2.sh](https://cs2.sh/docs/schema) e faz upsert de `Product` (skins tradable) mais um conjunto pequeno de listings demo. Exige `CS2SH_API_KEY` em `server/.env`. Sem a key o script sai com código 1 e não toca o banco. `CS2SH_IMPORT=true` no boot da API importa depois do seed demo; a API sobe mesmo se o import falhar. Ver `docs/adr/0014-cs2sh-catalog-import.md`.
+`npm run import:cs2sh` (local) or `POST /admin/catalog/cs2sh-import` (ADMIN; Render has no shell) busca o schema e o snapshot de preços da [cs2.sh](https://cs2.sh/docs/schema) e faz upsert de `Product` (skins tradable) mais um conjunto pequeno de listings demo. Exige `CS2SH_API_KEY`. Sem a key o script sai com código 1 e o POST responde 503; nenhum dos dois toca o banco. `CS2SH_IMPORT=true` agenda o import **depois** de `listen` para não bloquear `/ready`; a API sobe mesmo se o import falhar. Ver `docs/adr/0014-cs2sh-catalog-import.md` e `docs/operations/runbook.md`.
 
 ## Configuração
 

--- a/server/src/__tests__/cs2sh.import.integration.test.ts
+++ b/server/src/__tests__/cs2sh.import.integration.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Prisma } from "@prisma/client";
-import { importCs2ShCatalog } from "../modules/products/cs2shImport.service.js";
+import {
+  importCs2ShCatalog,
+  resetCs2ShImportStateForTests,
+} from "../modules/products/cs2shImport.service.js";
 import type { Cs2ShClient } from "../shared/integrations/cs2sh/cs2sh.client.js";
 import {
   CS2SH_PRICES_FIXTURE,
@@ -24,6 +27,7 @@ function fakeClient(
 }
 
 afterEach(() => {
+  resetCs2ShImportStateForTests();
   if (originalKey === undefined) delete process.env.CS2SH_API_KEY;
   else process.env.CS2SH_API_KEY = originalKey;
   if (originalCount === undefined) delete process.env.CS2SH_DEMO_LISTING_COUNT;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,17 +15,5 @@ if (process.env.SEED_DEMO_DATA === "true") {
   }
 }
 
-{
-  const { isCs2ShImportEnabled } = await import("./shared/config/cs2sh.js");
-  if (isCs2ShImportEnabled()) {
-    const { importCs2ShCatalog } = await import("./modules/products/cs2shImport.service.js");
-    const { logger } = await import("./shared/logger.js");
-    try {
-      await importCs2ShCatalog();
-    } catch (err) {
-      logger.error({ err }, "cs2.sh catalog import failed");
-    }
-  }
-}
-
-startApiProcess(app);
+const { scheduleCs2ShBootImport } = await import("./modules/products/cs2shImport.service.js");
+startApiProcess(app, { onListening: () => scheduleCs2ShBootImport() });

--- a/server/src/modules/admin/__tests__/admin.cs2sh.routes.test.ts
+++ b/server/src/modules/admin/__tests__/admin.cs2sh.routes.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import { errorHandler } from "../../../shared/errors/index.js";
+import { signAccessToken } from "../../../shared/utils/jwt.js";
+
+const getCs2ShImportStatus = vi.fn();
+const tryStartCs2ShCatalogImport = vi.fn();
+
+vi.mock("../../products/cs2shImport.service.js", () => ({
+  getCs2ShImportStatus: (...args: unknown[]) => getCs2ShImportStatus(...args),
+  tryStartCs2ShCatalogImport: (...args: unknown[]) => tryStartCs2ShCatalogImport(...args),
+}));
+
+const { adminRoutes } = await import("../admin.routes.js");
+
+function listen(app: express.Express) {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function adminToken() {
+  return signAccessToken({
+    sub: "admin-1",
+    email: "admin@test.local",
+    role: "ADMIN",
+  });
+}
+
+describe("/admin/catalog/cs2sh-import", () => {
+  let server: Server;
+  let baseUrl: string;
+  const originalKey = process.env.CS2SH_API_KEY;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use("/admin", adminRoutes);
+    app.use(errorHandler);
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  beforeEach(() => {
+    getCs2ShImportStatus.mockReset();
+    tryStartCs2ShCatalogImport.mockReset();
+    getCs2ShImportStatus.mockReturnValue({ running: false, lastResult: null });
+    tryStartCs2ShCatalogImport.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.CS2SH_API_KEY;
+    else process.env.CS2SH_API_KEY = originalKey;
+  });
+
+  it("returns 401 without a bearer token", async () => {
+    const response = await fetch(`${baseUrl}/admin/catalog/cs2sh-import`, { method: "POST" });
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for CUSTOMER", async () => {
+    const token = signAccessToken({
+      sub: "customer-1",
+      email: "buyer@test.local",
+      role: "CUSTOMER",
+    });
+    const response = await fetch(`${baseUrl}/admin/catalog/cs2sh-import`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("GET returns in-process status for ADMIN", async () => {
+    getCs2ShImportStatus.mockReturnValue({
+      running: true,
+      lastResult: { skipped: false, generationId: "gen-1", productsUpserted: 10, schemaSkipped: 0, listingsUpserted: 2 },
+    });
+    const response = await fetch(`${baseUrl}/admin/catalog/cs2sh-import`, {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      running: true,
+      lastResult: { productsUpserted: 10, listingsUpserted: 2 },
+    });
+  });
+
+  it("POST returns 503 when CS2SH_API_KEY is missing", async () => {
+    delete process.env.CS2SH_API_KEY;
+    const response = await fetch(`${baseUrl}/admin/catalog/cs2sh-import`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "A chave da API cs2.sh não está configurada",
+    });
+    expect(tryStartCs2ShCatalogImport).not.toHaveBeenCalled();
+  });
+
+  it("POST returns 202 and starts the import in the background", async () => {
+    process.env.CS2SH_API_KEY = "test-key";
+    getCs2ShImportStatus.mockReturnValue({ running: true, lastResult: null });
+    const response = await fetch(`${baseUrl}/admin/catalog/cs2sh-import`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "started",
+      running: true,
+    });
+    expect(tryStartCs2ShCatalogImport).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST returns 409 when an import is already running", async () => {
+    process.env.CS2SH_API_KEY = "test-key";
+    tryStartCs2ShCatalogImport.mockReturnValue(false);
+    const response = await fetch(`${baseUrl}/admin/catalog/cs2sh-import`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "A importação do catálogo cs2.sh já está em andamento",
+    });
+  });
+});

--- a/server/src/modules/admin/admin.controller.ts
+++ b/server/src/modules/admin/admin.controller.ts
@@ -3,6 +3,12 @@ import { adminService } from "./admin.service.js";
 import type { ListOrdersQuery } from "../orders/orders.dto.js";
 import { auditActorFromRequest } from "../audit/audit.service.js";
 import type { ListAuditLogsQueryInput } from "../audit/audit.dto.js";
+import { AppError } from "../../shared/errors/AppError.js";
+import { isCs2ShConfigured } from "../../shared/config/cs2sh.js";
+import {
+  getCs2ShImportStatus,
+  tryStartCs2ShCatalogImport,
+} from "../products/cs2shImport.service.js";
 
 export const adminController = {
   async listUsers(_req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -40,6 +46,29 @@ export const adminController = {
     try {
       const logs = await adminService.listAuditLogs(req.query as unknown as ListAuditLogsQueryInput);
       res.json(logs);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async getCs2ShImport(_req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      res.json(getCs2ShImportStatus());
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async startCs2ShImport(_req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (!isCs2ShConfigured()) {
+        throw new AppError(503, "A chave da API cs2.sh não está configurada");
+      }
+      const started = tryStartCs2ShCatalogImport();
+      if (!started) {
+        throw new AppError(409, "A importação do catálogo cs2.sh já está em andamento");
+      }
+      res.status(202).json({ status: "started", ...getCs2ShImportStatus() });
     } catch (e) {
       next(e);
     }

--- a/server/src/modules/admin/admin.routes.ts
+++ b/server/src/modules/admin/admin.routes.ts
@@ -14,6 +14,8 @@ router.use(requireRole("ADMIN"));
 router.get("/users", adminController.listUsers);
 router.get("/orders", validateQuery(listOrdersQueryDto), adminController.listOrders);
 router.get("/audit-logs", validateQuery(listAuditLogsQueryDto), adminController.listAuditLogs);
+router.get("/catalog/cs2sh-import", adminController.getCs2ShImport);
+router.post("/catalog/cs2sh-import", adminController.startCs2ShImport);
 router.patch(
   "/sellers/:id/approve",
   validateBody(approveSellerDto),

--- a/server/src/modules/products/__tests__/cs2shImport.service.test.ts
+++ b/server/src/modules/products/__tests__/cs2shImport.service.test.ts
@@ -1,13 +1,42 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { importCs2ShCatalog } from "../cs2shImport.service.js";
+import {
+  getCs2ShImportStatus,
+  importCs2ShCatalog,
+  resetCs2ShImportStateForTests,
+  scheduleCs2ShBootImport,
+  tryStartCs2ShCatalogImport,
+} from "../cs2shImport.service.js";
 import type { Cs2ShClient } from "../../../shared/integrations/cs2sh/cs2sh.client.js";
 import { CS2SH_PRICES_FIXTURE, CS2SH_SCHEMA_FIXTURE } from "../../../shared/integrations/cs2sh/__tests__/cs2sh.fixtures.js";
 
 const originalKey = process.env.CS2SH_API_KEY;
+const originalImport = process.env.CS2SH_IMPORT;
+
+function hangingClient(): { client: Cs2ShClient; fail: (err: unknown) => void } {
+  let fail = (_err: unknown) => {};
+  const gate = new Promise<typeof CS2SH_SCHEMA_FIXTURE>((_resolve, reject) => {
+    fail = reject;
+  });
+  return {
+    client: {
+      fetchSchema: () => gate,
+      fetchLatestPrices: async () => CS2SH_PRICES_FIXTURE,
+    },
+    fail,
+  };
+}
+
+const hangingRuns: Array<(err: unknown) => void> = [];
 
 afterEach(() => {
+  for (const fail of hangingRuns.splice(0)) {
+    fail(new Error("test cleanup"));
+  }
   if (originalKey === undefined) delete process.env.CS2SH_API_KEY;
   else process.env.CS2SH_API_KEY = originalKey;
+  if (originalImport === undefined) delete process.env.CS2SH_IMPORT;
+  else process.env.CS2SH_IMPORT = originalImport;
+  resetCs2ShImportStateForTests();
 });
 
 describe("importCs2ShCatalog", () => {
@@ -27,5 +56,51 @@ describe("importCs2ShCatalog", () => {
     const summary = await importCs2ShCatalog(client);
     expect(summary).toMatchObject({ skipped: true, skipReason: "missing_api_key", productsUpserted: 0 });
     expect(called).toBe(false);
+  });
+
+  it("rejects a concurrent import with 409 and tryStart returns false", async () => {
+    process.env.CS2SH_API_KEY = "test-key";
+    const { client, fail } = hangingClient();
+    hangingRuns.push(fail);
+    const first = importCs2ShCatalog(client);
+    expect(getCs2ShImportStatus().running).toBe(true);
+    expect(tryStartCs2ShCatalogImport(client)).toBe(false);
+    await expect(importCs2ShCatalog(client)).rejects.toMatchObject({
+      statusCode: 409,
+      message: "A importação do catálogo cs2.sh já está em andamento",
+    });
+    fail(new Error("stop hung import"));
+    hangingRuns.length = 0;
+    await expect(first).rejects.toBeInstanceOf(Error);
+    expect(getCs2ShImportStatus().running).toBe(false);
+  });
+});
+
+describe("scheduleCs2ShBootImport", () => {
+  it("does nothing when CS2SH_IMPORT is unset", () => {
+    delete process.env.CS2SH_IMPORT;
+    process.env.CS2SH_API_KEY = "test-key";
+    const { client, fail } = hangingClient();
+    hangingRuns.push(fail);
+    scheduleCs2ShBootImport(client);
+    expect(getCs2ShImportStatus().running).toBe(false);
+  });
+
+  it("does not start when CS2SH_IMPORT=true but the API key is missing", () => {
+    process.env.CS2SH_IMPORT = "true";
+    delete process.env.CS2SH_API_KEY;
+    const { client, fail } = hangingClient();
+    hangingRuns.push(fail);
+    scheduleCs2ShBootImport(client);
+    expect(getCs2ShImportStatus().running).toBe(false);
+  });
+
+  it("starts after listen when CS2SH_IMPORT=true and the key is set", () => {
+    process.env.CS2SH_IMPORT = "true";
+    process.env.CS2SH_API_KEY = "test-key";
+    const { client, fail } = hangingClient();
+    hangingRuns.push(fail);
+    scheduleCs2ShBootImport(client);
+    expect(getCs2ShImportStatus().running).toBe(true);
   });
 });

--- a/server/src/modules/products/__tests__/cs2shImport.service.test.ts
+++ b/server/src/modules/products/__tests__/cs2shImport.service.test.ts
@@ -17,6 +17,7 @@ function hangingClient(): { client: Cs2ShClient; fail: (err: unknown) => void } 
   const gate = new Promise<typeof CS2SH_SCHEMA_FIXTURE>((_resolve, reject) => {
     fail = reject;
   });
+  void gate.catch(() => undefined);
   return {
     client: {
       fetchSchema: () => gate,

--- a/server/src/modules/products/cs2shImport.service.ts
+++ b/server/src/modules/products/cs2shImport.service.ts
@@ -1,7 +1,9 @@
+import { AppError } from "../../shared/errors/AppError.js";
 import { logger } from "../../shared/logger.js";
 import {
   getCs2ShDemoListingCount,
   isCs2ShConfigured,
+  isCs2ShImportEnabled,
 } from "../../shared/config/cs2sh.js";
 import { createCs2ShClient, type Cs2ShClient } from "../../shared/integrations/cs2sh/cs2sh.client.js";
 import {
@@ -22,12 +24,81 @@ export type Cs2ShImportSummary = {
   listingsUpserted: number;
 };
 
+export type Cs2ShImportStatus = {
+  running: boolean;
+  lastResult: Cs2ShImportSummary | null;
+};
+
+let inFlight: Promise<Cs2ShImportSummary> | null = null;
+let lastResult: Cs2ShImportSummary | null = null;
+
+export function isCs2ShImportRunning(): boolean {
+  return inFlight !== null;
+}
+
+export function getCs2ShImportStatus(): Cs2ShImportStatus {
+  return { running: inFlight !== null, lastResult };
+}
+
+export function resetCs2ShImportStateForTests(): void {
+  inFlight = null;
+  lastResult = null;
+}
+
+/**
+ * Render has no SSH/shell on the web service. Trigger import after listen
+ * (`CS2SH_IMPORT=true`) or via ADMIN POST. Never block `/ready`.
+ */
+export function scheduleCs2ShBootImport(
+  client: Cs2ShClient = createCs2ShClient()
+): void {
+  if (!isCs2ShImportEnabled()) return;
+  if (!isCs2ShConfigured()) {
+    logger.info("cs2.sh boot import skipped: CS2SH_API_KEY is not set");
+    return;
+  }
+  const started = tryStartCs2ShCatalogImport(client);
+  if (started) {
+    logger.info("cs2.sh catalog import scheduled after listen");
+  }
+}
+
+function beginCs2ShCatalogImport(
+  client: Cs2ShClient
+): Promise<Cs2ShImportSummary> | null {
+  if (inFlight) return null;
+  const run = runCs2ShCatalogImport(client);
+  inFlight = run.finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+export function tryStartCs2ShCatalogImport(
+  client: Cs2ShClient = createCs2ShClient()
+): boolean {
+  const run = beginCs2ShCatalogImport(client);
+  if (!run) return false;
+  void run.catch((err) => {
+    logger.error({ err }, "cs2.sh catalog import failed");
+  });
+  return true;
+}
+
 export async function importCs2ShCatalog(
   client: Cs2ShClient = createCs2ShClient()
 ): Promise<Cs2ShImportSummary> {
+  const run = beginCs2ShCatalogImport(client);
+  if (!run) {
+    throw new AppError(409, "A importação do catálogo cs2.sh já está em andamento");
+  }
+  return run;
+}
+
+async function runCs2ShCatalogImport(client: Cs2ShClient): Promise<Cs2ShImportSummary> {
   if (!isCs2ShConfigured()) {
     logger.info("cs2.sh catalog import skipped: CS2SH_API_KEY is not set");
-    return {
+    const skipped: Cs2ShImportSummary = {
       skipped: true,
       skipReason: "missing_api_key",
       generationId: null,
@@ -35,6 +106,8 @@ export async function importCs2ShCatalog(
       schemaSkipped: 0,
       listingsUpserted: 0,
     };
+    lastResult = skipped;
+    return skipped;
   }
 
   const schema = await client.fetchSchema();
@@ -89,5 +162,6 @@ export async function importCs2ShCatalog(
     listingsUpserted,
   };
   logger.info(summary, "cs2.sh catalog import complete");
+  lastResult = summary;
   return summary;
 }

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -171,6 +171,27 @@ export const openApiSpec = {
           createdAt: { type: "string", format: "date-time" },
         },
       },
+      Cs2ShImportSummary: {
+        type: "object",
+        properties: {
+          skipped: { type: "boolean" },
+          skipReason: { type: "string", enum: ["missing_api_key"] },
+          generationId: { type: "string", nullable: true },
+          productsUpserted: { type: "integer" },
+          schemaSkipped: { type: "integer" },
+          listingsUpserted: { type: "integer" },
+        },
+      },
+      Cs2ShImportStatus: {
+        type: "object",
+        properties: {
+          running: { type: "boolean" },
+          lastResult: {
+            allOf: [{ $ref: "#/components/schemas/Cs2ShImportSummary" }],
+            nullable: true,
+          },
+        },
+      },
     },
   },
   security: [{ bearerAuth: [] }],
@@ -683,6 +704,54 @@ export const openApiSpec = {
           },
           401: { description: "Missing or invalid access token" },
           403: { description: "Caller is not ADMIN" },
+        },
+      },
+    },
+    "/admin/catalog/cs2sh-import": {
+      get: {
+        tags: ["Admin"],
+        summary: "cs2.sh catalog import status",
+        description:
+          "ADMIN-only in-process status. Render has no SSH; use this or POST to import without a shell. running is true while GET /v1/schema + /v1/prices/latest and the DB upsert are in flight. lastResult is the last completed summary on this process (lost on restart).",
+        responses: {
+          200: {
+            description: "Import status for this API process",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Cs2ShImportStatus" },
+              },
+            },
+          },
+          401: { description: "Missing or invalid access token" },
+          403: { description: "Caller is not ADMIN" },
+        },
+      },
+      post: {
+        tags: ["Admin"],
+        summary: "Start cs2.sh catalog import",
+        description:
+          "ADMIN-only. Starts the cs2.sh catalog upsert in the background and returns 202 before database writes finish. Requires CS2SH_API_KEY. Concurrent starts on the same process return 409. Does not block GET /ready. Alternative: set CS2SH_IMPORT=true so boot schedules the same work after listen.",
+        responses: {
+          202: {
+            description: "Import started on this process",
+            content: {
+              "application/json": {
+                schema: {
+                  allOf: [
+                    { $ref: "#/components/schemas/Cs2ShImportStatus" },
+                    {
+                      type: "object",
+                      properties: { status: { type: "string", example: "started" } },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          401: { description: "Missing or invalid access token" },
+          403: { description: "Caller is not ADMIN" },
+          409: { description: "An import is already running on this process" },
+          503: { description: "CS2SH_API_KEY is not configured" },
         },
       },
     },

--- a/server/src/shared/lifecycle/startApi.ts
+++ b/server/src/shared/lifecycle/startApi.ts
@@ -9,7 +9,12 @@ import { installProcessShutdownHandlers } from "./shutdown.js";
 
 export function startApiProcess(
   app: Express,
-  options?: { port?: number; host?: string; installSignals?: boolean }
+  options?: {
+    port?: number;
+    host?: string;
+    installSignals?: boolean;
+    onListening?: () => void | Promise<void>;
+  }
 ): Server {
   const port = options?.port ?? Number(process.env.PORT ?? 3001);
   const host = options?.host ?? "0.0.0.0";
@@ -24,6 +29,9 @@ export function startApiProcess(
       startSellerLedgerReconciliationJob(),
       startOutboxDispatcherJob()
     );
+    void Promise.resolve(options?.onListening?.()).catch((err: unknown) => {
+      logger.error({ err }, "onListening hook failed");
+    });
   });
 
   const stopJobs = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import SellerOrders from "./pages/seller/SellerOrders";
 import AdminSellers from "./pages/admin/AdminSellers";
 import AdminOrders from "./pages/admin/AdminOrders";
 import AdminUsers from "./pages/admin/AdminUsers";
+import AdminCatalog from "./pages/admin/AdminCatalog";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -133,6 +134,14 @@ const App = () => (
                     element={
                       <ProtectedRoute allowedRoles={["ADMIN"]}>
                         <AdminDashboard />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/catalog"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminCatalog />
                       </ProtectedRoute>
                     }
                   />

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,6 +1,24 @@
 import { api } from "./client";
 import type { User, Order, Seller } from "@/types/api";
 
+export type Cs2ShImportSummary = {
+  skipped: boolean;
+  skipReason?: "missing_api_key";
+  generationId: string | null;
+  productsUpserted: number;
+  schemaSkipped: number;
+  listingsUpserted: number;
+};
+
+export type Cs2ShImportStatus = {
+  running: boolean;
+  lastResult: Cs2ShImportSummary | null;
+};
+
+export type Cs2ShImportStartResponse = Cs2ShImportStatus & {
+  status: "started";
+};
+
 // ─── Users ────────────────────────────────────────────────────────────────────
 export function listAdminUsers(): Promise<User[]> {
   return api.get<User[]>("/admin/users");
@@ -17,4 +35,12 @@ export function adminApproveSeller(
   isApproved: boolean,
 ): Promise<Seller> {
   return api.patch<Seller>(`/admin/sellers/${id}/approve`, { isApproved });
+}
+
+export function getCs2ShImportStatus(): Promise<Cs2ShImportStatus> {
+  return api.get<Cs2ShImportStatus>("/admin/catalog/cs2sh-import");
+}
+
+export function startCs2ShImport(): Promise<Cs2ShImportStartResponse> {
+  return api.post<Cs2ShImportStartResponse>("/admin/catalog/cs2sh-import");
 }

--- a/src/components/admin/Cs2ShCatalogImportCard.tsx
+++ b/src/components/admin/Cs2ShCatalogImportCard.tsx
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getCs2ShImportStatus, startCs2ShImport } from "@/api/admin";
+import { Button } from "@/components/ui/button";
+import { userFacingApiError } from "@/lib/userFacingApiError";
+import { useToast } from "@/hooks/use-toast";
+
+function statusCopy(
+  status:
+    | {
+        running: boolean;
+        lastResult: {
+          skipped: boolean;
+          productsUpserted: number;
+          listingsUpserted: number;
+        } | null;
+      }
+    | undefined,
+  isError: boolean,
+): string {
+  if (isError) {
+    return "Não foi possível ler o status da importação.";
+  }
+  if (status?.running) {
+    return "Importação em andamento neste processo da API.";
+  }
+  const last = status?.lastResult;
+  if (!last) {
+    return "Nenhuma importação neste processo. Defina CS2SH_API_KEY no Render e use o botão, ou CS2SH_IMPORT=true no próximo deploy.";
+  }
+  if (last.skipped) {
+    return "A última tentativa pulou o import: a chave da API cs2.sh não está configurada.";
+  }
+  return `Última importação neste processo: ${last.productsUpserted} produtos e ${last.listingsUpserted} listings demo.`;
+}
+
+export function Cs2ShCatalogImportCard() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const statusQuery = useQuery({
+    queryKey: ["admin-cs2sh-import"],
+    queryFn: getCs2ShImportStatus,
+    refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
+  });
+  const startImport = useMutation({
+    mutationFn: startCs2ShImport,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-cs2sh-import"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-products"] });
+      toast({ title: "Importação do catálogo cs2.sh iniciada" });
+    },
+    onError: (error) => {
+      toast({
+        title: "Não foi possível importar o catálogo",
+        description: userFacingApiError(error),
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <section
+      aria-labelledby="cs2sh-catalog-heading"
+      className="space-y-3 rounded-md border border-border bg-card p-4"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2
+            id="cs2sh-catalog-heading"
+            className="text-lg font-semibold tracking-tight"
+          >
+            Catálogo cs2.sh
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            No Render não há shell. Importe skins tradable pela API; o
+            PostgreSQL guarda o resultado.
+          </p>
+        </div>
+        <Button
+          type="button"
+          disabled={startImport.isPending || statusQuery.data?.running === true}
+          onClick={() => startImport.mutate()}
+        >
+          {statusQuery.data?.running || startImport.isPending
+            ? "Importando…"
+            : "Importar catálogo"}
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {statusCopy(statusQuery.data ?? undefined, statusQuery.isError)}
+      </p>
+    </section>
+  );
+}

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -29,6 +29,7 @@ const sellerItems = [
 
 const adminItems = [
   { icon: BarChart3, label: "Visão Geral", href: "/admin" },
+  { icon: Package, label: "Catálogo", href: "/admin/catalog" },
   { icon: Users, label: "Vendedores", href: "/admin/sellers" },
   { icon: ShoppingBag, label: "Pedidos", href: "/admin/orders" },
   { icon: Shield, label: "Usuários", href: "/admin/users" },

--- a/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import DashboardLayout from "../DashboardLayout";
+
+vi.mock("@/components/Header", () => ({
+  Header: () => <div>header</div>,
+}));
+
+vi.mock("@/components/SiteFooter", () => ({
+  SiteFooter: () => null,
+}));
+
+function renderAdminNav(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<DashboardLayout />}>
+          <Route path="/admin" element={<div>overview</div>} />
+          <Route path="/admin/catalog" element={<div>catalog-page</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("DashboardLayout admin nav", () => {
+  it("exposes Catálogo next to Visão Geral", () => {
+    renderAdminNav("/admin");
+    const links = screen.getAllByRole("link", { name: "Catálogo" });
+    expect(links.length).toBeGreaterThan(0);
+    expect(links[0]).toHaveAttribute("href", "/admin/catalog");
+    expect(
+      screen.getAllByRole("link", { name: "Visão Geral" })[0],
+    ).toHaveAttribute("href", "/admin");
+  });
+
+  it("marks Catálogo current on /admin/catalog", () => {
+    renderAdminNav("/admin/catalog");
+    const links = screen.getAllByRole("link", { name: "Catálogo" });
+    expect(
+      links.some((link) => link.getAttribute("aria-current") === "page"),
+    ).toBe(true);
+    expect(screen.getByText("catalog-page")).toBeTruthy();
+  });
+});

--- a/src/lib/__tests__/userFacingApiError.test.ts
+++ b/src/lib/__tests__/userFacingApiError.test.ts
@@ -3,6 +3,8 @@ import {
   ApiClientError,
   USER_FACING_CONFLICT,
   USER_FACING_CREDENTIALS,
+  USER_FACING_CS2SH_IMPORT_RUNNING,
+  USER_FACING_CS2SH_KEY_MISSING,
   USER_FACING_EMAIL_TAKEN,
   USER_FACING_FORBIDDEN,
   USER_FACING_GENERIC,
@@ -91,6 +93,23 @@ describe("userFacingApiError", () => {
   });
 
   it("maps other 409s, 429, 5xx and validation", () => {
+    expect(
+      userFacingApiError(
+        new ApiClientError(
+          "A importação do catálogo cs2.sh já está em andamento",
+          {
+            status: 409,
+          },
+        ),
+      ),
+    ).toBe(USER_FACING_CS2SH_IMPORT_RUNNING);
+    expect(
+      userFacingApiError(
+        new ApiClientError("A chave da API cs2.sh não está configurada", {
+          status: 503,
+        }),
+      ),
+    ).toBe(USER_FACING_CS2SH_KEY_MISSING);
     expect(
       userFacingApiError(
         new ApiClientError("Order status changed concurrently", {

--- a/src/lib/userFacingApiError.ts
+++ b/src/lib/userFacingApiError.ts
@@ -30,6 +30,12 @@ export const USER_FACING_RATE_LIMIT =
 export const USER_FACING_SERVER =
   "O serviço está indisponível. Tente de novo em instantes.";
 
+export const USER_FACING_CS2SH_IMPORT_RUNNING =
+  "A importação do catálogo cs2.sh já está em andamento";
+
+export const USER_FACING_CS2SH_KEY_MISSING =
+  "A chave da API cs2.sh não está configurada";
+
 export const USER_FACING_VALIDATION =
   "Alguns dados estão inválidos. Confira os campos e tente de novo.";
 
@@ -195,6 +201,12 @@ export function userFacingApiError(error: unknown): string {
     copy = USER_FACING_VERIFICATION_CODE;
   } else if (/order is cancelled|order.*cancelled/i.test(message)) {
     copy = USER_FACING_ORDER_CANCELLED;
+  } else if (
+    /importação do catálogo cs2\.sh já está em andamento/i.test(message)
+  ) {
+    copy = USER_FACING_CS2SH_IMPORT_RUNNING;
+  } else if (/chave da API cs2\.sh não está configurada/i.test(message)) {
+    copy = USER_FACING_CS2SH_KEY_MISSING;
   } else if (isUnauthorizedApiError(error)) {
     copy = USER_FACING_UNAUTHORIZED;
   } else if (isForbiddenApiError(error)) {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,12 +1,21 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { adminApproveSeller, listAdminOrders } from "@/api/admin";
+import {
+  adminApproveSeller,
+  getCs2ShImportStatus,
+  listAdminOrders,
+  startCs2ShImport,
+} from "@/api/admin";
 import { listProducts } from "@/api/products";
 import { listSellers } from "@/api/sellers";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
+import {
+  orderStatusLabel,
+  paymentStatusLabel,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
 import {
   Table,
   TableBody,
@@ -26,6 +35,35 @@ function formatCommission(rate: Seller["commissionRate"]): string {
   return `${(Number(rate ?? 0.1) * 100).toFixed(0)}%`;
 }
 
+function cs2ShStatusCopy(
+  status:
+    | {
+        running: boolean;
+        lastResult: {
+          skipped: boolean;
+          productsUpserted: number;
+          listingsUpserted: number;
+        } | null;
+      }
+    | undefined,
+  isError: boolean,
+): string {
+  if (isError) {
+    return "Não foi possível ler o status da importação.";
+  }
+  if (status?.running) {
+    return "Importação em andamento neste processo da API.";
+  }
+  const last = status?.lastResult;
+  if (!last) {
+    return "Nenhuma importação neste processo. Defina CS2SH_API_KEY no Render e use o botão, ou CS2SH_IMPORT=true no próximo deploy.";
+  }
+  if (last.skipped) {
+    return "A última tentativa pulou o import: a chave da API cs2.sh não está configurada.";
+  }
+  return `Última importação neste processo: ${last.productsUpserted} produtos e ${last.listingsUpserted} listings demo.`;
+}
+
 export default function AdminDashboard() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -41,6 +79,11 @@ export default function AdminDashboard() {
   const productsQuery = useQuery({
     queryKey: ["admin-products"],
     queryFn: () => listProducts({ limit: 1 }),
+  });
+  const cs2shQuery = useQuery({
+    queryKey: ["admin-cs2sh-import"],
+    queryFn: getCs2ShImportStatus,
+    refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
   });
 
   const orders = ordersQuery.data ?? [];
@@ -66,6 +109,22 @@ export default function AdminDashboard() {
     onError: () => {
       toast({
         title: "Não foi possível atualizar o vendedor",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const startCs2sh = useMutation({
+    mutationFn: startCs2ShImport,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-cs2sh-import"] });
+      queryClient.invalidateQueries({ queryKey: ["admin-products"] });
+      toast({ title: "Importação do catálogo cs2.sh iniciada" });
+    },
+    onError: (error) => {
+      toast({
+        title: "Não foi possível importar o catálogo",
+        description: userFacingApiError(error),
         variant: "destructive",
       });
     },
@@ -128,6 +187,32 @@ export default function AdminDashboard() {
           Catálogo, vendedores e pedidos da plataforma.
         </p>
       </div>
+
+      <section className="space-y-3 rounded-md border border-border bg-card p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight">
+              Catálogo cs2.sh
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              No Render não há shell. Importe skins tradable pela API; o
+              PostgreSQL guarda o resultado.
+            </p>
+          </div>
+          <Button
+            type="button"
+            disabled={startCs2sh.isPending || cs2shQuery.data?.running === true}
+            onClick={() => startCs2sh.mutate()}
+          >
+            {cs2shQuery.data?.running || startCs2sh.isPending
+              ? "Importando…"
+              : "Importar catálogo"}
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {cs2ShStatusCopy(cs2shQuery.data ?? undefined, cs2shQuery.isError)}
+        </p>
+      </section>
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {stats.map((stat) => (

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,21 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  adminApproveSeller,
-  getCs2ShImportStatus,
-  listAdminOrders,
-  startCs2ShImport,
-} from "@/api/admin";
+import { adminApproveSeller, listAdminOrders } from "@/api/admin";
 import { listProducts } from "@/api/products";
 import { listSellers } from "@/api/sellers";
+import { Cs2ShCatalogImportCard } from "@/components/admin/Cs2ShCatalogImportCard";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  orderStatusLabel,
-  paymentStatusLabel,
-  userFacingApiError,
-} from "@/lib/userFacingApiError";
+import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
 import {
   Table,
   TableBody,
@@ -35,35 +27,6 @@ function formatCommission(rate: Seller["commissionRate"]): string {
   return `${(Number(rate ?? 0.1) * 100).toFixed(0)}%`;
 }
 
-function cs2ShStatusCopy(
-  status:
-    | {
-        running: boolean;
-        lastResult: {
-          skipped: boolean;
-          productsUpserted: number;
-          listingsUpserted: number;
-        } | null;
-      }
-    | undefined,
-  isError: boolean,
-): string {
-  if (isError) {
-    return "Não foi possível ler o status da importação.";
-  }
-  if (status?.running) {
-    return "Importação em andamento neste processo da API.";
-  }
-  const last = status?.lastResult;
-  if (!last) {
-    return "Nenhuma importação neste processo. Defina CS2SH_API_KEY no Render e use o botão, ou CS2SH_IMPORT=true no próximo deploy.";
-  }
-  if (last.skipped) {
-    return "A última tentativa pulou o import: a chave da API cs2.sh não está configurada.";
-  }
-  return `Última importação neste processo: ${last.productsUpserted} produtos e ${last.listingsUpserted} listings demo.`;
-}
-
 export default function AdminDashboard() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -79,11 +42,6 @@ export default function AdminDashboard() {
   const productsQuery = useQuery({
     queryKey: ["admin-products"],
     queryFn: () => listProducts({ limit: 1 }),
-  });
-  const cs2shQuery = useQuery({
-    queryKey: ["admin-cs2sh-import"],
-    queryFn: getCs2ShImportStatus,
-    refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
   });
 
   const orders = ordersQuery.data ?? [];
@@ -114,63 +72,11 @@ export default function AdminDashboard() {
     },
   });
 
-  const startCs2sh = useMutation({
-    mutationFn: startCs2ShImport,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin-cs2sh-import"] });
-      queryClient.invalidateQueries({ queryKey: ["admin-products"] });
-      toast({ title: "Importação do catálogo cs2.sh iniciada" });
-    },
-    onError: (error) => {
-      toast({
-        title: "Não foi possível importar o catálogo",
-        description: userFacingApiError(error),
-        variant: "destructive",
-      });
-    },
-  });
-
   const isLoading =
     ordersQuery.isLoading || sellersQuery.isLoading || productsQuery.isLoading;
   const isError =
     ordersQuery.isError || sellersQuery.isError || productsQuery.isError;
   const error = ordersQuery.error ?? sellersQuery.error ?? productsQuery.error;
-
-  if (isLoading) {
-    return (
-      <div className="space-y-6" role="status" aria-label="Carregando">
-        <Skeleton className="h-8 w-48" />
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <Skeleton className="h-24 w-full" />
-          <Skeleton className="h-24 w-full" />
-          <Skeleton className="h-24 w-full" />
-          <Skeleton className="h-24 w-full" />
-        </div>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <ErrorState
-        title="Erro ao carregar o painel"
-        error={error}
-        action={
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              void ordersQuery.refetch();
-              void sellersQuery.refetch();
-              void productsQuery.refetch();
-            }}
-          >
-            Tentar novamente
-          </Button>
-        }
-      />
-    );
-  }
 
   const stats = [
     { label: "Receita", value: formatMoney(totalRevenue) },
@@ -188,91 +94,102 @@ export default function AdminDashboard() {
         </p>
       </div>
 
-      <section className="space-y-3 rounded-md border border-border bg-card p-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
+      <Cs2ShCatalogImportCard />
+
+      {isLoading ? (
+        <div className="space-y-6" role="status" aria-label="Carregando">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        </div>
+      ) : isError ? (
+        <ErrorState
+          title="Erro ao carregar o painel"
+          error={error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                void ordersQuery.refetch();
+                void sellersQuery.refetch();
+                void productsQuery.refetch();
+              }}
+            >
+              Tentar novamente
+            </Button>
+          }
+        />
+      ) : (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-md border border-border bg-card p-4"
+              >
+                <p className="text-xs text-muted-foreground">{stat.label}</p>
+                <p className="mt-2 tabular-nums text-2xl font-semibold tracking-tight">
+                  {stat.value}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <section className="space-y-3">
+            <div>
+              <h2 className="text-lg font-semibold tracking-tight">
+                Vendedores pendentes
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Aprove ou rejeite cadastros aguardando revisão.
+              </p>
+            </div>
+            {pendingSellers.length === 0 ? (
+              <EmptyState
+                title="Nenhum vendedor pendente de aprovação"
+                description="Todos os cadastros já foram revisados."
+              />
+            ) : (
+              <PendingSellersTable
+                sellers={pendingSellers}
+                busy={approveSeller.isPending}
+                onApprove={(id) =>
+                  approveSeller.mutate({ id, isApproved: true })
+                }
+                onReject={(id) =>
+                  approveSeller.mutate({ id, isApproved: false })
+                }
+              />
+            )}
+          </section>
+
+          <section className="space-y-3">
             <h2 className="text-lg font-semibold tracking-tight">
-              Catálogo cs2.sh
+              Todos os vendedores
             </h2>
-            <p className="text-sm text-muted-foreground">
-              No Render não há shell. Importe skins tradable pela API; o
-              PostgreSQL guarda o resultado.
-            </p>
-          </div>
-          <Button
-            type="button"
-            disabled={startCs2sh.isPending || cs2shQuery.data?.running === true}
-            onClick={() => startCs2sh.mutate()}
-          >
-            {cs2shQuery.data?.running || startCs2sh.isPending
-              ? "Importando…"
-              : "Importar catálogo"}
-          </Button>
-        </div>
-        <p className="text-sm text-muted-foreground">
-          {cs2ShStatusCopy(cs2shQuery.data ?? undefined, cs2shQuery.isError)}
-        </p>
-      </section>
+            {sellers.length === 0 ? (
+              <EmptyState title="Nenhum vendedor cadastrado" />
+            ) : (
+              <SellersOverviewTable sellers={sellers} />
+            )}
+          </section>
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        {stats.map((stat) => (
-          <div
-            key={stat.label}
-            className="rounded-md border border-border bg-card p-4"
-          >
-            <p className="text-xs text-muted-foreground">{stat.label}</p>
-            <p className="mt-2 tabular-nums text-2xl font-semibold tracking-tight">
-              {stat.value}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      <section className="space-y-3">
-        <div>
-          <h2 className="text-lg font-semibold tracking-tight">
-            Vendedores pendentes
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Aprove ou rejeite cadastros aguardando revisão.
-          </p>
-        </div>
-        {pendingSellers.length === 0 ? (
-          <EmptyState
-            title="Nenhum vendedor pendente de aprovação"
-            description="Todos os cadastros já foram revisados."
-          />
-        ) : (
-          <PendingSellersTable
-            sellers={pendingSellers}
-            busy={approveSeller.isPending}
-            onApprove={(id) => approveSeller.mutate({ id, isApproved: true })}
-            onReject={(id) => approveSeller.mutate({ id, isApproved: false })}
-          />
-        )}
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold tracking-tight">
-          Todos os vendedores
-        </h2>
-        {sellers.length === 0 ? (
-          <EmptyState title="Nenhum vendedor cadastrado" />
-        ) : (
-          <SellersOverviewTable sellers={sellers} />
-        )}
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold tracking-tight">
-          Pedidos recentes
-        </h2>
-        {recentOrders.length === 0 ? (
-          <EmptyState title="Nenhum pedido encontrado" />
-        ) : (
-          <RecentOrdersTable orders={recentOrders} />
-        )}
-      </section>
+          <section className="space-y-3">
+            <h2 className="text-lg font-semibold tracking-tight">
+              Pedidos recentes
+            </h2>
+            {recentOrders.length === 0 ? (
+              <EmptyState title="Nenhum pedido encontrado" />
+            ) : (
+              <RecentOrdersTable orders={recentOrders} />
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/__tests__/AdminDashboard.test.tsx
+++ b/src/pages/__tests__/AdminDashboard.test.tsx
@@ -108,8 +108,8 @@ describe("AdminDashboard", () => {
 
     renderDashboard();
 
-    expect(await screen.findByText("Painel admin")).toBeTruthy();
-    expect(screen.getByText("Receita")).toBeTruthy();
+    expect(await screen.findByText("Receita")).toBeTruthy();
+    expect(screen.getByText("Painel admin")).toBeTruthy();
     expect(screen.getAllByText("$42.00").length).toBeGreaterThan(0);
     expect(screen.getByText("12")).toBeTruthy();
     expect(screen.getAllByText("Loja Pendente").length).toBeGreaterThan(0);
@@ -129,5 +129,18 @@ describe("AdminDashboard", () => {
     await waitFor(() => {
       expect(startCs2ShImport).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("keeps Importar catálogo when other admin lists fail", async () => {
+    listAdminOrders.mockRejectedValue(new Error("boom"));
+    listSellers.mockRejectedValue(new Error("boom"));
+    listProducts.mockRejectedValue(new Error("boom"));
+
+    renderDashboard();
+
+    expect(
+      await screen.findByRole("button", { name: "Importar catálogo" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Painel admin")).toBeTruthy();
   });
 });

--- a/src/pages/__tests__/AdminDashboard.test.tsx
+++ b/src/pages/__tests__/AdminDashboard.test.tsx
@@ -9,10 +9,14 @@ const listAdminOrders = vi.fn();
 const adminApproveSeller = vi.fn();
 const listSellers = vi.fn();
 const listProducts = vi.fn();
+const getCs2ShImportStatus = vi.fn();
+const startCs2ShImport = vi.fn();
 
 vi.mock("@/api/admin", () => ({
   listAdminOrders: (...args: unknown[]) => listAdminOrders(...args),
   adminApproveSeller: (...args: unknown[]) => adminApproveSeller(...args),
+  getCs2ShImportStatus: (...args: unknown[]) => getCs2ShImportStatus(...args),
+  startCs2ShImport: (...args: unknown[]) => startCs2ShImport(...args),
 }));
 
 vi.mock("@/api/sellers", () => ({
@@ -75,7 +79,18 @@ describe("AdminDashboard", () => {
     adminApproveSeller.mockReset();
     listSellers.mockReset();
     listProducts.mockReset();
+    getCs2ShImportStatus.mockReset();
+    startCs2ShImport.mockReset();
     adminApproveSeller.mockResolvedValue(seller({ isApproved: true }));
+    getCs2ShImportStatus.mockResolvedValue({
+      running: false,
+      lastResult: null,
+    });
+    startCs2ShImport.mockResolvedValue({
+      status: "started",
+      running: true,
+      lastResult: null,
+    });
   });
 
   it("uses current admin lists and approve contract without leftover marketplace chrome", async () => {
@@ -108,6 +123,11 @@ describe("AdminDashboard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Aprovar" }));
     await waitFor(() => {
       expect(adminApproveSeller).toHaveBeenCalledWith("seller-pending", true);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Importar catálogo" }));
+    await waitFor(() => {
+      expect(startCs2ShImport).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/pages/admin/AdminCatalog.tsx
+++ b/src/pages/admin/AdminCatalog.tsx
@@ -1,0 +1,15 @@
+import { Cs2ShCatalogImportCard } from "@/components/admin/Cs2ShCatalogImportCard";
+
+export default function AdminCatalog() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Catálogo</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Importação do catálogo cs2.sh. Não exige SSH no Render.
+        </p>
+      </div>
+      <Cs2ShCatalogImportCard />
+    </div>
+  );
+}

--- a/src/pages/admin/__tests__/AdminCatalog.test.tsx
+++ b/src/pages/admin/__tests__/AdminCatalog.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AdminCatalog from "../AdminCatalog";
+
+const getCs2ShImportStatus = vi.fn();
+const startCs2ShImport = vi.fn();
+
+vi.mock("@/api/admin", () => ({
+  getCs2ShImportStatus: (...args: unknown[]) => getCs2ShImportStatus(...args),
+  startCs2ShImport: (...args: unknown[]) => startCs2ShImport(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function renderCatalog() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminCatalog />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminCatalog", () => {
+  beforeEach(() => {
+    getCs2ShImportStatus.mockReset();
+    startCs2ShImport.mockReset();
+    getCs2ShImportStatus.mockResolvedValue({
+      running: false,
+      lastResult: null,
+    });
+    startCs2ShImport.mockResolvedValue({
+      status: "started",
+      running: true,
+      lastResult: null,
+    });
+  });
+
+  it("shows the import button without waiting on other admin lists", async () => {
+    renderCatalog();
+
+    expect(
+      await screen.findByRole("heading", { name: "Catálogo" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Importar catálogo" }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Importar catálogo" }));
+    await waitFor(() => {
+      expect(startCs2ShImport).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

O PR #153 mergeou só o import cs2.sh via CLI. Estes commits ficaram na branch depois do merge e não tinham PR.

Render web service **não tem SSH/shell**. Este PR adiciona o caminho de operador HTTP + UI:

- `POST /admin/catalog/cs2sh-import` (ADMIN, 202 em background). Sem key → 503. Já em andamento neste processo → 409.
- `GET /admin/catalog/cs2sh-import` para status in-process.
- Boot `CS2SH_IMPORT=true` **depois** de `listen`, para não bloquear `GET /ready`.
- Painel admin: item **Catálogo** (`/admin/catalog`) e botão **Importar catálogo** também na Visão Geral (visível mesmo se pedidos/vendedores falharem).
- `render.yaml`: `CS2SH_API_KEY` `sync: false`, `CS2SH_IMPORT=false`.

## Commits

- `c1fa15b` feat(catalog): trigger cs2.sh import on Render without a shell
- `3e41ca0` test(catalog): avoid unhandled rejection in cs2.sh import lock tests
- `4b9290d` fix(admin): put cs2.sh import on a Catálogo sidebar page

## Invariants

- `/ready` não espera o cs2.sh.
- HTTP para cs2.sh termina antes das escritas Prisma.
- Listings demo não revivem `SOLD`/`RESERVED`.
- `CS2SH_API_KEY` fica só em env.

## Operator path

1. Render Dashboard → `neon-arsenal-api` → `CS2SH_API_KEY`.
2. Deploy **API e frontend** deste PR.
3. Login ADMIN → sidebar **Catálogo** → **Importar catálogo**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

