### PR TITLE
feat(ui): preview de imagem nas listings do seller e no carrinho

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -2,23 +2,43 @@ import { Link } from "react-router-dom";
 import type { Listing, Product } from "@/types/api";
 import { ListingCartCta } from "@/components/ListingCartCta";
 
-export function productDisplayName(product: Product): string {
+export function productDisplayName(
+  product: Pick<Product, "weapon" | "skinName" | "exterior">,
+): string {
   return `${product.weapon} | ${product.skinName} (${product.exterior})`;
 }
+
+export type SkinProduct = Pick<Product, "weapon" | "skinName" | "exterior"> & {
+  imageUrl?: string | null;
+};
+
+const SKIN_THUMB_SIZE = {
+  sm: "h-8 w-8",
+  md: "h-12 w-12",
+  lg: "h-16 w-16",
+} as const;
 
 export function SkinVisual({
   product,
   className = "text-2xl",
+  padded = true,
+  decorative = false,
 }: {
-  product: Product;
+  product: SkinProduct;
   className?: string;
+  padded?: boolean;
+  decorative?: boolean;
 }) {
   if (product.imageUrl) {
     return (
       <img
         src={product.imageUrl}
-        alt={productDisplayName(product)}
-        className="h-full w-full object-contain p-3"
+        alt={decorative ? "" : productDisplayName(product)}
+        className={
+          padded
+            ? "h-full w-full object-contain p-3"
+            : "h-full w-full object-contain p-0.5"
+        }
       />
     );
   }
@@ -27,6 +47,31 @@ export function SkinVisual({
       className={`font-semibold tracking-tight text-muted-foreground/70 ${className}`}
     >
       {product.weapon.slice(0, 3).toUpperCase()}
+    </span>
+  );
+}
+
+/** Compact catalog preview for tables, cart lines, and select options. */
+export function SkinThumb({
+  product,
+  size = "md",
+  decorative = false,
+}: {
+  product: SkinProduct;
+  size?: keyof typeof SKIN_THUMB_SIZE;
+  decorative?: boolean;
+}) {
+  return (
+    <span
+      className={`inline-flex ${SKIN_THUMB_SIZE[size]} shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted`}
+      aria-hidden={decorative || undefined}
+    >
+      <SkinVisual
+        product={product}
+        className="text-[10px]"
+        padded={false}
+        decorative={decorative}
+      />
     </span>
   );
 }

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -13,9 +13,9 @@ export type SkinProduct = Pick<Product, "weapon" | "skinName" | "exterior"> & {
 };
 
 const SKIN_THUMB_SIZE = {
-  sm: "h-8 w-8",
-  md: "h-12 w-12",
-  lg: "h-16 w-16",
+  sm: "h-8 w-10",
+  md: "h-12 w-16",
+  lg: "h-16 w-24",
 } as const;
 
 export function SkinVisual({
@@ -63,7 +63,7 @@ export function SkinThumb({
 }) {
   return (
     <span
-      className={`inline-flex ${SKIN_THUMB_SIZE[size]} shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted`}
+      className={`inline-flex ${SKIN_THUMB_SIZE[size]} shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/40 ring-1 ring-border`}
       aria-hidden={decorative || undefined}
     >
       <SkinVisual

--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { ListingCard } from "../ProductCard";
+import { ListingCard, SkinThumb } from "../ProductCard";
 import { CartProvider, useCart } from "../../contexts/CartContext";
 import type { Listing } from "@/types/api";
 import {
@@ -277,5 +277,41 @@ describe("ListingCard", () => {
     renderCard(makeListing());
     expect(screen.queryByText(/SKINMARKET/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/CS2 Skin Marketplace/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("SkinThumb", () => {
+  it("renders a compact catalog image", () => {
+    render(
+      <SkinThumb
+        product={{
+          weapon: "AK-47",
+          skinName: "Redline",
+          exterior: "Field-Tested",
+          imageUrl: "https://cs2.sh/image/ak.png",
+        }}
+      />,
+    );
+    expect(
+      screen.getByRole("img", { name: "AK-47 | Redline (Field-Tested)" }),
+    ).toHaveAttribute("src", "https://cs2.sh/image/ak.png");
+  });
+
+  it("hides the image from the accessibility tree when decorative", () => {
+    render(
+      <SkinThumb
+        decorative
+        product={{
+          weapon: "AK-47",
+          skinName: "Redline",
+          exterior: "Field-Tested",
+          imageUrl: "https://cs2.sh/image/ak.png",
+        }}
+      />,
+    );
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(
+      document.querySelector('img[src="https://cs2.sh/image/ak.png"]'),
+    ).toBeTruthy();
   });
 });

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -4,15 +4,10 @@ import { useCart } from "@/contexts/CartContext";
 import { useCartListingsRevalidation } from "@/hooks/useCartListingsRevalidation";
 import { CartListingAlerts } from "@/components/CartListingAlerts";
 import { EmptyState } from "@/components/page-state";
+import { productDisplayName, SkinThumb } from "@/components/ProductCard";
 import { ReservationHold } from "@/components/ReservationHold";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-
-function listingLabel(listing: {
-  product: { weapon: string; skinName: string; exterior: string };
-}) {
-  return `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
-}
 
 export default function CartPage() {
   const { items, removeItem, updateListing, totalPrice, totalItems } =
@@ -66,15 +61,13 @@ export default function CartPage() {
             }
 
             const listing = line.display;
-            const name = listingLabel(listing);
+            const name = productDisplayName(listing.product);
             return (
               <li
                 key={listing.id}
                 className="flex items-center gap-4 rounded-md border border-border bg-card p-4"
               >
-                <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-md bg-muted px-1 text-center text-[10px] leading-tight text-muted-foreground">
-                  {listing.product.weapon}
-                </div>
+                <SkinThumb product={listing.product} size="lg" />
                 <div className="min-w-0 flex-1">
                   <Link
                     to={`/listing/${listing.id}`}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -7,6 +7,7 @@ import { createOrder } from "@/api/orders";
 import { createPaymentLink } from "@/api/payments";
 import { CartListingAlerts } from "@/components/CartListingAlerts";
 import { EmptyState } from "@/components/page-state";
+import { productDisplayName, SkinThumb } from "@/components/ProductCard";
 import { ReservationHold } from "@/components/ReservationHold";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -179,12 +180,17 @@ export default function Checkout() {
               }
 
               const listing = line.display;
-              const name = `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`;
+              const name = productDisplayName(listing.product);
               return (
                 <li key={listing.id} className="space-y-1 text-sm">
                   <div className="flex items-start justify-between gap-4">
-                    <span className="min-w-0 truncate text-foreground">
-                      {name}
+                    <span className="flex min-w-0 items-center gap-3 text-foreground">
+                      <SkinThumb
+                        product={listing.product}
+                        size="sm"
+                        decorative
+                      />
+                      <span className="truncate">{name}</span>
                     </span>
                     <span className="flex shrink-0 items-center gap-2">
                       <span className="tabular-price text-muted-foreground">

--- a/src/pages/__tests__/CartPage.test.tsx
+++ b/src/pages/__tests__/CartPage.test.tsx
@@ -229,4 +229,40 @@ describe("CartPage", () => {
     });
     expect(screen.queryByText("Erro ao atualizar")).toBeNull();
   });
+
+  it("shows the listing image when product.imageUrl is set", async () => {
+    cartState.items = [
+      {
+        listing: listing("listing-ak", 100, {
+          product: {
+            ...listing("listing-ak", 100).product,
+            imageUrl: "https://cs2.sh/image/ak-neon-rider.png",
+          },
+        }),
+        priceWhenAdded: 100,
+      },
+    ];
+    cartState.totalPrice = 100;
+    cartState.totalItems = 1;
+    renderCart();
+
+    expect(
+      await screen.findByRole("img", {
+        name: "AK-47 | Neon Rider (Field-Tested)",
+      }),
+    ).toHaveAttribute("src", "https://cs2.sh/image/ak-neon-rider.png");
+  });
+
+  it("falls back to a weapon monogram when the listing has no image", async () => {
+    cartState.items = [
+      { listing: listing("listing-ak", 100), priceWhenAdded: 100 },
+    ];
+    cartState.totalPrice = 100;
+    cartState.totalItems = 1;
+    renderCart();
+
+    expect(await screen.findByText("Finalizar compra")).toBeTruthy();
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("AK-")).toBeTruthy();
+  });
 });

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -243,6 +243,24 @@ describe("Checkout", () => {
     expect(reserveListing).not.toHaveBeenCalled();
   });
 
+  it("shows a catalog thumbnail for each checkout line", async () => {
+    const withImage = listing(100);
+    withImage.product = {
+      ...withImage.product,
+      imageUrl: "https://cs2.sh/image/ak-redline.png",
+    };
+    cartState.items = [{ listing: withImage }];
+    cartState.totalPrice = 100;
+    asCustomer();
+
+    renderCheckout();
+    await waitForPayable();
+
+    expect(
+      document.querySelector('img[src="https://cs2.sh/image/ak-redline.png"]'),
+    ).toBeTruthy();
+  });
+
   it("sends absolute returnUrl and cancelUrl and prunes ordered listings", async () => {
     cartState.items = [{ listing: listing(100) }];
     cartState.totalPrice = 100;

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -494,7 +494,7 @@ export default function SellerListings() {
               </Select>
               {selectedFormProduct ? (
                 <div className="flex items-center gap-3 rounded-md border border-border bg-muted/40 p-3">
-                  <div className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+                  <div className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/40 ring-1 ring-border">
                     <SkinVisual
                       product={selectedFormProduct}
                       className="text-sm"

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -48,6 +48,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { EmptyState, ErrorState } from "@/components/page-state";
+import {
+  productDisplayName,
+  SkinThumb,
+  SkinVisual,
+} from "@/components/ProductCard";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -291,6 +296,12 @@ export default function SellerListings() {
     }
   };
 
+  const selectedFormProduct =
+    products.find((product) => product.id === form.productId) ??
+    (editingListing?.productId === form.productId
+      ? editingListing.product
+      : undefined);
+
   if (error) {
     return (
       <ErrorState
@@ -354,10 +365,15 @@ export default function SellerListings() {
             </TableHeader>
             <TableBody>
               {listings.map((l) => {
-                const productName = `${l.product.weapon} | ${l.product.skinName} (${l.product.exterior})`;
+                const productName = productDisplayName(l.product);
                 return (
                   <TableRow key={l.id}>
-                    <TableCell className="font-medium">{productName}</TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        <SkinThumb product={l.product} size="md" decorative />
+                        <span className="font-medium">{productName}</span>
+                      </div>
+                    </TableCell>
                     <TableCell className="hidden md:table-cell text-muted-foreground">
                       {Number(l.floatValue).toFixed(8)}
                     </TableCell>
@@ -456,17 +472,40 @@ export default function SellerListings() {
                 }
                 disabled={!!editingListing}
               >
-                <SelectTrigger id="productId" aria-labelledby="productId-label">
+                <SelectTrigger
+                  id="productId"
+                  aria-labelledby="productId-label"
+                  className="h-auto min-h-11 [&>span]:line-clamp-none [&>span]:flex [&>span]:items-center [&>span]:gap-2"
+                >
                   <SelectValue placeholder="Selecione um produto" />
                 </SelectTrigger>
                 <SelectContent>
                   {products.map((p) => (
                     <SelectItem key={p.id} value={p.id}>
-                      {p.weapon} | {p.skinName} ({p.exterior})
+                      <span className="flex items-center gap-2">
+                        <SkinThumb product={p} size="sm" decorative />
+                        <span>
+                          {p.weapon} | {p.skinName} ({p.exterior})
+                        </span>
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
+              {selectedFormProduct ? (
+                <div className="flex items-center gap-3 rounded-md border border-border bg-muted/40 p-3">
+                  <div className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+                    <SkinVisual
+                      product={selectedFormProduct}
+                      className="text-sm"
+                      padded={false}
+                    />
+                  </div>
+                  <p className="text-sm font-medium">
+                    {productDisplayName(selectedFormProduct)}
+                  </p>
+                </div>
+              ) : null}
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="grid gap-2">

--- a/src/pages/seller/SellerProducts.tsx
+++ b/src/pages/seller/SellerProducts.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { listProducts } from "@/api/products";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
+import { SkinThumb } from "@/components/ProductCard";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -92,8 +93,13 @@ export default function SellerProductsPage() {
             <TableBody>
               {items.map((product) => (
                 <TableRow key={product.id}>
-                  <TableCell className="font-medium">
-                    {product.weapon} | {product.skinName}
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <SkinThumb product={product} size="md" decorative />
+                      <span className="font-medium">
+                        {product.weapon} | {product.skinName}
+                      </span>
+                    </div>
                   </TableCell>
                   <TableCell>{product.rarity}</TableCell>
                   <TableCell className="hidden text-muted-foreground md:table-cell">

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import SellerListings from "../SellerListings";
-import type { Listing, Seller, User } from "@/types/api";
+import type { Listing, Product, Seller, User } from "@/types/api";
 
 const getSellerMe = vi.fn();
 const getSellerListings = vi.fn();
@@ -48,10 +48,28 @@ function seller(): Seller {
   };
 }
 
-function listing(): Listing {
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: "https://cs2.sh/image/ak-redline.png",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function listing(overrides: Partial<Listing> = {}): Listing {
+  const catalog = product();
   return {
     id: "listing-1",
-    productId: "ak-redline-ft",
+    productId: catalog.id,
     sellerId: "seller-1",
     floatValue: 0.25,
     pattern: 123,
@@ -60,32 +78,23 @@ function listing(): Listing {
     status: "ACTIVE",
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    product: {
-      id: "ak-redline-ft",
-      game: "CS2",
-      weapon: "AK-47",
-      skinName: "Redline",
-      rarity: "Classified",
-      exterior: "Field-Tested",
-      isStattrak: false,
-      isSouvenir: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    },
+    product: catalog,
     seller: { id: "seller-1", storeName: "NeonTrader Store" },
+    ...overrides,
   };
 }
 
 describe("SellerListings", () => {
   beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
     getSellerMe.mockReset();
     getSellerListings.mockReset();
     listProducts.mockReset();
     getSellerMe.mockResolvedValue(seller());
     getSellerListings.mockResolvedValue({ items: [listing()], total: 1 });
     listProducts.mockResolvedValue({
-      items: [],
-      total: 0,
+      items: [product()],
+      total: 1,
       page: 1,
       limit: 100,
     });
@@ -168,5 +177,76 @@ describe("SellerListings", () => {
     expect(screen.queryByText("Seller not found")).toBeNull();
     expect(getSellerMe).not.toHaveBeenCalled();
     expect(getSellerListings).not.toHaveBeenCalled();
+  });
+
+  it("shows a catalog thumbnail in each listing row", async () => {
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    const thumb = document.querySelector(
+      'img[src="https://cs2.sh/image/ak-redline.png"]',
+    );
+    expect(thumb).toBeTruthy();
+  });
+
+  it("shows a product preview in the edit listing dialog", async () => {
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByLabelText("Editar"));
+    expect(await screen.findByText("Editar listing")).toBeTruthy();
+    expect(
+      screen.getByRole("img", { name: "AK-47 | Redline (Field-Tested)" }),
+    ).toHaveAttribute("src", "https://cs2.sh/image/ak-redline.png");
+  });
+
+  it("shows option thumbnails and a preview when creating a listing", async () => {
+    const awp = product({
+      id: "awp-asiimov-ft",
+      weapon: "AWP",
+      skinName: "Asiimov",
+      imageUrl: "https://cs2.sh/image/awp-asiimov.png",
+    });
+    listProducts.mockResolvedValue({
+      items: [product(), awp],
+      total: 2,
+      page: 1,
+      limit: 100,
+    });
+
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Novo Listing" }),
+    );
+    expect(await screen.findByText("Novo listing")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Produto"));
+    const option = await screen.findByText("AWP | Asiimov (Field-Tested)");
+    expect(
+      option
+        .closest("[role='option']")
+        ?.querySelector('img[src="https://cs2.sh/image/awp-asiimov.png"]'),
+    ).toBeTruthy();
+
+    fireEvent.click(option);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("img", { name: "AWP | Asiimov (Field-Tested)" }),
+      ).toHaveAttribute("src", "https://cs2.sh/image/awp-asiimov.png");
+    });
   });
 });

--- a/src/pages/seller/__tests__/SellerProducts.test.tsx
+++ b/src/pages/seller/__tests__/SellerProducts.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
 }));
 
-function product(): Product {
+function product(overrides: Partial<Product> = {}): Product {
   return {
     id: "ak-redline-ft",
     game: "CS2",
@@ -37,6 +37,7 @@ function product(): Product {
     isSouvenir: false,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
+    ...overrides,
   };
 }
 
@@ -89,6 +90,22 @@ describe("SellerProducts", () => {
       screen.getByText("Ir para listings").closest("a")?.getAttribute("href"),
     ).toBe("/seller/listings");
     expect(listProducts).toHaveBeenCalled();
+  });
+
+  it("shows a catalog thumbnail when product.imageUrl is set", async () => {
+    listProducts.mockResolvedValue({
+      items: [product({ imageUrl: "https://cs2.sh/image/ak-redline.png" })],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderProducts();
+
+    expect(await screen.findByText("AK-47 | Redline")).toBeTruthy();
+    expect(
+      document.querySelector('img[src="https://cs2.sh/image/ak-redline.png"]'),
+    ).toBeTruthy();
   });
 
   it("does not expose listing or product mutations", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Por que

Depois do import cs2.sh, `product.imageUrl` existe no catálogo, mas o seller e o carrinho ainda mostravam só texto (ou o monograma da arma). Faltava um preview pequeno nas superfícies de CRUD e compra.

## O que mudou

- `SkinThumb` reutiliza `product.imageUrl` (fallback no monograma de 3 letras).
- Tabela **Meus listings**: thumbnail 4:3 à esquerda da skin.
- Dialog **Novo/Editar listing**: thumbnail em cada opção do dropdown + preview no formulário.
- Tabela **Produtos** do seller: mesma thumbnail (catálogo somente leitura).
- **Carrinho** e **checkout**: thumbnail na linha do item.

Não altera API, schema, reserva, pagamento nem o invariante de item único.

## Verificação

- Vitest: SellerListings, SellerProducts, CartPage, Checkout, SkinThumb.
- Browser local: seller listings + dialog; buyer cart + checkout.

[Tabela Meus listings com thumbnail à esquerda](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listings-table-thumbs.webp)
[Dropdown de produto com thumbnail nas opções](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listing-dropdown-thumbs.webp)
[Preview da skin no dialog Novo listing](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listing-dialog-preview.webp)
[Carrinho com thumbnail do item](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcart-line-thumb.webp)
[Checkout com thumbnail do item](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcheckout-line-thumb.webp)

[seller-listings-image-previews.mp4](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listings-image-previews.mp4)
[cart-checkout-image-previews.mp4](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcart-checkout-image-previews.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

