### PR TITLE
feat(seller): buscar o catálogo ao criar listing

### DIFF
--- a/src/components/seller/ProductCatalogPicker.tsx
+++ b/src/components/seller/ProductCatalogPicker.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { listProducts } from "@/api/products";
+import { productDisplayName, SkinThumb } from "@/components/ProductCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  logTechnicalError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
+import type { Product } from "@/types/api";
+
+export const CATALOG_PICKER_PAGE_SIZE = 20;
+export const CATALOG_PICKER_SEARCH_DEBOUNCE_MS = 300;
+
+export function ProductCatalogPicker({
+  selectedProduct,
+  onSelect,
+  disabled = false,
+  enabled = true,
+}: {
+  selectedProduct?: Product;
+  onSelect: (product: Product) => void;
+  disabled?: boolean;
+  enabled?: boolean;
+}) {
+  const [query, setQuery] = useState("");
+  const [items, setItems] = useState<Product[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || disabled) return;
+    let cancelled = false;
+    const trimmed = query.trim();
+    const delay = trimmed === "" ? 0 : CATALOG_PICKER_SEARCH_DEBOUNCE_MS;
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      setError(null);
+      void listProducts({
+        page: 1,
+        limit: CATALOG_PICKER_PAGE_SIZE,
+        ...(trimmed ? { search: trimmed } : {}),
+      })
+        .then((res) => {
+          if (cancelled) return;
+          setItems(res.items);
+          setTotal(res.total);
+          setPage(1);
+        })
+        .catch((e: unknown) => {
+          if (cancelled) return;
+          logTechnicalError(e);
+          setError(userFacingApiError(e));
+          setItems([]);
+          setTotal(0);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, delay);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [enabled, disabled, query]);
+
+  const loadMore = async () => {
+    const trimmed = query.trim();
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const nextPage = page + 1;
+      const res = await listProducts({
+        page: nextPage,
+        limit: CATALOG_PICKER_PAGE_SIZE,
+        ...(trimmed ? { search: trimmed } : {}),
+      });
+      setItems((current) => {
+        const seen = new Set(current.map((item) => item.id));
+        return [...current, ...res.items.filter((item) => !seen.has(item.id))];
+      });
+      setTotal(res.total);
+      setPage(nextPage);
+    } catch (e) {
+      logTechnicalError(e);
+      setError(userFacingApiError(e));
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  if (disabled) {
+    return null;
+  }
+
+  const hasMore = items.length < total;
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="product-catalog-search">Buscar no catálogo</Label>
+      <Input
+        id="product-catalog-search"
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Arma, skin ou nome Steam (ex: AK-47 Redline)"
+        autoComplete="off"
+        aria-controls="product-catalog-results"
+      />
+      <p className="text-xs text-muted-foreground">
+        O catálogo tem milhares de skins. Digite para filtrar; a lista não
+        carrega o inventário inteiro de uma vez.
+      </p>
+      {error ? (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div
+        id="product-catalog-results"
+        role="listbox"
+        aria-label="Produtos do catálogo"
+        aria-busy={loading || undefined}
+        className="max-h-64 overflow-y-auto rounded-md border border-border"
+      >
+        {loading ? (
+          <div
+            className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground"
+            role="status"
+            aria-label="Carregando"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Carregando catálogo
+          </div>
+        ) : items.length === 0 ? (
+          <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+            Nenhum produto encontrado
+          </p>
+        ) : (
+          <ul>
+            {items.map((product) => {
+              const selected = product.id === selectedProduct?.id;
+              const name = productDisplayName(product);
+              return (
+                <li key={product.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    aria-label={name}
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent ${
+                      selected ? "bg-accent" : ""
+                    }`}
+                    onClick={() => onSelect(product)}
+                  >
+                    <SkinThumb product={product} size="sm" decorative />
+                    <span className="min-w-0 truncate">{name}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+      {!loading && items.length > 0 ? (
+        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span className="tabular-nums">
+            Mostrando {items.length} de {total}
+          </span>
+          {hasMore ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void loadMore()}
+              disabled={loadingMore}
+            >
+              {loadingMore ? (
+                <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+              ) : null}
+              Carregar mais
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/seller/__tests__/ProductCatalogPicker.test.tsx
+++ b/src/components/seller/__tests__/ProductCatalogPicker.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  CATALOG_PICKER_PAGE_SIZE,
+  ProductCatalogPicker,
+} from "../ProductCatalogPicker";
+import type { Product } from "@/types/api";
+
+const listProducts = vi.fn();
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: "https://cs2.sh/image/ak-redline.png",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ProductCatalogPicker", () => {
+  beforeEach(() => {
+    listProducts.mockReset();
+    listProducts.mockResolvedValue({
+      items: [product()],
+      total: 1,
+      page: 1,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not fetch the catalog while disabled", () => {
+    render(<ProductCatalogPicker enabled disabled onSelect={vi.fn()} />);
+    expect(listProducts).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText("Buscar no catálogo")).toBeNull();
+  });
+
+  it("loads one page from GET /products instead of the full catalog", async () => {
+    render(<ProductCatalogPicker enabled onSelect={vi.fn()} />);
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(listProducts).toHaveBeenCalledWith({
+      page: 1,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+    expect(listProducts).not.toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 100 }),
+    );
+    expect(screen.getByText("Mostrando 1 de 1")).toBeTruthy();
+  });
+
+  it("searches the catalog by weapon, skin, or Steam name", async () => {
+    const awp = product({
+      id: "awp-asiimov-ft",
+      weapon: "AWP",
+      skinName: "Asiimov",
+      imageUrl: "https://cs2.sh/image/awp-asiimov.png",
+    });
+    listProducts.mockResolvedValueOnce({
+      items: [product()],
+      total: 21924,
+      page: 1,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+    listProducts.mockResolvedValue({
+      items: [awp],
+      total: 4,
+      page: 1,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+
+    render(<ProductCatalogPicker enabled onSelect={vi.fn()} />);
+    expect(await screen.findByText(/AK-47/)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Buscar no catálogo"), {
+      target: { value: "AWP Asiimov" },
+    });
+
+    expect(
+      await screen.findByText("AWP | Asiimov (Field-Tested)"),
+    ).toBeTruthy();
+    expect(listProducts).toHaveBeenCalledWith({
+      page: 1,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+      search: "AWP Asiimov",
+    });
+    expect(screen.getByText("Mostrando 1 de 4")).toBeTruthy();
+  });
+
+  it("selects a result and keeps catalog thumbnails", async () => {
+    const onSelect = vi.fn();
+    render(<ProductCatalogPicker enabled onSelect={onSelect} />);
+
+    fireEvent.click(
+      await screen.findByRole("option", {
+        name: "AK-47 | Redline (Field-Tested)",
+      }),
+    );
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "ak-redline-ft" }),
+    );
+    expect(
+      document.querySelector('img[src="https://cs2.sh/image/ak-redline.png"]'),
+    ).toBeTruthy();
+  });
+
+  it("loads the next page without replacing the current results", async () => {
+    const first = product();
+    const second = product({
+      id: "awp-asiimov-ft",
+      weapon: "AWP",
+      skinName: "Asiimov",
+    });
+    listProducts.mockResolvedValueOnce({
+      items: [first],
+      total: 2,
+      page: 1,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+    listProducts.mockResolvedValueOnce({
+      items: [second],
+      total: 2,
+      page: 2,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+
+    render(<ProductCatalogPicker enabled onSelect={vi.fn()} />);
+    expect(await screen.findByText(/AK-47/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Carregar mais" }));
+
+    expect(await screen.findByText(/AWP/)).toBeTruthy();
+    expect(screen.getByText(/AK-47/)).toBeTruthy();
+    expect(listProducts).toHaveBeenLastCalledWith({
+      page: 2,
+      limit: CATALOG_PICKER_PAGE_SIZE,
+    });
+    expect(screen.queryByRole("button", { name: "Carregar mais" })).toBeNull();
+    expect(screen.getByText("Mostrando 2 de 2")).toBeTruthy();
+  });
+});

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -17,7 +17,7 @@ import {
   cancelListing,
 } from "@/api";
 import type { Seller, Listing, Product } from "@/types/api";
-import { listProducts } from "@/api/products";
+import { ProductCatalogPicker } from "@/components/seller/ProductCatalogPicker";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -83,7 +83,7 @@ export default function SellerListings() {
   const isAdmin = user?.role === "ADMIN";
   const [seller, setSeller] = useState<Seller | null>(null);
   const [listings, setListings] = useState<Listing[]>([]);
-  const [products, setProducts] = useState<Product[]>([]);
+  const [selectedProduct, setSelectedProduct] = useState<Product | undefined>();
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -123,15 +123,6 @@ export default function SellerListings() {
     }
   };
 
-  const loadProducts = async () => {
-    try {
-      const res = await listProducts({ page: 1, limit: 100 });
-      setProducts(res.items);
-    } catch (e) {
-      console.error("Erro ao carregar produtos:", e);
-    }
-  };
-
   const reload = async () => {
     setLoading(true);
     setError(null);
@@ -140,7 +131,7 @@ export default function SellerListings() {
       setLoading(false);
       return;
     }
-    await Promise.all([loadListings(), loadProducts()]);
+    await loadListings();
   };
 
   useEffect(() => {
@@ -156,12 +147,14 @@ export default function SellerListings() {
 
   const openCreate = () => {
     setEditingListing(null);
+    setSelectedProduct(undefined);
     setForm(emptyForm);
     setFormOpen(true);
   };
 
   const openEdit = (l: Listing) => {
     setEditingListing(l);
+    setSelectedProduct(l.product);
     setForm({
       productId: l.productId,
       floatValue: String(l.floatValue),
@@ -296,11 +289,7 @@ export default function SellerListings() {
     }
   };
 
-  const selectedFormProduct =
-    products.find((product) => product.id === form.productId) ??
-    (editingListing?.productId === form.productId
-      ? editingListing.product
-      : undefined);
+  const selectedFormProduct = selectedProduct;
 
   if (error) {
     return (
@@ -449,7 +438,7 @@ export default function SellerListings() {
       )}
 
       <Dialog open={formOpen} onOpenChange={setFormOpen}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
               {editingListing ? "Editar listing" : "Novo listing"}
@@ -462,36 +451,17 @@ export default function SellerListings() {
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
-              <Label htmlFor="productId" id="productId-label">
-                Produto
-              </Label>
-              <Select
-                value={form.productId}
-                onValueChange={(value) =>
-                  setForm((f) => ({ ...f, productId: value }))
-                }
-                disabled={!!editingListing}
-              >
-                <SelectTrigger
-                  id="productId"
-                  aria-labelledby="productId-label"
-                  className="h-auto min-h-11 [&>span]:line-clamp-none [&>span]:flex [&>span]:items-center [&>span]:gap-2"
-                >
-                  <SelectValue placeholder="Selecione um produto" />
-                </SelectTrigger>
-                <SelectContent>
-                  {products.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      <span className="flex items-center gap-2">
-                        <SkinThumb product={p} size="sm" decorative />
-                        <span>
-                          {p.weapon} | {p.skinName} ({p.exterior})
-                        </span>
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Label id="productId-label">Produto</Label>
+              {editingListing ? null : (
+                <ProductCatalogPicker
+                  selectedProduct={selectedProduct}
+                  enabled={formOpen}
+                  onSelect={(product) => {
+                    setSelectedProduct(product);
+                    setForm((f) => ({ ...f, productId: product.id }));
+                  }}
+                />
+              )}
               {selectedFormProduct ? (
                 <div className="flex items-center gap-3 rounded-md border border-border bg-muted/40 p-3">
                   <div className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/40 ring-1 ring-border">

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -96,7 +96,7 @@ describe("SellerListings", () => {
       items: [product()],
       total: 1,
       page: 1,
-      limit: 100,
+      limit: 20,
     });
     authState.user = {
       id: "seller-user",
@@ -121,6 +121,7 @@ describe("SellerListings", () => {
     expect(screen.getByTitle("Atualizar preço")).toBeTruthy();
     expect(screen.getByTitle("Cancelar listing")).toBeTruthy();
     expect(screen.getByLabelText("Editar")).toBeTruthy();
+    expect(listProducts).not.toHaveBeenCalled();
   });
 
   it("shows an empty state when the seller has no listings", async () => {
@@ -209,7 +210,7 @@ describe("SellerListings", () => {
     ).toHaveAttribute("src", "https://cs2.sh/image/ak-redline.png");
   });
 
-  it("shows option thumbnails and a preview when creating a listing", async () => {
+  it("searches the catalog instead of listing only the first 100 products", async () => {
     const awp = product({
       id: "awp-asiimov-ft",
       weapon: "AWP",
@@ -218,9 +219,9 @@ describe("SellerListings", () => {
     });
     listProducts.mockResolvedValue({
       items: [product(), awp],
-      total: 2,
+      total: 21924,
       page: 1,
-      limit: 100,
+      limit: 20,
     });
 
     render(
@@ -233,13 +234,25 @@ describe("SellerListings", () => {
       await screen.findByRole("button", { name: "Novo Listing" }),
     );
     expect(await screen.findByText("Novo listing")).toBeTruthy();
-
-    fireEvent.click(screen.getByLabelText("Produto"));
-    const option = await screen.findByText("AWP | Asiimov (Field-Tested)");
     expect(
-      option
-        .closest("[role='option']")
-        ?.querySelector('img[src="https://cs2.sh/image/awp-asiimov.png"]'),
+      await screen.findByRole("option", {
+        name: "AK-47 | Redline (Field-Tested)",
+      }),
+    ).toBeTruthy();
+    expect(listProducts).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+    });
+    expect(listProducts).not.toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 100 }),
+    );
+    expect(screen.getByText("Mostrando 2 de 21924")).toBeTruthy();
+
+    const option = screen.getByRole("option", {
+      name: "AWP | Asiimov (Field-Tested)",
+    });
+    expect(
+      option.querySelector('img[src="https://cs2.sh/image/awp-asiimov.png"]'),
     ).toBeTruthy();
 
     fireEvent.click(option);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Por que

Depois do import cs2.sh o catálogo tem ~22k `Product`. O dialog **Novo listing** chamava `GET /products?page=1&limit=100` e montava um `<Select>` com só essa página. A API já limita `limit` em 100, então o seller não conseguia anunciar a maior parte do catálogo.

## O que mudou

- `ProductCatalogPicker` busca com `GET /products?search=` (arma, skin, collection, `marketHashName`).
- Primeira página tem 20 itens; **Carregar mais** pede a página seguinte.
- A listagem de listings do seller não baixa mais o catálogo no mount.
- Preview da skin selecionada permanece.

Não altera schema, createListing, reserva nem pagamento. Não carrega 22k rows no browser.

## Verificação

Vitest: `ProductCatalogPicker` + `SellerListings`.

Browser local: listagem inicial **20 de 21965**, Carregar mais → **40 de 21965**, busca `Redline` → AWP e AK-47.

[Novo listing mostra 20 de 21965 no catálogo](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-catalog-search-initial.webp)
[Carregar mais aumenta para 40 de 21965](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-catalog-search-load-more.webp)
[Busca Redline encontra AWP e AK-47](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-catalog-search-redline.webp)
[Preview após selecionar AK-47 Redline](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-catalog-search-preview.webp)

[seller-catalog-search-picker.mp4](https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-catalog-search-picker.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

