### PR TITLE
fix(checkout): PayPal sandbox login help and invalid_client mapping

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -18,6 +18,17 @@ Secrets (`PAYPAL_*`, `RESEND_API_KEY`, `EMAIL_FROM`, `JWT_*`, `CS2SH_API_KEY`) s
 
 Rollback: Render Dashboard → previous deploy. Schema rollback is a new Prisma migration, not `migrate down`.
 
+## Sandbox checkout (PayPal login)
+
+Production `PAYPAL_MODE` is `sandbox` (`render.yaml`). Checkout uses **PayPal Sandbox**, not live PayPal. Two credential layers must both be sandbox:
+
+1. **REST app (merchant)** — `PAYPAL_CLIENT_ID` and `PAYPAL_SECRET` on `neon-arsenal-api` must belong to a **Sandbox** app from [developer.paypal.com](https://developer.paypal.com/dashboard/applications/sandbox). A live Client ID fails sandbox OAuth with HTTP 401 `invalid_client` / `Client Authentication failed`. Checkout then never opens a valid PayPal session. After rotating secrets in the Render Dashboard, restart the API.
+2. **Buyer login** — on `sandbox.paypal.com`, sign in with a **Sandbox Personal** (Buyer) account from Developer Dashboard → Sandbox → Accounts. A real PayPal email/password, Google, or Apple login does **not** work in sandbox.
+
+Do not set `PAYPAL_MODE=production` to “make login work.” That is a live-money cutover, not a login fix. Never paste Client Secret into git, issues, or logs.
+
+If checkout creates a local order but PayPal does not open, check API logs for `PAYPAL_CLIENT_AUTH_FAILED` (HTTP 503, no PayPal JSON in the body). The storefront maps that message to Portuguese copy when the buyer retries payment.
+
 ## Health vs ready
 
 The API exposes two GET routes. Render has **one** probe (`healthCheckPath`).

--- a/server/src/shared/utils/__tests__/paypal.orders-create.test.ts
+++ b/server/src/shared/utils/__tests__/paypal.orders-create.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildPayPalOrdersCreateBody, PAYPAL_HTTP_POLICY } from "../paypal.js";
+import {
+  buildPayPalOrdersCreateBody,
+  mapPayPalHttpError,
+  PAYPAL_CLIENT_AUTH_FAILED,
+  PAYPAL_HTTP_POLICY,
+} from "../paypal.js";
 
 describe("PayPal OrdersCreate body", () => {
   it("includes application_context URLs when the client supplies both", () => {
@@ -50,5 +55,22 @@ describe("PayPal OrdersCreate body", () => {
 
   it("still does not retry OrdersCreate", () => {
     expect(PAYPAL_HTTP_POLICY.orders_create.retry).toBe(false);
+  });
+});
+
+describe("mapPayPalHttpError", () => {
+  it("maps invalid_client 401 to a stable 503 without echoing PayPal JSON", () => {
+    const err = Object.assign(
+      new Error('{"error":"invalid_client","error_description":"Client Authentication failed"}'),
+      { statusCode: 401 }
+    );
+    const mapped = mapPayPalHttpError(err);
+    expect(mapped).toMatchObject({ statusCode: 503, message: PAYPAL_CLIENT_AUTH_FAILED });
+    expect(mapped.message).not.toMatch(/invalid_client/);
+  });
+
+  it("leaves unrelated errors unchanged", () => {
+    const err = new Error("PayPal OrdersCreate timed out");
+    expect(mapPayPalHttpError(err)).toBe(err);
   });
 });

--- a/server/src/shared/utils/paypal.ts
+++ b/server/src/shared/utils/paypal.ts
@@ -98,8 +98,12 @@ export async function createPayPalOrder(
   request.requestBody(buildPayPalOrdersCreateBody(amount, currency, orderId, urls));
   return withPaypalOperation("orders_create", async () => {
     // OrdersCreate is not retried: a retry can create a second PayPal order.
-    const response = await withTimeout(client.execute(request), "PayPal OrdersCreate");
-    return response.result;
+    try {
+      const response = await withTimeout(client.execute(request), "PayPal OrdersCreate");
+      return response.result;
+    } catch (err) {
+      throw mapPayPalHttpError(err);
+    }
   });
 }
 
@@ -193,6 +197,29 @@ export async function getPayPalAccessToken(): Promise<string> {
       throw err;
     }
   });
+}
+
+export const PAYPAL_CLIENT_AUTH_FAILED = "PayPal client authentication failed";
+
+export function isPayPalClientAuthError(err: unknown): boolean {
+  const status =
+    err && typeof err === "object" && "statusCode" in err
+      ? (err as { statusCode?: unknown }).statusCode
+      : undefined;
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  return (
+    status === 401 ||
+    /invalid_client|Client Authentication failed/i.test(message)
+  );
+}
+
+/** Stable AppError for REST credential failures. Does not echo PayPal JSON. */
+export function mapPayPalHttpError(err: unknown): Error {
+  if (err instanceof AppError) return err;
+  if (isPayPalClientAuthError(err)) {
+    return new AppError(503, PAYPAL_CLIENT_AUTH_FAILED);
+  }
+  return err instanceof Error ? err : new Error(String(err));
 }
 
 export function getPayPalOrderIdFromResult(result: { id?: string }): string | undefined {

--- a/src/lib/__tests__/userFacingApiError.test.ts
+++ b/src/lib/__tests__/userFacingApiError.test.ts
@@ -11,6 +11,7 @@ import {
   USER_FACING_LISTING_CONFLICT,
   USER_FACING_NETWORK,
   USER_FACING_NOT_FOUND,
+  USER_FACING_PAYPAL_CLIENT_AUTH,
   USER_FACING_RATE_LIMIT,
   USER_FACING_SERVER,
   USER_FACING_UNAUTHORIZED,
@@ -110,6 +111,13 @@ describe("userFacingApiError", () => {
         }),
       ),
     ).toBe(USER_FACING_CS2SH_KEY_MISSING);
+    expect(
+      userFacingApiError(
+        new ApiClientError("PayPal client authentication failed", {
+          status: 503,
+        }),
+      ),
+    ).toBe(USER_FACING_PAYPAL_CLIENT_AUTH);
     expect(
       userFacingApiError(
         new ApiClientError("Order status changed concurrently", {

--- a/src/lib/orderPaymentView.ts
+++ b/src/lib/orderPaymentView.ts
@@ -11,6 +11,9 @@ export const ORDER_POLL_INTERVAL_MS = 4000;
 export const PRE_ORDER_HOLD_COPY =
   "O item só é reservado quando você inicia o pagamento.";
 
+export const PAYPAL_SANDBOX_LOGIN_COPY =
+  "Este ambiente usa PayPal sandbox (sandbox.paypal.com). Entre com uma conta Personal de teste em developer.paypal.com → Sandbox → Accounts. E-mail e senha da sua conta PayPal real, e login com Google/Apple, não funcionam lá.";
+
 export const EXPIRED_HOLD_COPY =
   "A reserva expirou. O item pode ter voltado ao Market.";
 

--- a/src/lib/userFacingApiError.ts
+++ b/src/lib/userFacingApiError.ts
@@ -48,6 +48,9 @@ export const USER_FACING_VERIFICATION_CODE =
 export const USER_FACING_GENERIC =
   "Algo deu errado. Tente de novo em instantes.";
 
+export const USER_FACING_PAYPAL_CLIENT_AUTH =
+  "Não foi possível autenticar no PayPal sandbox. Confira PAYPAL_CLIENT_ID e PAYPAL_SECRET no servidor — não use o login da sua conta PayPal pessoal.";
+
 export const USER_FACING_ORDER_CANCELLED =
   "Este pedido foi cancelado. Não é possível continuar o pagamento.";
 
@@ -207,6 +210,8 @@ export function userFacingApiError(error: unknown): string {
     copy = USER_FACING_CS2SH_IMPORT_RUNNING;
   } else if (/chave da API cs2\.sh não está configurada/i.test(message)) {
     copy = USER_FACING_CS2SH_KEY_MISSING;
+  } else if (/PayPal client authentication failed/i.test(message)) {
+    copy = USER_FACING_PAYPAL_CLIENT_AUTH;
   } else if (isUnauthorizedApiError(error)) {
     copy = USER_FACING_UNAUTHORIZED;
   } else if (isForbiddenApiError(error)) {

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -19,6 +19,7 @@ import {
 import {
   earliestReservationExpiresAt,
   isReservationExpired,
+  PAYPAL_SANDBOX_LOGIN_COPY,
 } from "@/lib/orderPaymentView";
 import { paypalCheckoutUrls } from "@/lib/paypalCheckoutUrls";
 import { redirectToExternal } from "@/lib/redirect";
@@ -235,6 +236,9 @@ export default function Checkout() {
             Você será redirecionado ao PayPal. O pagamento só é confirmado
             depois que o provedor retornar o resultado — esta página não marca o
             pedido como pago.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {PAYPAL_SANDBOX_LOGIN_COPY}
           </p>
           {error ? (
             <p className="text-sm text-destructive" role="alert">

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   EXPIRED_HOLD_COPY,
+  PAYPAL_SANDBOX_LOGIN_COPY,
   VERIFYING_RESERVATION_COPY,
   canRetryPayment,
   earliestReservationExpiresAt,
@@ -299,6 +300,11 @@ export default function OrderStatusPage() {
       </section>
 
       <div className="mt-6 space-y-3">
+        {showPayButton ? (
+          <p className="text-sm text-muted-foreground">
+            {PAYPAL_SANDBOX_LOGIN_COPY}
+          </p>
+        ) : null}
         {retryError ? (
           <p className="text-sm text-destructive" role="alert">
             {retryError}

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -4,7 +4,10 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Checkout from "../Checkout";
 import type { Listing, Order, User } from "@/types/api";
-import { PRE_ORDER_HOLD_COPY } from "@/lib/orderPaymentView";
+import {
+  PRE_ORDER_HOLD_COPY,
+  PAYPAL_SANDBOX_LOGIN_COPY,
+} from "@/lib/orderPaymentView";
 import { USER_FACING_NETWORK } from "@/lib/userFacingApiError";
 
 const createOrder = vi.fn();
@@ -234,6 +237,7 @@ describe("Checkout", () => {
     expect(screen.getByText("$105.00")).toBeTruthy();
     expect(screen.getByText(/Pagar com PayPal — \$105\.00/)).toBeTruthy();
     expect(screen.getByText(PRE_ORDER_HOLD_COPY)).toBeTruthy();
+    expect(screen.getByText(PAYPAL_SANDBOX_LOGIN_COPY)).toBeTruthy();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(screen.queryByText(/Pedido Confirmado/i)).toBeNull();
     expect(screen.queryByText(/processado com sucesso/i)).toBeNull();

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -6,6 +6,7 @@ import OrderStatusPage from "../OrderStatus";
 import type { Order } from "@/types/api";
 import {
   EXPIRED_HOLD_COPY,
+  PAYPAL_SANDBOX_LOGIN_COPY,
   VERIFYING_RESERVATION_COPY,
 } from "@/lib/orderPaymentView";
 import {
@@ -182,6 +183,7 @@ describe("OrderStatusPage", () => {
     expect(
       screen.getByRole("button", { name: "Pagar novamente" }),
     ).toBeTruthy();
+    expect(screen.getByText(PAYPAL_SANDBOX_LOGIN_COPY)).toBeTruthy();
     expect(screen.getByRole("link", { name: "Ir ao Market" })).toHaveAttribute(
       "href",
       "/products",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Checkout cannot complete a PayPal login because this environment is **PayPal Sandbox**, not live PayPal. Production API logs showed REST OAuth `invalid_client` / `Client Authentication failed` (HTTP 401) on `OrdersCreate`. Separately, signing in on `sandbox.paypal.com` with a real PayPal email, Google, or Apple does not work.

## What changed

- Map PayPal REST `invalid_client` / 401 on `OrdersCreate` to a stable HTTP 503 (`PayPal client authentication failed`) without echoing provider JSON.
- Storefront: Portuguese copy on Checkout and Order Status explaining sandbox Personal (buyer) accounts.
- Map the 503 message to operator-facing Portuguese copy (check `PAYPAL_CLIENT_ID` / `PAYPAL_SECRET` on the API).
- Runbook section **Sandbox checkout (PayPal login)** — merchant REST app vs buyer sandbox account.

## What did not change

- `PAYPAL_MODE` stays `sandbox`.
- Capture, webhook, reservation, and ledger invariants are unchanged.
- No secrets committed.

## Operator steps (not in this PR)

1. In [PayPal Developer](https://developer.paypal.com/dashboard/applications/sandbox), create/use a **Sandbox** REST app.
2. Set `PAYPAL_CLIENT_ID` and `PAYPAL_SECRET` on Render service `neon-arsenal-api`, then restart.
3. Pay with a **Sandbox Personal** buyer from Developer Dashboard → Sandbox → Accounts.

## Verification

- `npx vitest run src/pages/__tests__/Checkout.test.tsx src/pages/__tests__/OrderStatus.test.tsx src/lib/__tests__/userFacingApiError.test.ts` → 37 passed
- `npx vitest run src/shared/utils/__tests__/paypal.orders-create.test.ts` (from `server/`) → 6 passed
- Commit hook: client + server `tsc --noEmit` passed

Live PayPal sandbox login was not exercised here: that needs Dashboard REST secrets and a Personal buyer account.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

