### PR TITLE
#50 — P1 — Criar suíte de testes de concorrência do checkout

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,6 +106,7 @@ Integration tests are not skipped when PostgreSQL is down. A missing or unreacha
 | `order.idempotency.integration.test.ts` | Replay, canonical listing order, conflicting key reuse, customer isolation, service-level rollback, concurrent same-key retries, reservation race. |
 | `payment.link.idempotency.integration.test.ts` | Payment-link replay, concurrent `POST /payments` (one `OrdersCreate`), claim rollback after PayPal failure, `PaymentLink(orderId)` uniqueness. |
 | `reservation.lifecycle.integration.test.ts` | Reservation timestamps, concurrent buyers, expiration vs payment, no duplicate seller transactions. |
+| `checkout.concurrency.integration.test.ts` | Eight concurrent `ordersService.create` for one listing (one winner); concurrent duplicate `PAYMENT.CAPTURE.COMPLETED` webhooks; concurrent `confirmPayment` (one PAID claim, one `SellerTransaction`). |
 | `paypal.webhook.integration.test.ts` | Duplicate/out-of-order events, expired capture, stale-order capture, payment rollback. PayPal remains isolated. |
 | `observability.integration.test.ts` | Order/reservation/payment/webhook spans and counters against real PostgreSQL. No secrets or high-cardinality labels. |
 | `seller.ledger.integration.test.ts` | Sequential/concurrent confirm; Decimal net identity; projection matches PAID SUM. |

--- a/server/src/__tests__/checkout.concurrency.integration.test.ts
+++ b/server/src/__tests__/checkout.concurrency.integration.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { DomainInvariant } from "../shared/domain/invariants.js";
+import { prisma } from "../shared/database/index.js";
+import { ordersService } from "../modules/orders/orders.service.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import { createCheckoutGraph, createOrder, createUser, orderKey } from "./helpers/index.js";
+
+const CONCURRENT_BUYERS = 8;
+const CONCURRENT_WEBHOOKS = 8;
+const CONCURRENT_CONFIRMS = 8;
+
+function captureEvent(eventId: string, localOrderId: string, paypalOrderId = `PAYPAL-${localOrderId}`) {
+  return {
+    id: eventId,
+    event_type: "PAYMENT.CAPTURE.COMPLETED",
+    resource: {
+      id: `CAPTURE-${eventId}`,
+      purchase_units: [{ reference_id: localOrderId }],
+      supplementary_data: { related_ids: { order_id: paypalOrderId } },
+    },
+  };
+}
+
+describe("checkout concurrency (postgres)", () => {
+  it(`${DomainInvariant.LISTING_EXCLUSIVE_RESERVE}: eight concurrent creates reserve a unique listing once`, async () => {
+    const fixture = await createCheckoutGraph();
+    const listingId = fixture.listings[0].id;
+    const extraBuyers = await Promise.all(
+      Array.from({ length: CONCURRENT_BUYERS - 1 }, (_, index) =>
+        createUser({ name: `Buyer ${index + 2}` })
+      )
+    );
+    const buyers = [fixture.customer, ...extraBuyers];
+
+    const results = await Promise.allSettled(
+      buyers.map((buyer, index) => createOrder(buyer.id, [listingId], orderKey(`n-buyer-${index}`)))
+    );
+
+    const fulfilled = results.filter(
+      (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof ordersService.create>>> =>
+        result.status === "fulfilled"
+    );
+    const rejected = results.filter((result) => result.status === "rejected");
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(CONCURRENT_BUYERS - 1);
+    for (const result of rejected) {
+      expect(result).toMatchObject({
+        status: "rejected",
+        reason: expect.objectContaining({
+          statusCode: 400,
+          message: expect.stringContaining("not available"),
+        }),
+      });
+    }
+
+    const winnerId = fulfilled[0].value.id;
+    const listing = await prisma.listing.findUnique({ where: { id: listingId } });
+    const orders = await prisma.order.findMany({
+      where: { items: { some: { listingId } } },
+    });
+    const orderItems = await prisma.orderItem.findMany({ where: { listingId } });
+    const reservedListings = await prisma.listing.findMany({
+      where: { id: listingId, status: "RESERVED" },
+    });
+    const txns = await prisma.sellerTransaction.findMany();
+
+    expect(listing?.status).toBe("RESERVED");
+    expect(listing?.reservedByOrderId).toBe(winnerId);
+    expect(reservedListings).toHaveLength(1);
+    expect(orders).toHaveLength(1);
+    expect(orders[0]?.id).toBe(winnerId);
+    expect(orderItems).toHaveLength(1);
+    expect(orderItems[0]?.orderId).toBe(winnerId);
+    expect(txns).toHaveLength(0);
+  });
+
+  it(`${DomainInvariant.PAYMENT_WEBHOOK_IDEMPOTENT}: concurrent duplicate capture webhooks sell once`, async () => {
+    const fixture = await createCheckoutGraph();
+    const listingId = fixture.listings[0].id;
+    const order = await createOrder(fixture.customer.id, [listingId], orderKey("webhook-winner"));
+    const payload = captureEvent(`WH-${listingId}-checkout-concurrent`, order.id);
+
+    const results = await Promise.allSettled(
+      Array.from({ length: CONCURRENT_WEBHOOKS }, () => paymentsService.handleWebhook(payload))
+    );
+
+    expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+
+    const listing = await prisma.listing.findUnique({ where: { id: listingId } });
+    const paid = await prisma.order.findUnique({ where: { id: order.id } });
+    const txns = await prisma.sellerTransaction.findMany({ where: { orderId: order.id } });
+    const events = await prisma.paymentWebhookEvent.findMany({
+      where: { externalEventId: payload.id },
+    });
+    const seller = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+
+    expect(listing?.status).toBe("SOLD");
+    expect(paid?.paymentStatus).toBe("PAID");
+    expect(paid?.status).toBe("CONFIRMED");
+    expect(txns).toHaveLength(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.status).toBe("PROCESSED");
+    expect(seller?.balance.toString()).toBe("90");
+  });
+
+  it(`${DomainInvariant.SELLER_TXN_UNIQUE}: concurrent confirmPayment claims PAID once`, async () => {
+    const fixture = await createCheckoutGraph();
+    const listingId = fixture.listings[0].id;
+    const created = await createOrder(
+      fixture.customer.id,
+      [listingId],
+      orderKey("confirm-concurrent")
+    );
+
+    const unpaid = await prisma.order.findUnique({ where: { id: created.id } });
+    expect(unpaid?.paymentStatus).toBe("PENDING");
+    expect(unpaid?.status).toBe("PENDING");
+
+    const results = await Promise.allSettled(
+      Array.from({ length: CONCURRENT_CONFIRMS }, () => paymentsService.confirmPayment(created.id))
+    );
+
+    expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+
+    const listing = await prisma.listing.findUnique({ where: { id: listingId } });
+    const order = await prisma.order.findUnique({ where: { id: created.id } });
+    const txns = await prisma.sellerTransaction.findMany({ where: { orderId: created.id } });
+    const seller = await prisma.seller.findUnique({ where: { id: fixture.seller.id } });
+
+    expect(listing?.status).toBe("SOLD");
+    expect(order?.paymentStatus).toBe("PAID");
+    expect(order?.status).toBe("CONFIRMED");
+    expect(txns).toHaveLength(1);
+    expect(seller?.balance.toString()).toBe("90");
+  });
+});

--- a/server/src/__tests__/checkout.concurrency.integration.test.ts
+++ b/server/src/__tests__/checkout.concurrency.integration.test.ts
@@ -56,13 +56,12 @@ describe("checkout concurrency (postgres)", () => {
 
     const winnerId = fulfilled[0].value.id;
     const listing = await prisma.listing.findUnique({ where: { id: listingId } });
-    const orders = await prisma.order.findMany({
-      where: { items: { some: { listingId } } },
-    });
+    const orders = await prisma.order.findMany();
     const orderItems = await prisma.orderItem.findMany({ where: { listingId } });
     const reservedListings = await prisma.listing.findMany({
       where: { id: listingId, status: "RESERVED" },
     });
+    const keys = await prisma.orderIdempotencyKey.findMany();
     const txns = await prisma.sellerTransaction.findMany();
 
     expect(listing?.status).toBe("RESERVED");
@@ -72,6 +71,9 @@ describe("checkout concurrency (postgres)", () => {
     expect(orders[0]?.id).toBe(winnerId);
     expect(orderItems).toHaveLength(1);
     expect(orderItems[0]?.orderId).toBe(winnerId);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]?.orderId).toBe(winnerId);
+    expect(keys[0]?.status).toBe("COMPLETED");
     expect(txns).toHaveLength(0);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

#50 — P1 — Criar suíte de testes de concorrência do checkout

## What this is

PostgreSQL integration suite for unique-listing checkout races. No production payment or reservation semantics change.

## Coverage

`server/src/__tests__/checkout.concurrency.integration.test.ts`

- Eight concurrent `ordersService.create` for the same listing → exactly one winner, listing `RESERVED` once, `reservedByOrderId` matches, one `OrderItem`, losers HTTP 400 and no leftover `Order` / `OrderIdempotencyKey`.
- Eight concurrent identical `PAYMENT.CAPTURE.COMPLETED` webhooks → one `SOLD`, one `PAID`, one `SellerTransaction`, one `PaymentWebhookEvent`.
- Eight concurrent `confirmPayment` → one PAID claim, one ledger row.

Existing two-buyer / webhook tests remain. This file is the named N-way suite. PayPal HTTP stays unused on `handleWebhook` (same isolation as `paypal.webhook.integration.test.ts`).

## Verification

- `cd server && npm run test:unit` → 45 files, 275 passed
- `cd server && npm run test:integration` → 18 files, 102 passed
- Parent re-run: `npx vitest run --config vitest.integration.config.ts src/__tests__/checkout.concurrency.integration.test.ts` → 3 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d735f78-e980-49bb-a3d6-2783a7f89c8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

