### PR TITLE
#98 — [UX] Exibir saldo, comissão e transações no dashboard do vendedor

### DIFF
--- a/docs/frontend-sprint.md
+++ b/docs/frontend-sprint.md
@@ -36,7 +36,7 @@ Brand/visual/seller locks in this file still apply. The **executable queue is Gi
 | Storefront | `/`, `/products`, `/listing/:id` | Home: 8 ACTIVE listings. Market: exterior / StatTrak / price / client-side sort / pagination. Detail: float, pattern, trade lock, price history, related, cart. |
 | Purchase | `/cart`, `/checkout` | Device-local cart (`localStorage` schema v1 in `src/lib/cartStorage.ts`). Not multi-device and not account-bound; logout keeps the guest cart. Checkout only `CUSTOMER`. `createOrder` + PayPal. 5% display total stays unless a later issue says otherwise. |
 | Auth | `/login`, `/register` | Login. Register 2-step email code. `CUSTOMER` or `SELLER` + `storeName`. |
-| Seller | `/seller`, `/seller/products`, `/seller/listings`, `/seller/orders` | Stats, listing CRUD on listings, orders. Products page must stop being a second listing CRUD. |
+| Seller | `/seller`, `/seller/products`, `/seller/listings`, `/seller/orders`, `/seller/transactions` | Stats from `/commissions/balance` + `GET /sellers/me` commission rate, listing CRUD on listings, orders, ledger transactions. Products page must stop being a second listing CRUD. |
 | Admin | `/admin`, `/admin/sellers`, `/admin/orders`, `/admin/users` | Stats, approve seller, orders, users, commission display. |
 | Shell | `MainLayout`, `DashboardLayout`, `Header` | Nav, auth, cart. Dashboard needs mobile nav (today sidebar is `lg` only). |
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import AdminDashboard from "./pages/AdminDashboard";
 import SellerProducts from "./pages/seller/SellerProducts";
 import SellerListings from "./pages/seller/SellerListings";
 import SellerOrders from "./pages/seller/SellerOrders";
+import SellerTransactions from "./pages/seller/SellerTransactions";
 import AdminSellers from "./pages/admin/AdminSellers";
 import AdminOrders from "./pages/admin/AdminOrders";
 import AdminUsers from "./pages/admin/AdminUsers";
@@ -126,6 +127,14 @@ const App = () => (
                     element={
                       <ProtectedRoute allowedRoles={["SELLER"]}>
                         <SellerOrders />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/seller/transactions"
+                    element={
+                      <ProtectedRoute allowedRoles={["SELLER"]}>
+                        <SellerTransactions />
                       </ProtectedRoute>
                     }
                   />

--- a/src/api/__tests__/commissions.test.ts
+++ b/src/api/__tests__/commissions.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getCommissionBalance,
+  listCommissionTransactions,
+} from "../commissions";
+
+const get = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    get: (...args: unknown[]) => get(...args),
+  },
+}));
+
+describe("commissions API client", () => {
+  beforeEach(() => {
+    get.mockReset();
+  });
+
+  it("GETs /commissions/balance", async () => {
+    get.mockResolvedValue({ balance: "135.00" });
+
+    const result = await getCommissionBalance();
+
+    expect(get).toHaveBeenCalledWith("/commissions/balance");
+    expect(result).toEqual({ balance: "135.00" });
+  });
+
+  it("GETs /commissions/transactions", async () => {
+    const rows = [
+      {
+        id: "tx-1",
+        sellerId: "seller-1",
+        orderId: "ord-1",
+        grossAmount: "100.00",
+        commissionAmount: "10.00",
+        netAmount: "90.00",
+        status: "PAID",
+        createdAt: "2026-09-01T12:00:00.000Z",
+      },
+    ];
+    get.mockResolvedValue(rows);
+
+    const result = await listCommissionTransactions();
+
+    expect(get).toHaveBeenCalledWith("/commissions/transactions");
+    expect(result).toEqual(rows);
+  });
+});

--- a/src/api/commissions.ts
+++ b/src/api/commissions.ts
@@ -1,0 +1,10 @@
+import { api } from "./client";
+import type { CommissionBalance, SellerTransaction } from "@/types/api";
+
+export function getCommissionBalance(): Promise<CommissionBalance> {
+  return api.get<CommissionBalance>("/commissions/balance");
+}
+
+export function listCommissionTransactions(): Promise<SellerTransaction[]> {
+  return api.get<SellerTransaction[]>("/commissions/transactions");
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,3 +6,4 @@ export * from "./price-history";
 export * from "./orders";
 export * from "./payments";
 export * from "./sellers";
+export * from "./commissions";

--- a/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/src/components/__tests__/ProtectedRoute.test.tsx
@@ -19,6 +19,7 @@ const SELLER_ROUTES = [
   "/seller/listings",
   "/seller/products",
   "/seller/orders",
+  "/seller/transactions",
 ] as const;
 
 function userFor(role: Role): User {
@@ -50,6 +51,7 @@ function renderSellerGate(path: string) {
           <Route path="/seller/listings" element={null} />
           <Route path="/seller/products" element={null} />
           <Route path="/seller/orders" element={null} />
+          <Route path="/seller/transactions" element={null} />
         </Route>
         <Route path="/admin" element={<div>admin-home</div>} />
         <Route path="/login" element={<div>login</div>} />

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import {
   BarChart3,
   Menu,
   Package,
+  Receipt,
   ShoppingBag,
   Users,
   Shield,
@@ -22,6 +23,7 @@ import {
 
 const sellerItems = [
   { icon: BarChart3, label: "Visão Geral", href: "/seller" },
+  { icon: Receipt, label: "Transações", href: "/seller/transactions" },
   { icon: Tag, label: "Listings", href: "/seller/listings" },
   { icon: Package, label: "Produtos", href: "/seller/products" },
   { icon: ShoppingBag, label: "Pedidos", href: "/seller/orders" },

--- a/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -24,6 +24,22 @@ function renderAdminNav(path: string) {
   );
 }
 
+function renderSellerNav(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<DashboardLayout />}>
+          <Route path="/seller" element={<div>overview</div>} />
+          <Route
+            path="/seller/transactions"
+            element={<div>transactions-page</div>}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
 describe("DashboardLayout admin nav", () => {
   it("exposes Catálogo next to Visão Geral", () => {
     renderAdminNav("/admin");
@@ -42,5 +58,26 @@ describe("DashboardLayout admin nav", () => {
       links.some((link) => link.getAttribute("aria-current") === "page"),
     ).toBe(true);
     expect(screen.getByText("catalog-page")).toBeTruthy();
+  });
+});
+
+describe("DashboardLayout seller nav", () => {
+  it("exposes Transações next to Visão Geral", () => {
+    renderSellerNav("/seller");
+    const links = screen.getAllByRole("link", { name: "Transações" });
+    expect(links.length).toBeGreaterThan(0);
+    expect(links[0]).toHaveAttribute("href", "/seller/transactions");
+    expect(
+      screen.getAllByRole("link", { name: "Visão Geral" })[0],
+    ).toHaveAttribute("href", "/seller");
+  });
+
+  it("marks Transações current on /seller/transactions", () => {
+    renderSellerNav("/seller/transactions");
+    const links = screen.getAllByRole("link", { name: "Transações" });
+    expect(
+      links.some((link) => link.getAttribute("aria-current") === "page"),
+    ).toBe(true);
+    expect(screen.getByText("transactions-page")).toBeTruthy();
   });
 });

--- a/src/lib/__tests__/formatLedgerAmount.test.ts
+++ b/src/lib/__tests__/formatLedgerAmount.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCommissionRate,
+  formatLedgerAmount,
+  scaleDecimalStringBy100,
+} from "../formatLedgerAmount";
+
+describe("formatLedgerAmount", () => {
+  it("prefixes the API decimal string without Number() rounding", () => {
+    expect(formatLedgerAmount("135.00")).toBe("$135.00");
+    expect(formatLedgerAmount("0.00")).toBe("$0.00");
+    expect(formatLedgerAmount("0.30")).toBe("$0.30");
+  });
+
+  it("keeps extra fractional digits from the ledger", () => {
+    expect(formatLedgerAmount("90.015")).toBe("$90.015");
+  });
+
+  it("renders a missing value as an em dash", () => {
+    expect(formatLedgerAmount(undefined)).toBe("—");
+    expect(formatLedgerAmount("")).toBe("—");
+  });
+});
+
+describe("scaleDecimalStringBy100", () => {
+  it("converts a 0.1 commission fraction to 10 without JS float multiply", () => {
+    expect(scaleDecimalStringBy100("0.1")).toBe("10");
+    expect(scaleDecimalStringBy100("0.10")).toBe("10");
+    expect(scaleDecimalStringBy100("0.15")).toBe("15");
+    expect(scaleDecimalStringBy100("0.105")).toBe("10.5");
+  });
+});
+
+describe("formatCommissionRate", () => {
+  it("displays GET /sellers/me commissionRate as a percent", () => {
+    expect(formatCommissionRate("0.1")).toBe("10%");
+    expect(formatCommissionRate("0.10")).toBe("10%");
+  });
+
+  it("does not invent a default rate when the field is missing", () => {
+    expect(formatCommissionRate(undefined)).toBe("—");
+    expect(formatCommissionRate("")).toBe("—");
+  });
+});

--- a/src/lib/__tests__/isSellerPath.test.ts
+++ b/src/lib/__tests__/isSellerPath.test.ts
@@ -7,6 +7,7 @@ describe("isSellerPath", () => {
     expect(isSellerPath("/seller/listings")).toBe(true);
     expect(isSellerPath("/seller/products")).toBe(true);
     expect(isSellerPath("/seller/orders")).toBe(true);
+    expect(isSellerPath("/seller/transactions")).toBe(true);
   });
 
   it("does not treat admin or storefront paths as seller", () => {

--- a/src/lib/__tests__/postLoginPath.test.ts
+++ b/src/lib/__tests__/postLoginPath.test.ts
@@ -61,6 +61,7 @@ describe("postLoginPath", () => {
     expect(postLoginPath("ADMIN", "/seller/listings").path).toBe("/admin");
     expect(postLoginPath("ADMIN", "/seller/products").path).toBe("/admin");
     expect(postLoginPath("ADMIN", "/seller/orders").path).toBe("/admin");
+    expect(postLoginPath("ADMIN", "/seller/transactions").path).toBe("/admin");
   });
 
   it("sends seller without from to /seller", () => {

--- a/src/lib/formatLedgerAmount.ts
+++ b/src/lib/formatLedgerAmount.ts
@@ -1,0 +1,65 @@
+/**
+ * Display helpers for seller-ledger decimals.
+ * Arithmetic must not use JavaScript `number` (INV-SELLER-COMMISSION-DECIMAL).
+ * The API already computed the figure; we only format the wire string.
+ */
+
+function asTrimmedString(
+  value: string | number | null | undefined,
+): string | null {
+  if (value == null) return null;
+  const raw = typeof value === "number" ? String(value) : value.trim();
+  return raw === "" ? null : raw;
+}
+
+function isDecimalLiteral(value: string): boolean {
+  return /^-?(?:\d+\.?\d*|\.\d+)$/.test(value);
+}
+
+function stripLeadingZeros(digits: string): string {
+  const stripped = digits.replace(/^0+/, "");
+  return stripped === "" ? "0" : stripped;
+}
+
+function stripTrailingZeros(digits: string): string {
+  return digits.replace(/0+$/, "");
+}
+
+/** Move the decimal point two places right (× 100) with string ops only. */
+export function scaleDecimalStringBy100(raw: string): string {
+  const trimmed = raw.trim();
+  const negative = trimmed.startsWith("-");
+  const unsigned = negative ? trimmed.slice(1) : trimmed;
+  if (unsigned === "" || unsigned === ".") return "0";
+
+  const [intRaw, fracRaw = ""] = unsigned.split(".");
+  const intPart = intRaw === "" ? "0" : intRaw;
+  const shiftedInt = stripLeadingZeros(
+    intPart + fracRaw.slice(0, 2).padEnd(2, "0"),
+  );
+  const shiftedFrac = stripTrailingZeros(fracRaw.slice(2));
+  const result =
+    shiftedFrac === "" ? shiftedInt : `${shiftedInt}.${shiftedFrac}`;
+  return negative && result !== "0" ? `-${result}` : result;
+}
+
+/** Prefix the API decimal with `$`. Does not round, sum, or coerce through `Number`. */
+export function formatLedgerAmount(
+  value: string | number | null | undefined,
+): string {
+  const raw = asTrimmedString(value);
+  if (raw == null) return "—";
+  return `$${raw}`;
+}
+
+/**
+ * Seller.commissionRate is a fraction (`"0.1"` = 10%).
+ * Missing/invalid values render as em dash — do not invent a default rate.
+ */
+export function formatCommissionRate(
+  rate: string | number | null | undefined,
+): string {
+  const raw = asTrimmedString(rate);
+  if (raw == null || !isDecimalLiteral(raw)) return "—";
+  return `${scaleDecimalStringBy100(raw)}%`;
+}

--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -1,27 +1,21 @@
 import { Link, Navigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Package, ShoppingBag, DollarSign } from "lucide-react";
+import { Package, Percent, Wallet } from "lucide-react";
 import { listOrders } from "@/api/orders";
 import { getSellerListings } from "@/api/listings";
+import { getCommissionBalance } from "@/api/commissions";
+import { getSellerMe } from "@/api/sellers";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  formatCommissionRate,
+  formatLedgerAmount,
+} from "@/lib/formatLedgerAmount";
 import { orderStatusLabel } from "@/lib/userFacingApiError";
 import type { Order } from "@/types/api";
-
-function orderTotal(order: Order): number {
-  if (order.totalAmount != null && Number(order.totalAmount) > 0) {
-    return Number(order.totalAmount);
-  }
-  return (
-    order.items?.reduce(
-      (sum, item) => sum + Number(item.priceSnapshot || 0),
-      0,
-    ) ?? 0
-  );
-}
 
 function orderSummary(order: Order): string {
   const names =
@@ -40,23 +34,46 @@ function orderSummary(order: Order): string {
 export default function SellerDashboard() {
   const { user } = useAuth();
   const isAdmin = user?.role === "ADMIN";
+  const sellerQueriesEnabled = !isAdmin;
 
   const listingsQuery = useQuery({
     queryKey: ["sellerListings"],
     queryFn: () => getSellerListings(),
-    enabled: !isAdmin,
+    enabled: sellerQueriesEnabled,
+  });
+  const balanceQuery = useQuery({
+    queryKey: ["commissionBalance"],
+    queryFn: () => getCommissionBalance(),
+    enabled: sellerQueriesEnabled,
+  });
+  const sellerMeQuery = useQuery({
+    queryKey: ["sellerMe"],
+    queryFn: () => getSellerMe(),
+    enabled: sellerQueriesEnabled,
   });
   const ordersQuery = useQuery({
     queryKey: ["orders"],
     queryFn: () => listOrders(),
-    enabled: !isAdmin,
+    enabled: sellerQueriesEnabled,
   });
 
   const listings = listingsQuery.data?.items ?? [];
   const orders = ordersQuery.data ?? [];
-  const isLoading = listingsQuery.isLoading || ordersQuery.isLoading;
-  const isError = listingsQuery.isError || ordersQuery.isError;
-  const error = listingsQuery.error ?? ordersQuery.error;
+  const isLoading =
+    listingsQuery.isLoading ||
+    balanceQuery.isLoading ||
+    sellerMeQuery.isLoading ||
+    ordersQuery.isLoading;
+  const isError =
+    listingsQuery.isError ||
+    balanceQuery.isError ||
+    sellerMeQuery.isError ||
+    ordersQuery.isError;
+  const error =
+    listingsQuery.error ??
+    balanceQuery.error ??
+    sellerMeQuery.error ??
+    ordersQuery.error;
 
   if (isAdmin) {
     return <Navigate to="/admin" replace />;
@@ -65,20 +82,22 @@ export default function SellerDashboard() {
   const activeListings = listings.filter(
     (listing) => listing.status === "ACTIVE",
   ).length;
-  const totalRevenue = orders.reduce(
-    (sum, order) => sum + orderTotal(order),
-    0,
+  const balanceLabel = formatLedgerAmount(balanceQuery.data?.balance);
+  const commissionLabel = formatCommissionRate(
+    sellerMeQuery.data?.commissionRate,
   );
 
   if (isLoading) {
     return (
       <div className="space-y-6" role="status" aria-label="Carregando">
         <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64" />
         <div className="grid gap-3 sm:grid-cols-3">
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
         </div>
+        <Skeleton className="h-40 w-full" />
       </div>
     );
   }
@@ -94,6 +113,8 @@ export default function SellerDashboard() {
             variant="outline"
             onClick={() => {
               void listingsQuery.refetch();
+              void balanceQuery.refetch();
+              void sellerMeQuery.refetch();
               void ordersQuery.refetch();
             }}
           >
@@ -105,13 +126,9 @@ export default function SellerDashboard() {
   }
 
   const stats = [
+    { label: "Saldo", value: balanceLabel, icon: Wallet },
+    { label: "Comissão", value: commissionLabel, icon: Percent },
     { label: "Listings ativos", value: String(activeListings), icon: Package },
-    {
-      label: "Receita",
-      value: `$${totalRevenue.toFixed(2)}`,
-      icon: DollarSign,
-    },
-    { label: "Pedidos", value: String(orders.length), icon: ShoppingBag },
   ];
 
   return (
@@ -119,7 +136,7 @@ export default function SellerDashboard() {
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Visão geral</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Listings únicos, pedidos e receita da loja.
+          Saldo {balanceLabel} · Comissão {commissionLabel}
         </p>
       </div>
 
@@ -145,9 +162,14 @@ export default function SellerDashboard() {
           <h2 className="text-sm font-semibold tracking-tight">
             Pedidos recentes
           </h2>
-          <Button asChild variant="outline" size="sm">
-            <Link to="/seller/orders">Ver pedidos</Link>
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link to="/seller/transactions">Ver transações</Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/seller/orders">Ver pedidos</Link>
+            </Button>
+          </div>
         </div>
         {orders.length === 0 ? (
           <EmptyState
@@ -176,7 +198,7 @@ export default function SellerDashboard() {
                 </div>
                 <div className="text-right">
                   <p className="tabular-nums text-sm font-semibold">
-                    ${orderTotal(order).toFixed(2)}
+                    {formatLedgerAmount(order.totalAmount)}
                   </p>
                   <Badge variant="secondary" className="mt-1">
                     {orderStatusLabel(order.status)}

--- a/src/pages/__tests__/SellerDashboard.test.tsx
+++ b/src/pages/__tests__/SellerDashboard.test.tsx
@@ -159,7 +159,7 @@ describe("SellerDashboard", () => {
     expect(screen.getAllByText("10%").length).toBeGreaterThan(0);
     expect(screen.getByText("Listings ativos")).toBeTruthy();
     expect(screen.getAllByText("1").length).toBeGreaterThan(0);
-    expect(screen.getByText("AK-47 | Redline")).toBeTruthy();
+    expect(screen.getAllByText("AK-47 | Redline").length).toBeGreaterThan(0);
     expect(screen.queryByText("Receita")).toBeNull();
     expect(screen.queryByText("$84.00")).toBeNull();
     expect(screen.queryByText(/SKINMARKET/i)).toBeNull();

--- a/src/pages/__tests__/SellerDashboard.test.tsx
+++ b/src/pages/__tests__/SellerDashboard.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SellerDashboard from "../SellerDashboard";
-import type { Listing, Order, Role, User } from "@/types/api";
+import type { Listing, Order, Role, Seller, User } from "@/types/api";
 
 const getSellerListings = vi.fn();
 const listOrders = vi.fn();
+const getCommissionBalance = vi.fn();
+const getSellerMe = vi.fn();
 const authState = {
   user: {
     id: "seller-user",
@@ -22,6 +24,14 @@ vi.mock("@/api/listings", () => ({
 
 vi.mock("@/api/orders", () => ({
   listOrders: (...args: unknown[]) => listOrders(...args),
+}));
+
+vi.mock("@/api/commissions", () => ({
+  getCommissionBalance: (...args: unknown[]) => getCommissionBalance(...args),
+}));
+
+vi.mock("@/api/sellers", () => ({
+  getSellerMe: (...args: unknown[]) => getSellerMe(...args),
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -52,6 +62,19 @@ function listing(status: Listing["status"] = "ACTIVE"): Listing {
       updatedAt: new Date().toISOString(),
     },
     seller: { id: "seller-1", storeName: "NeonTrader Store" },
+  };
+}
+
+function sellerMe(overrides: Partial<Seller> = {}): Seller {
+  return {
+    id: "seller-1",
+    userId: "seller-user",
+    storeName: "NeonTrader Store",
+    commissionRate: "0.1",
+    balance: "0.00",
+    rating: 0,
+    isApproved: true,
+    ...overrides,
   };
 }
 
@@ -99,6 +122,10 @@ function renderDashboard(role: Role = "SELLER") {
         <Routes>
           <Route path="/seller" element={<SellerDashboard />} />
           <Route path="/admin" element={<div>admin-home</div>} />
+          <Route
+            path="/seller/transactions"
+            element={<div>transactions-page</div>}
+          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -109,29 +136,79 @@ describe("SellerDashboard", () => {
   beforeEach(() => {
     getSellerListings.mockReset();
     listOrders.mockReset();
+    getCommissionBalance.mockReset();
+    getSellerMe.mockReset();
   });
 
-  it("shows listing, revenue and order stats without leftover marketplace chrome", async () => {
+  it("shows ledger balance, sellers/me commission rate, and active listings", async () => {
     getSellerListings.mockResolvedValue({
       items: [listing("ACTIVE"), listing("SOLD")],
       total: 2,
     });
-    listOrders.mockResolvedValue([order("ord-1", 42)]);
+    listOrders.mockResolvedValue([order("ord-1", 42), order("ord-2", 42)]);
+    getCommissionBalance.mockResolvedValue({ balance: "135.00" });
+    getSellerMe.mockResolvedValue(sellerMe({ commissionRate: "0.1" }));
 
     renderDashboard("SELLER");
 
     expect(await screen.findByText("Visão geral")).toBeTruthy();
+    expect(screen.getByText("Saldo $135.00 · Comissão 10%")).toBeTruthy();
+    expect(screen.getByText("Saldo")).toBeTruthy();
+    expect(screen.getAllByText("$135.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("Comissão")).toBeTruthy();
+    expect(screen.getAllByText("10%").length).toBeGreaterThan(0);
     expect(screen.getByText("Listings ativos")).toBeTruthy();
     expect(screen.getAllByText("1").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("$42.00").length).toBeGreaterThan(0);
     expect(screen.getByText("AK-47 | Redline")).toBeTruthy();
+    expect(screen.queryByText("Receita")).toBeNull();
+    expect(screen.queryByText("$84.00")).toBeNull();
     expect(screen.queryByText(/SKINMARKET/i)).toBeNull();
     expect(screen.queryByText(/CS2 Skin Marketplace/i)).toBeNull();
+    expect(getCommissionBalance).toHaveBeenCalled();
+    expect(getSellerMe).toHaveBeenCalled();
+  });
+
+  it("does not invent saldo by summing local order totals", async () => {
+    getSellerListings.mockResolvedValue({ items: [], total: 0 });
+    listOrders.mockResolvedValue([order("ord-1", 50), order("ord-2", 50)]);
+    getCommissionBalance.mockResolvedValue({ balance: "0.00" });
+    getSellerMe.mockResolvedValue(sellerMe({ commissionRate: "0.15" }));
+
+    renderDashboard("SELLER");
+
+    expect(await screen.findByText("Saldo $0.00 · Comissão 15%")).toBeTruthy();
+    expect(screen.getAllByText("$0.00").length).toBeGreaterThan(0);
+    expect(screen.queryByText("$100.00")).toBeNull();
+    expect(screen.queryByText("Receita")).toBeNull();
+  });
+
+  it("retries all seller dashboard queries from the error state", async () => {
+    getSellerListings.mockRejectedValue(new Error("boom"));
+    listOrders.mockRejectedValue(new Error("boom"));
+    getCommissionBalance.mockRejectedValue(new Error("boom"));
+    getSellerMe.mockRejectedValue(new Error("boom"));
+
+    renderDashboard("SELLER");
+
+    expect(await screen.findByText("Erro ao carregar o painel")).toBeTruthy();
+
+    getSellerListings.mockResolvedValue({ items: [], total: 0 });
+    listOrders.mockResolvedValue([]);
+    getCommissionBalance.mockResolvedValue({ balance: "0.00" });
+    getSellerMe.mockResolvedValue(sellerMe());
+
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+
+    expect(await screen.findByText("Visão geral")).toBeTruthy();
+    expect(getCommissionBalance.mock.calls.length).toBeGreaterThan(1);
+    expect(getSellerMe.mock.calls.length).toBeGreaterThan(1);
   });
 
   it("redirects ADMIN to /admin instead of showing Seller not found", async () => {
     getSellerListings.mockRejectedValue(new Error("Seller not found"));
     listOrders.mockRejectedValue(new Error("Seller not found"));
+    getCommissionBalance.mockRejectedValue(new Error("Seller not found"));
+    getSellerMe.mockRejectedValue(new Error("Seller not found"));
 
     renderDashboard("ADMIN");
 
@@ -140,5 +217,7 @@ describe("SellerDashboard", () => {
     expect(screen.queryByText("Seller not found")).toBeNull();
     expect(getSellerListings).not.toHaveBeenCalled();
     expect(listOrders).not.toHaveBeenCalled();
+    expect(getCommissionBalance).not.toHaveBeenCalled();
+    expect(getSellerMe).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/admin/AdminSellers.tsx
+++ b/src/pages/admin/AdminSellers.tsx
@@ -16,7 +16,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import type { Seller } from "@/types/api";
 
-function formatMoney(value: number): string {
+function formatMoney(value: string | number): string {
   return `$${Number(value).toFixed(2)}`;
 }
 

--- a/src/pages/seller/SellerTransactions.tsx
+++ b/src/pages/seller/SellerTransactions.tsx
@@ -1,0 +1,119 @@
+import { Link, Navigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { listCommissionTransactions } from "@/api/commissions";
+import { useAuth } from "@/contexts/AuthContext";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatLedgerAmount } from "@/lib/formatLedgerAmount";
+import { paymentStatusLabel } from "@/lib/userFacingApiError";
+
+function formatTransactionDate(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString();
+}
+
+export default function SellerTransactionsPage() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "ADMIN";
+  const {
+    data: transactions = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["commissionTransactions"],
+    queryFn: () => listCommissionTransactions(),
+    enabled: user?.role === "SELLER",
+  });
+
+  if (isAdmin) {
+    return <Navigate to="/admin" replace />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-4 w-72 max-w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar transações"
+        error={error}
+        action={
+          <Button type="button" variant="outline" onClick={() => refetch()}>
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Transações</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Movimentos oficiais do ledger. O valor é o líquido creditado após a
+          comissão.
+        </p>
+      </div>
+
+      {transactions.length === 0 ? (
+        <EmptyState
+          title="Nenhuma transação"
+          description="Quando um pedido for pago, o movimento aparece aqui."
+          action={
+            <Button asChild>
+              <Link to="/seller/listings">Criar listing</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Data</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Valor</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {transactions.map((tx) => (
+              <TableRow key={tx.id}>
+                <TableCell className="whitespace-nowrap text-muted-foreground">
+                  {formatTransactionDate(tx.createdAt)}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="secondary">
+                    {paymentStatusLabel(tx.status)}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right tabular-nums font-medium">
+                  {formatLedgerAmount(tx.netAmount)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/src/pages/seller/__tests__/SellerTransactions.test.tsx
+++ b/src/pages/seller/__tests__/SellerTransactions.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import SellerTransactionsPage from "../SellerTransactions";
+import type { Role, SellerTransaction, User } from "@/types/api";
+
+const listCommissionTransactions = vi.fn();
+const authState = {
+  user: {
+    id: "seller-user",
+    name: "Seller",
+    email: "seller@test.com",
+    role: "SELLER",
+  } as User,
+};
+
+vi.mock("@/api/commissions", () => ({
+  listCommissionTransactions: (...args: unknown[]) =>
+    listCommissionTransactions(...args),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+function transaction(
+  overrides: Partial<SellerTransaction> = {},
+): SellerTransaction {
+  return {
+    id: "tx-1",
+    sellerId: "seller-1",
+    orderId: "ord-1",
+    grossAmount: "100.00",
+    commissionAmount: "10.00",
+    netAmount: "90.00",
+    status: "PAID",
+    createdAt: "2026-09-01T12:00:00.000Z",
+    order: { id: "ord-1", createdAt: "2026-09-01T11:00:00.000Z" },
+    ...overrides,
+  };
+}
+
+function setRole(role: Role) {
+  authState.user = {
+    id: `${role.toLowerCase()}-user`,
+    name: role,
+    email: `${role.toLowerCase()}@test.com`,
+    role,
+  };
+}
+
+function renderTransactions() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/seller/transactions"]}>
+        <Routes>
+          <Route
+            path="/seller/transactions"
+            element={<SellerTransactionsPage />}
+          />
+          <Route path="/admin" element={<div>admin-home</div>} />
+          <Route path="/seller/listings" element={<div>listings-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SellerTransactions", () => {
+  beforeEach(() => {
+    listCommissionTransactions.mockReset();
+    setRole("SELLER");
+  });
+
+  it("renders date, status, and net amount from the commissions payload", async () => {
+    listCommissionTransactions.mockResolvedValue([transaction()]);
+
+    renderTransactions();
+
+    expect(await screen.findByText("Transações")).toBeTruthy();
+    expect(screen.getByText("Pago")).toBeTruthy();
+    expect(screen.getByText("$90.00")).toBeTruthy();
+    expect(screen.queryByText("$100.00")).toBeNull();
+    expect(listCommissionTransactions).toHaveBeenCalled();
+  });
+
+  it("shows the empty next-step copy instead of a broken table", async () => {
+    listCommissionTransactions.mockResolvedValue([]);
+
+    renderTransactions();
+
+    expect(
+      await screen.findByText(
+        "Quando um pedido for pago, o movimento aparece aqui.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+    expect(screen.getByRole("link", { name: "Criar listing" })).toHaveAttribute(
+      "href",
+      "/seller/listings",
+    );
+  });
+
+  it("retries the transactions query from the error state", async () => {
+    listCommissionTransactions.mockRejectedValue(new Error("boom"));
+
+    renderTransactions();
+
+    expect(await screen.findByText("Erro ao carregar transações")).toBeTruthy();
+
+    listCommissionTransactions.mockResolvedValue([]);
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+
+    expect(
+      await screen.findByText(
+        "Quando um pedido for pago, o movimento aparece aqui.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("redirects ADMIN to /admin without calling listCommissionTransactions", async () => {
+    setRole("ADMIN");
+    listCommissionTransactions.mockResolvedValue([transaction()]);
+
+    renderTransactions();
+
+    expect(await screen.findByText("admin-home")).toBeTruthy();
+    expect(screen.queryByText("Transações")).toBeNull();
+    expect(listCommissionTransactions).not.toHaveBeenCalled();
+  });
+});

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -27,13 +27,40 @@ export interface Seller {
   id: string;
   userId: string;
   storeName: string;
-  commissionRate?: number;
-  balance: number;
+  /** Prisma Decimal JSON string (fraction, e.g. "0.1" = 10%). OpenAPI may still say number. */
+  commissionRate?: string | number;
+  /** Prisma Decimal JSON string. Prefer GET /commissions/balance for the projection. */
+  balance: string | number;
   rating: number;
   isApproved: boolean;
   createdAt?: string;
   updatedAt?: string;
   user?: { id: string; name: string; email: string };
+}
+
+export type PaymentStatus = "PENDING" | "PAID" | "REFUNDED";
+
+/** GET /commissions/balance — Seller.balance projection as a Decimal JSON string. */
+export interface CommissionBalance {
+  balance: string;
+}
+
+/**
+ * GET /commissions/transactions — SellerTransaction row.
+ * Decimal fields serialize as strings (Prisma Decimal#toJSON).
+ * SELLER payload includes `order`; ADMIN list also includes `seller`.
+ */
+export interface SellerTransaction {
+  id: string;
+  sellerId: string;
+  orderId: string;
+  grossAmount: string | number;
+  commissionAmount: string | number;
+  netAmount: string | number;
+  status: PaymentStatus;
+  createdAt: string;
+  order?: { id: string; createdAt: string };
+  seller?: { id: string; storeName: string };
 }
 
 // Product catalog base (skin model definition)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Seller dashboard now shows ledger balance, store commission rate, and a transactions screen from the existing commissions API. No payout/saque. No client-side `number` sum as a balance substitute.

Closes #98.

## What changed

- `src/api/commissions.ts` — `GET /commissions/balance` and `GET /commissions/transactions`.
- Dashboard cards: saldo from balance endpoint, taxa from `GET /sellers/me` (`commissionRate`), listings ativos (existing).
- New `/seller/transactions` page: date, payment status, `netAmount`. Empty copy: “Quando um pedido for pago, o movimento aparece aqui.”
- `formatLedgerAmount` / `formatCommissionRate` display API decimals as strings (no JS float arithmetic).
- Loading skeletons, error + retry, SELLER-only route (ADMIN redirected).
- Tests for API client, formatters, dashboard cards, transactions empty/error/table.

## Acceptance

- [x] Seller screens do not invent saldo by summing local `number` values
- [x] Commission rate comes from `GET /sellers/me`
- [x] User with no transactions sees the empty state, not a broken table

## Verification

- `npm run typecheck` → pass
- `npm run lint` → pass (0 errors)
- `npm test` → 45 files, 259 tests pass

## Risks

- Display prefix `$` matches existing seller UI; ledger currency on the server remains BRL (ADR 0011).
- `SellerOrders` still formats a single order with `Number().toFixed`; it is not used as a balance substitute.
- Browser walkthrough was not recorded in this run; coverage is unit/UI tests + CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d841ca1-2e41-4b6a-ad5f-0927795a4927?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d841ca1-2e41-4b6a-ad5f-0927795a4927&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

