### PR TITLE
feat(ai-factory): establish AI-native engineering foundation

### DIFF
--- a/docs/architecture/ai-engineering-authority.md
+++ b/docs/architecture/ai-engineering-authority.md
@@ -1,0 +1,65 @@
+# AI Engineering Authority Model
+
+## Purpose
+
+Define how Neon Arsenal agents interpret and reconcile requirements, architecture decisions, invariants, implementation, tests, runtime evidence, and historical knowledge.
+
+## Artifact hierarchy
+
+```text
+Intent
+  ↓
+Specification
+  ↓
+Plan
+  ↓
+Task
+  ↓
+Implementation
+  ↓
+Verification
+  ↓
+Evaluation
+  ↓
+Memory
+```
+
+GitHub Issues are the operational intake and tracking layer. They are not a substitute for a material Specification.
+
+## Authority by concern
+
+| Concern | Authoritative artifact | Rule |
+|---|---|---|
+| Business requirement | Specification | Defines what must be true and what is explicitly out of scope. |
+| Architecture decision | ADR | Defines durable structural trade-offs and selected architecture. |
+| Business invariant | Domain invariant catalog + tests/schema | Defines truths that must survive refactors, retries, races, and crashes. |
+| Current implementation | Code | Describes executable behavior today; disagreement with docs is a defect to resolve, not permission to invent behavior. |
+| Acceptance evidence | Tests/checks/runtime evidence | Proves whether a requirement is satisfied. |
+| Operational learning | Engineering Memory | Reusable context; never overrides current code, spec, ADR, or invariant evidence automatically. |
+| Agent procedure | `AGENTS.md` + `.cursor/rules/` | Defines how agents operate, not what product behavior should be. |
+
+## Conflict resolution
+
+1. Protect security, data integrity, and explicit business invariants.
+2. Do not silently invent a requirement when artifacts disagree.
+3. Inspect executable behavior and relevant tests to establish the current state.
+4. For a material requirement conflict, escalate to HUMAN and record the decision.
+5. Update the stale artifact in the same coherent change once the decision is made.
+
+## Materiality rule
+
+A Specification is required when a change affects business behavior, public API contracts, database schema/state, security guarantees, payment semantics, concurrency, reliability, architecture boundaries, or user-visible workflow beyond a trivial isolated fix.
+
+Small reversible changes may use the existing Issue + task workflow until the specification threshold is triggered.
+
+## Traceability
+
+Material work should be traceable as:
+
+`Issue → SPEC → PLAN → TASK(S) → PR → CONVERGENCE → EVALUATION`
+
+Later phases may append `MEMORY` references to the chain.
+
+## Non-goals
+
+This document does not introduce microservices, queues, new databases, LLM-vendor dependencies, or a second orchestration system. The existing modular monolith remains the application architecture.

--- a/docs/templates/evaluation.md
+++ b/docs/templates/evaluation.md
@@ -1,0 +1,42 @@
+# [EVAL-ID] — Evaluation
+
+## Execution
+
+- Task / PR: ...
+- Spec: [SPEC-ID]
+- Plan: [PLAN-ID]
+- Agent workflow version: ...
+
+## Outcome
+
+PASS | FAIL | BLOCKED
+
+## Software Quality
+
+- Spec adherence:
+- Architecture adherence:
+- Invariant preservation:
+- Security:
+- Test quality:
+- Verification quality:
+- Scope discipline:
+
+## Agent Execution Quality
+
+- First-pass verification:
+- Verification retries:
+- Human escalation:
+- Out-of-scope changes:
+- Rework / rollback:
+
+## Evidence
+
+Exact commands, test results and review findings.
+
+## Findings
+
+What went well, what failed and why.
+
+## Learning Candidates
+
+Reusable knowledge that may belong in Engineering Memory.

--- a/docs/templates/memory.md
+++ b/docs/templates/memory.md
@@ -1,0 +1,29 @@
+# [MEMORY-ID] — Title
+
+## Status
+
+ACTIVE | UNVERIFIED | SUPERSEDED
+
+## Confidence
+
+HIGH | MEDIUM | LOW
+
+## Statement
+
+A reusable engineering fact or lesson.
+
+## Evidence
+
+Where the statement came from: code, tests, provider docs, production evidence, PR or incident.
+
+## Affected Areas
+
+Modules, integrations or workflows affected.
+
+## Last Verified
+
+YYYY-MM-DD
+
+## Agent Guidance
+
+How a future agent should use this knowledge and when it must revalidate it.

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -1,0 +1,63 @@
+# [PLAN-ID] — Title
+
+## Source
+
+- Specification: [SPEC-ID]
+- Issue: #...
+
+## Current State
+
+Relevant existing behavior and constraints.
+
+## Goal
+
+Implementation outcome, without redefining the Spec.
+
+## Affected Areas
+
+Modules, files, schema, API contracts and infrastructure.
+
+## Architecture
+
+How the change fits the existing architecture and dependency direction.
+
+## Database
+
+Schema/migration/transaction implications when applicable.
+
+## Implementation Sequence
+
+1. ...
+2. ...
+3. ...
+
+## Task Graph
+
+```text
+Task A → Task B → Task D
+       ↘ Task C ↗
+```
+
+## Testing Strategy
+
+Unit, integration, concurrency, security, contract, browser and operational checks as applicable.
+
+## Verification Strategy
+
+Exact commands and acceptance evidence.
+
+## Risks
+
+Material technical risks and mitigations.
+
+## Dependencies
+
+Tasks, decisions or external capabilities that must exist first.
+
+## Stop Conditions
+
+Conditions requiring HUMAN escalation.
+
+## Definition of Done
+
+Observable conditions proving that the Plan has been executed without silently expanding scope.

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,0 +1,76 @@
+# [SPEC-ID] — Title
+
+## Status
+
+Proposed | Accepted | Superseded
+
+## Problem
+
+What problem exists today?
+
+## Goal
+
+What outcome must become true?
+
+## Actors
+
+Who or what participates in the behavior?
+
+## Scope
+
+What this specification includes.
+
+## Non-goals
+
+What this specification explicitly does not include.
+
+## Business Rules
+
+Rules that define expected domain behavior.
+
+## Invariants
+
+Reference canonical invariant IDs. Create a new invariant only when the rule is genuinely new.
+
+## State Transitions
+
+Document lifecycle transitions when applicable.
+
+## API / Data Contract
+
+Requests, responses, events, persistence or schema changes when applicable.
+
+## Concurrency Model
+
+Race conditions, transaction boundaries and isolation assumptions when applicable.
+
+## Failure Modes
+
+Retries, crashes, timeouts, partial completion and recovery behavior.
+
+## Security
+
+Trust boundaries, authentication, authorization, validation and sensitive-data constraints.
+
+## Observability
+
+Logs, metrics, traces and operational signals needed to prove or operate the behavior.
+
+## Backward Compatibility
+
+Compatibility constraints and migrations.
+
+## Acceptance Criteria
+
+- [ ] AC-01: ...
+- [ ] AC-02: ...
+
+Every material criterion should indicate how it can be verified.
+
+## Verification Strategy
+
+Commands, tests, static checks, integration tests, browser/runtime checks or human review required to establish acceptance.
+
+## Decisions / References
+
+Relevant ADRs, architecture docs and external provider documentation.

--- a/docs/templates/task.md
+++ b/docs/templates/task.md
@@ -1,0 +1,42 @@
+# [TASK-ID] — Action
+
+## Source
+
+- Specification: [SPEC-ID]
+- Plan: [PLAN-ID]
+- Issue: #...
+
+## Objective
+
+One concrete outcome.
+
+## Scope
+
+Files/modules expected to change. Unrelated cleanup is out of scope.
+
+## Preconditions
+
+What must already be true.
+
+## Acceptance Criteria
+
+- [ ] AC-01: ...
+- [ ] AC-02: ...
+
+## Dependencies
+
+Upstream task IDs.
+
+## Risks
+
+Specific risks for this task.
+
+## Verification Command
+
+```bash
+...
+```
+
+## Expected Evidence
+
+What the agent must report after execution.


### PR DESCRIPTION
## Context

This is the first implementation increment of the Neon Arsenal AI-Native Software Factory.

The implementation follows the planning created in Notion under **Neon Arsenal — AI-Native Software Factory**.

## Notion plan

- Seven-phase roadmap: Foundation → Specification → Planning → Convergence → Evaluation → Memory → Factory
- Task backlog tracks the implementation sequence and acceptance criteria.

## This PR

Implements the first Foundation artifacts only:

- `docs/architecture/ai-engineering-authority.md`
- `docs/templates/spec.md`
- `docs/templates/plan.md`
- `docs/templates/task.md`
- `docs/templates/evaluation.md`
- `docs/templates/memory.md`

## Design intent

Establishes a stable authority model and canonical artifact contracts before changing the orchestrator. This intentionally does **not** introduce new agents, infrastructure, queues, databases, or a second orchestration system.

## Traceability

- Phase: F1 Foundation
- Tasks: F1.1–F1.3 (artifact authority/taxonomy/template foundation)
- Next: F1.4–F1.5

## Verification

Documentation-only change; no application behavior is modified.

## Non-goals

- No production feature changes
- No orchestrator behavior changes yet
- No autonomous merge
- No migration to microservices
