### PR TITLE
feat(ai-factory): complete Foundation agent rules and validation

### DIFF
--- a/.cursor/rules/00-agent-operating-system.mdc
+++ b/.cursor/rules/00-agent-operating-system.mdc
@@ -7,22 +7,30 @@ alwaysApply: true
 
 You are the engineering agent for this repository. Your job is to implement requested work while preserving correctness, security, reliability, testability, observability, performance, maintainability, and the documented architecture.
 
-## Mandatory source of truth
+## Mandatory context
 
-Before non-trivial implementation, read:
+For non-trivial work, start with:
 
 1. `AGENTS.md`
-2. `docs/agents/README.md`
-3. `docs/agents/roles.md`
-4. `docs/agents/context-policy.md`
-5. `docs/agents/decision-policy.md`
-6. `docs/agents/execution-protocol.md`
-7. `docs/agents/orchestrator.md`
-8. the relevant architecture and invariant documents
-9. the GitHub issue / task requirements
-10. relevant source, schema, migrations, and tests
+2. `docs/architecture/ai-engineering-authority.md`
+3. the relevant agent protocol/rules
+4. the relevant architecture and invariant documents
+5. the authoritative GitHub Issue, Specification, Plan, or Task
+6. relevant source, schema, migrations, tests, and provider documentation
 
 Do not load the entire repository unnecessarily. Follow the context policy and search before opening large files.
+
+## Artifact-driven operating mode
+
+Use the repository's persistent engineering artifact chain:
+
+```text
+Intent → Specification → Plan → Task → Implementation → Verification → Evaluation → Memory
+```
+
+For material work, the Specification is the contract for what must be true; the Plan explains how; Tasks define bounded execution units. GitHub Issues provide intake/tracking but do not replace a material Specification.
+
+Use the authority model at `docs/architecture/ai-engineering-authority.md` to resolve conflicts. Never invent requirements to make artifacts agree.
 
 ## Operating mode
 
@@ -48,14 +56,16 @@ For a requested issue or feature:
 1. Identify the exact issue and acceptance criteria.
 2. Classify risk and select roles.
 3. Load minimum relevant context.
-4. Produce a compact implementation plan before broad edits.
-5. Inspect existing code, tests, schema, migrations, and conventions.
-6. Implement only the requested scope.
-7. Add or update tests that prove behavior and failure modes.
-8. Review the diff against architecture and invariants.
-9. Run targeted verification, then broader checks when justified.
-10. Report exact commands/results and remaining risks.
-11. Commit only when the task's completion criteria are satisfied.
+4. Determine the authoritative artifact chain; for material work, require a Specification.
+5. Produce or follow a Plan and bounded Task when the work is non-trivial.
+6. Inspect existing code, tests, schema, migrations, and conventions.
+7. Implement only the requested scope.
+8. Add or update tests that prove behavior and failure modes.
+9. Review the diff against architecture and invariants.
+10. Run targeted verification, then broader checks when justified.
+11. Run artifact validation with `python3 scripts/ai-factory/validate.py` when artifact contracts are affected.
+12. Report exact commands/results and remaining risks.
+13. Commit only when the task's completion criteria are satisfied.
 
 Do not mark work complete merely because TypeScript compiles or a happy-path test passes.
 
@@ -93,6 +103,7 @@ Never invent provider contracts, environment variables, APIs, or requirements.
 
 Before claiming completion, state:
 
+- artifact chain used
 - files changed
 - invariant(s) affected and preserved
 - tests/checks executed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  factory:
+    name: AI Factory (artifact validation)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate factory artifacts
+        run: python3 scripts/ai-factory/validate.py
+
+      - name: Test validator
+        run: python3 scripts/ai-factory/test_validate.py
+
   # ─────────────────────────────────────────────
   # Frontend: lint + typecheck + unit tests
   # ─────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,14 +28,48 @@ Work should generally follow this order:
 
 Do not add complexity merely to make the project look more sophisticated.
 
+## AI-Native Artifact Hierarchy
+
+For non-trivial work, the repository uses a persistent artifact chain:
+
+```text
+Intent → Specification → Plan → Task → Implementation → Verification → Evaluation → Memory
+```
+
+Authority by concern:
+
+- **Business requirement and acceptance:** Specification (`docs/specs/`)
+- **Architecture decision:** ADRs (`docs/adr/`)
+- **Invariant:** invariant catalog + schema + executable tests (`docs/invariants/` and tests)
+- **Current implementation:** source code
+- **Acceptance evidence:** tests, static checks, integration/runtime evidence
+- **Agent procedure:** this file + `.cursor/rules/`
+- **Operational/engineering learning:** Engineering Memory (`docs/memory/`)
+- **Issue tracking/intake:** GitHub Issues; an Issue is not a substitute for a material Specification
+
+Materiality rule: create a Specification before implementation when a change affects business behavior, public API contracts, database schema/state, security, payment semantics, concurrency, reliability guarantees, architecture boundaries, or a significant user-visible workflow. Small, reversible, convention-backed changes may remain Issue + Task driven.
+
+Traceability for material changes must be recoverable as:
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+Do not invent missing requirements to make artifacts agree. When artifacts conflict, protect security, data integrity, and explicit invariants first; inspect code and tests; escalate material ambiguity to a human; then update the stale artifact after the decision is made.
+
+Templates live under `docs/templates/`. Canonical artifact IDs and file naming are defined by the factory authority document at `docs/architecture/ai-engineering-authority.md`.
+
 ## Before Changing Code
 
-1. Read the relevant existing module, service, repository, schema, migration, and tests.
-2. Understand the current domain rules before proposing an abstraction.
-3. Search the repository for existing implementations before creating new utilities, types, middleware, or patterns.
-4. Check whether the requested change affects transaction boundaries, authorization, money, inventory state, payments, or external integrations.
-5. Prefer the smallest coherent change that solves the problem.
-6. Do not silently change business behavior while performing refactors.
+1. Identify the Issue, Specification, Plan, or Task that authorizes the work.
+2. Read `docs/architecture/ai-engineering-authority.md` for material changes and artifact conflicts.
+3. Load only the relevant architecture, invariant, role, execution, and provider documentation required by the task. Do not read every agent document by default.
+4. Read the relevant existing module, service, repository, schema, migration, and tests.
+5. Understand the current domain rules before proposing an abstraction.
+6. Search the repository for existing implementations before creating new utilities, types, middleware, or patterns.
+7. Check whether the requested change affects transaction boundaries, authorization, money, inventory state, payments, or external integrations.
+8. Prefer the smallest coherent change that solves the problem.
+9. Do not silently change business behavior while performing refactors.
 
 ## Architecture
 
@@ -324,16 +358,16 @@ For every non-trivial task, follow this sequence:
 
 ### 1. Understand
 
-- Read the relevant code.
-- Identify business invariants.
-- Identify dependencies and side effects.
-- Identify failure modes.
+- Identify the authoritative artifact(s) for the change.
+- Read the minimum relevant context.
+- Identify business invariants, dependencies, side effects, and failure modes.
 
 ### 2. Plan
 
-Before editing, state a concise implementation plan internally or in the task context.
-
-For changes involving concurrency, payments, transactions, or infrastructure, explicitly identify the consistency and failure model.
+- For material changes, ensure a SPEC exists before implementation.
+- Create or follow a PLAN and TASK graph when the work spans multiple files, concerns, or agents.
+- State a concise implementation plan before broad edits.
+- For changes involving concurrency, payments, transactions, or infrastructure, explicitly identify the consistency and failure model.
 
 ### 3. Implement
 
@@ -353,6 +387,7 @@ Run the most relevant checks available:
 - integration tests
 - build
 - migration validation
+- artifact validation via `python3 scripts/ai-factory/validate.py`
 
 If a check cannot be run, say so instead of claiming success.
 
@@ -369,6 +404,17 @@ Before finishing, inspect the diff and ask:
 - Is the abstraction actually necessary?
 - Is documentation now inaccurate?
 - Does the change improve the evidence of Senior Backend engineering?
+- Does the implementation still trace back to the authoritative artifact?
+
+### 6. Close the loop
+
+For material work, completion means more than green tests:
+
+```text
+Implementation → Verification → Convergence → Evaluation → Memory
+```
+
+These later artifacts may be lightweight until their dedicated factory phases are implemented, but the agent must not claim completion without recording the evidence required by the current task.
 
 ## Rules for AI-Generated Code
 
@@ -384,6 +430,7 @@ AI agents must not:
 - use `any` to bypass TypeScript errors unless there is a documented, unavoidable boundary
 - add speculative abstractions for hypothetical future requirements
 - convert synchronous workflows to asynchronous ones without analyzing consistency and failure semantics
+- treat a GitHub Issue, chat prompt, or agent memory as more authoritative than a current Specification for material business behavior
 
 When uncertain, inspect the repository and existing documentation before making assumptions.
 
@@ -402,6 +449,7 @@ A significant change is complete only when the implementation and documentation 
 - testing strategy
 - scalability limits
 - alternatives and trade-offs
+- the artifact chain that authorized and verified the change
 
 The project should demonstrate engineering judgment, not technology collecting.
 

--- a/scripts/ai-factory/test_validate.py
+++ b/scripts/ai-factory/test_validate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Smoke/unit tests for the dependency-free AI Factory validator."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from validate import ID_PATTERNS, TEMPLATES
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "scripts" / "ai-factory" / "validate.py"
+
+
+class ValidatorTests(unittest.TestCase):
+    def test_canonical_id_patterns(self) -> None:
+        valid = {
+            "specs": "SPEC-ORDERS-001",
+            "plans": "PLAN-ORDERS-001",
+            "tasks": "TASK-ORDERS-001",
+            "evaluations": "EVAL-ORDERS-001",
+            "memory": "MEM-ORDERS-001",
+        }
+        for kind, value in valid.items():
+            self.assertRegex(value, ID_PATTERNS[kind])
+
+        self.assertNotRegex("SPEC-orders-001", ID_PATTERNS["specs"])
+        self.assertNotRegex("ORDER-001", ID_PATTERNS["specs"])
+
+    def test_template_contracts_are_non_empty(self) -> None:
+        for filename, headings in TEMPLATES.items():
+            path = ROOT / "docs" / "templates" / filename
+            self.assertTrue(path.is_file(), filename)
+            content = path.read_text(encoding="utf-8")
+            for heading in headings:
+                self.assertIn(heading, content)
+
+    def test_repository_validation_passes(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("AI Factory artifact validation: PASS", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ai-factory/validate.py
+++ b/scripts/ai-factory/validate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate the structural contracts of Neon Arsenal AI Factory artifacts.
+
+This validator intentionally uses only Python's standard library so it can run in
+CI, local hooks, or an agent sandbox without adding project dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+TEMPLATES = {
+    "spec.md": [
+        "## Status", "## Problem", "## Goal", "## Actors", "## Scope",
+        "## Non-goals", "## Business Rules", "## Invariants", "## Acceptance Criteria",
+        "## Verification Strategy",
+    ],
+    "plan.md": [
+        "## Source Specification", "## Current State", "## Goal", "## Affected Areas",
+        "## Implementation Sequence", "## Task Graph", "## Testing", "## Verification",
+        "## Risks", "## Definition of Done",
+    ],
+    "task.md": [
+        "## Source", "## Objective", "## Scope", "## Preconditions",
+        "## Acceptance Criteria", "## Dependencies", "## Verification",
+    ],
+    "evaluation.md": [
+        "## Execution", "## Outcome", "## Software Quality", "## Agent Execution Quality",
+        "## Evidence", "## Findings", "## Learning Candidates",
+    ],
+    "memory.md": [
+        "## Status", "## Confidence", "## Statement", "## Evidence",
+        "## Affected Areas", "## Last Verified", "## Agent Guidance",
+    ],
+}
+
+ID_PATTERNS = {
+    "specs": re.compile(r"^SPEC-[A-Z0-9][A-Z0-9._-]*$"),
+    "plans": re.compile(r"^PLAN-[A-Z0-9][A-Z0-9._-]*$"),
+    "tasks": re.compile(r"^TASK-[A-Z0-9][A-Z0-9._-]*$"),
+    "evaluations": re.compile(r"^EVAL-[A-Z0-9][A-Z0-9._-]*$"),
+    "memory": re.compile(r"^MEM-[A-Z0-9][A-Z0-9._-]*$"),
+}
+
+errors: list[str] = []
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+
+
+def validate_templates() -> None:
+    for filename, headings in TEMPLATES.items():
+        path = ROOT / "docs" / "templates" / filename
+        if not path.is_file():
+            fail(f"missing canonical template: {path.relative_to(ROOT)}")
+            continue
+        content = path.read_text(encoding="utf-8")
+        for heading in headings:
+            if heading not in content:
+                fail(f"{path.relative_to(ROOT)} missing required heading: {heading}")
+
+
+def artifact_id(content: str, kind: str, path: Path) -> str | None:
+    match = re.search(r"^#\s+\[([A-Z0-9][A-Z0-9._-]*)\]\s+—", content, re.MULTILINE)
+    if not match:
+        fail(f"{path.relative_to(ROOT)} has no canonical ID in the title")
+        return None
+    value = match.group(1)
+    expected = ID_PATTERNS[kind]
+    if not expected.match(value):
+        fail(f"{path.relative_to(ROOT)} has invalid {kind[:-1]} ID: {value}")
+        return None
+    return value
+
+
+def validate_artifacts(kind: str) -> set[str]:
+    directory = ROOT / "docs" / kind
+    ids: set[str] = set()
+    if not directory.exists():
+        return ids
+    for path in sorted(directory.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        value = artifact_id(content, kind, path)
+        if value:
+            if value in ids:
+                fail(f"duplicate {kind[:-1]} ID: {value}")
+            ids.add(value)
+    return ids
+
+
+def validate_references() -> None:
+    known_specs = validate_artifacts("specs")
+    known_plans = validate_artifacts("plans")
+    known_tasks = validate_artifacts("tasks")
+    validate_artifacts("evaluations")
+    validate_artifacts("memory")
+
+    for path in sorted((ROOT / "docs").glob("**/*.md")):
+        content = path.read_text(encoding="utf-8")
+        for prefix, known, label in (
+            ("SPEC-", known_specs, "SPEC"),
+            ("PLAN-", known_plans, "PLAN"),
+            ("TASK-", known_tasks, "TASK"),
+        ):
+            for ref in sorted(set(re.findall(rf"{prefix}[A-Z0-9][A-Z0-9._-]*", content))):
+                # Templates contain placeholders and are intentionally exempt.
+                if "templates" in path.parts:
+                    continue
+                if ref not in known:
+                    fail(f"{path.relative_to(ROOT)} references missing {label}: {ref}")
+
+
+def main() -> int:
+    validate_templates()
+    validate_references()
+    if errors:
+        print("AI Factory artifact validation: FAILED")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("AI Factory artifact validation: PASS")
+    print("- canonical templates: valid")
+    print("- artifact IDs: valid")
+    print("- internal references: valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ai-factory/validate.py
+++ b/scripts/ai-factory/validate.py
@@ -1,134 +1,74 @@
 #!/usr/bin/env python3
-"""Validate the structural contracts of Neon Arsenal AI Factory artifacts.
-
-This validator intentionally uses only Python's standard library so it can run in
-CI, local hooks, or an agent sandbox without adding project dependencies.
-"""
-
+"""Validate structural contracts of Neon Arsenal AI Factory artifacts."""
 from __future__ import annotations
-
 import re
-import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-
 TEMPLATES = {
-    "spec.md": [
-        "## Status", "## Problem", "## Goal", "## Actors", "## Scope",
-        "## Non-goals", "## Business Rules", "## Invariants", "## Acceptance Criteria",
-        "## Verification Strategy",
-    ],
-    "plan.md": [
-        "## Source Specification", "## Current State", "## Goal", "## Affected Areas",
-        "## Implementation Sequence", "## Task Graph", "## Testing", "## Verification",
-        "## Risks", "## Definition of Done",
-    ],
-    "task.md": [
-        "## Source", "## Objective", "## Scope", "## Preconditions",
-        "## Acceptance Criteria", "## Dependencies", "## Verification",
-    ],
-    "evaluation.md": [
-        "## Execution", "## Outcome", "## Software Quality", "## Agent Execution Quality",
-        "## Evidence", "## Findings", "## Learning Candidates",
-    ],
-    "memory.md": [
-        "## Status", "## Confidence", "## Statement", "## Evidence",
-        "## Affected Areas", "## Last Verified", "## Agent Guidance",
-    ],
+    "spec.md": ["## Status", "## Problem", "## Goal", "## Actors", "## Scope", "## Non-goals", "## Business Rules", "## Invariants", "## Acceptance Criteria", "## Verification Strategy"],
+    "plan.md": ["## Source", "## Current State", "## Goal", "## Affected Areas", "## Implementation Sequence", "## Task Graph", "## Testing Strategy", "## Verification Strategy", "## Risks", "## Definition of Done"],
+    "task.md": ["## Source", "## Objective", "## Scope", "## Preconditions", "## Acceptance Criteria", "## Dependencies", "## Verification Command", "## Expected Evidence"],
+    "evaluation.md": ["## Execution", "## Outcome", "## Software Quality", "## Agent Execution Quality", "## Evidence", "## Findings", "## Learning Candidates"],
+    "memory.md": ["## Status", "## Confidence", "## Statement", "## Evidence", "## Affected Areas", "## Last Verified", "## Agent Guidance"],
 }
+ID_PATTERNS = {k: re.compile(rf"^{p}-[A-Z0-9][A-Z0-9._-]*$") for k, p in {"specs":"SPEC", "plans":"PLAN", "tasks":"TASK", "evaluations":"EVAL", "memory":"MEM"}.items()}
 
-ID_PATTERNS = {
-    "specs": re.compile(r"^SPEC-[A-Z0-9][A-Z0-9._-]*$"),
-    "plans": re.compile(r"^PLAN-[A-Z0-9][A-Z0-9._-]*$"),
-    "tasks": re.compile(r"^TASK-[A-Z0-9][A-Z0-9._-]*$"),
-    "evaluations": re.compile(r"^EVAL-[A-Z0-9][A-Z0-9._-]*$"),
-    "memory": re.compile(r"^MEM-[A-Z0-9][A-Z0-9._-]*$"),
-}
-
-errors: list[str] = []
-
-
-def fail(message: str) -> None:
-    errors.append(message)
-
-
-def validate_templates() -> None:
+def validate_templates(errors: list[str]) -> None:
     for filename, headings in TEMPLATES.items():
         path = ROOT / "docs" / "templates" / filename
         if not path.is_file():
-            fail(f"missing canonical template: {path.relative_to(ROOT)}")
+            errors.append(f"missing canonical template: {path.relative_to(ROOT)}")
             continue
         content = path.read_text(encoding="utf-8")
         for heading in headings:
             if heading not in content:
-                fail(f"{path.relative_to(ROOT)} missing required heading: {heading}")
+                errors.append(f"{path.relative_to(ROOT)} missing required heading: {heading}")
 
-
-def artifact_id(content: str, kind: str, path: Path) -> str | None:
-    match = re.search(r"^#\s+\[([A-Z0-9][A-Z0-9._-]*)\]\s+—", content, re.MULTILINE)
-    if not match:
-        fail(f"{path.relative_to(ROOT)} has no canonical ID in the title")
-        return None
-    value = match.group(1)
-    expected = ID_PATTERNS[kind]
-    if not expected.match(value):
-        fail(f"{path.relative_to(ROOT)} has invalid {kind[:-1]} ID: {value}")
-        return None
-    return value
-
-
-def validate_artifacts(kind: str) -> set[str]:
+def validate_artifacts(kind: str, errors: list[str]) -> set[str]:
     directory = ROOT / "docs" / kind
     ids: set[str] = set()
     if not directory.exists():
         return ids
     for path in sorted(directory.glob("*.md")):
         content = path.read_text(encoding="utf-8")
-        value = artifact_id(content, kind, path)
-        if value:
-            if value in ids:
-                fail(f"duplicate {kind[:-1]} ID: {value}")
-            ids.add(value)
+        match = re.search(r"^#\s+\[([A-Z0-9][A-Z0-9._-]*)\]\s+—", content, re.MULTILINE)
+        if not match:
+            errors.append(f"{path.relative_to(ROOT)} has no canonical ID in the title")
+            continue
+        value = match.group(1)
+        if not ID_PATTERNS[kind].match(value):
+            errors.append(f"{path.relative_to(ROOT)} has invalid {kind[:-1]} ID: {value}")
+            continue
+        if value in ids:
+            errors.append(f"duplicate {kind[:-1]} ID: {value}")
+        ids.add(value)
     return ids
 
-
-def validate_references() -> None:
-    known_specs = validate_artifacts("specs")
-    known_plans = validate_artifacts("plans")
-    known_tasks = validate_artifacts("tasks")
-    validate_artifacts("evaluations")
-    validate_artifacts("memory")
-
+def validate_references(errors: list[str]) -> None:
+    known = {"SPEC-": validate_artifacts("specs", errors), "PLAN-": validate_artifacts("plans", errors), "TASK-": validate_artifacts("tasks", errors)}
+    validate_artifacts("evaluations", errors)
+    validate_artifacts("memory", errors)
     for path in sorted((ROOT / "docs").glob("**/*.md")):
+        if "templates" in path.parts:
+            continue
         content = path.read_text(encoding="utf-8")
-        for prefix, known, label in (
-            ("SPEC-", known_specs, "SPEC"),
-            ("PLAN-", known_plans, "PLAN"),
-            ("TASK-", known_tasks, "TASK"),
-        ):
+        for prefix, ids in known.items():
             for ref in sorted(set(re.findall(rf"{prefix}[A-Z0-9][A-Z0-9._-]*", content))):
-                # Templates contain placeholders and are intentionally exempt.
-                if "templates" in path.parts:
-                    continue
-                if ref not in known:
-                    fail(f"{path.relative_to(ROOT)} references missing {label}: {ref}")
-
+                if ref not in ids:
+                    errors.append(f"{path.relative_to(ROOT)} references missing {prefix[:-1]}: {ref}")
 
 def main() -> int:
-    validate_templates()
-    validate_references()
+    errors: list[str] = []
+    validate_templates(errors)
+    validate_references(errors)
     if errors:
         print("AI Factory artifact validation: FAILED")
-        for error in errors:
-            print(f"- {error}")
+        print("\n".join(f"- {e}" for e in errors))
         return 1
     print("AI Factory artifact validation: PASS")
-    print("- canonical templates: valid")
-    print("- artifact IDs: valid")
-    print("- internal references: valid")
+    print("- canonical templates: valid\n- artifact IDs: valid\n- internal references: valid")
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Context

Continuation of the Neon Arsenal AI-Native Software Factory roadmap defined in Notion.

The first Foundation PR (#171) was merged. This PR continues F1 without entering F2.

## F1 scope completed here

- F1.4 — Reorganize global agent rules
  - `AGENTS.md` now explicitly defines the artifact hierarchy and authority model.
  - Materiality rules require a Specification for material changes.
  - Agent workflow now follows Spec → Plan → Task when applicable.
  - Artifact validation is part of completion evidence.
- F1.5 — Structural factory validator
  - Added dependency-free `scripts/ai-factory/validate.py`.
  - Validates canonical template structure.
  - Validates artifact IDs and duplicate IDs.
  - Validates internal SPEC/PLAN/TASK references.
  - Uses meaningful exit codes for CI/local automation.
  - Added `scripts/ai-factory/test_validate.py` smoke/unit coverage.

## Guardrails

- No application behavior changes.
- No new runtime dependencies.
- No second orchestrator.
- No microservices/queues/databases.
- Existing modular-monolith architecture remains unchanged.

## Verification note

The validator and tests are designed to run with Python standard library only. The connected execution environment cannot reach GitHub to clone the repository, so local execution here is blocked by network/DNS rather than by a repository test failure. The current commit status also reports an unrelated Vercel build-rate-limit failure.

## Next gate

Do not start F2 until the F1 Foundation gate is explicitly satisfied. After this PR, the next work should be the formal Specification System and a real reference Specification, not broad feature implementation.