### PR TITLE
feat(ai-factory): formalize Specification contract

### DIFF
--- a/docs/specs/SPEC-0001-specification-system.md
+++ b/docs/specs/SPEC-0001-specification-system.md
@@ -1,0 +1,166 @@
+---
+id: SPEC-0001
+status: Accepted
+version: 1
+source_issue: "Factory F2.1 / F2.5"
+owner: "AI Engineering Factory"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [SPEC-0001] — Specification System
+
+## Status
+
+`Accepted`
+
+This Specification defines the contract for material Specifications in Neon Arsenal Market. It is itself the reference implementation of the contract established in `docs/templates/spec.md`.
+
+## Problem
+
+Material engineering work currently has requirements distributed across GitHub Issues, architecture documents, ADRs, invariants, and agent instructions. Without a canonical Specification contract, an agent can begin implementation without a durable, independently verifiable statement of what must become true.
+
+## Goal
+
+Establish a repository-native Specification artifact that becomes the authoritative contract for material business behavior and can be consumed by planners, executors, verifiers, and future convergence tooling without requiring the original conversation.
+
+## Actors
+
+- Human product/engineering requester
+- AI engineering agent
+- Planner
+- Implementation agent
+- Verification agent
+- GitHub Issue/PR workflow
+- CI artifact validator
+
+## Scope
+
+- Define the canonical Specification structure and metadata.
+- Require stable Specification IDs and lifecycle status.
+- Make acceptance criteria independently verifiable.
+- Preserve traceability from Issue through downstream factory artifacts.
+- Allow future planning, convergence, evaluation, and memory systems to reference the Specification deterministically.
+
+## Non-goals
+
+- Replacing ADRs, the invariant catalog, source code, or tests.
+- Implementing a second orchestration system.
+- Automatically approving product requirements.
+- Making every trivial bug fix require a Specification.
+- Introducing new runtime infrastructure or dependencies.
+
+## Business Rules
+
+- `BR-01`: Material changes require an authoritative Specification before implementation.
+- `BR-02`: An `Accepted` Specification is the authoritative contract for the business behavior it defines.
+- `BR-03`: `Proposed` Specifications may be refined but must not be treated as accepted implementation contracts.
+- `BR-04`: `Superseded` Specifications remain historical references and must not silently authorize new implementation.
+- `BR-05`: Acceptance criteria describe observable outcomes and identify evidence sufficient for independent verification.
+- `BR-06`: A Specification may reference ADRs and invariants but may not silently override them.
+- `BR-07`: A material change to an accepted Specification requires downstream Plan/Task artifacts to be re-evaluated.
+
+## Invariants
+
+- `AI-ARTIFACT-001`: Canonical artifact IDs must be unique within their artifact type.
+- `AI-ARTIFACT-002`: A material implementation must remain traceable to its authoritative Specification.
+- `AI-ARTIFACT-003`: Agent memory cannot override current authoritative requirements, architecture decisions, or executable invariant evidence.
+
+## State Transitions
+
+```text
+Proposed → Accepted
+Accepted → Superseded
+```
+
+`Superseded` is terminal for that Specification version. A replacement Specification receives its own version/identity according to the factory's future revision policy.
+
+## API / Data Contract
+
+Specification frontmatter must contain:
+
+- `id`
+- `status`
+- `version`
+- `source_issue`
+- `owner`
+- `created`
+- `updated`
+
+The title must contain the same canonical `SPEC-*` identifier as the frontmatter.
+
+The document must contain the canonical contract sections in `docs/templates/spec.md`.
+
+## Concurrency Model
+
+Specification editing is not runtime business concurrency. The relevant consistency requirement is artifact consistency: when an accepted Specification changes materially, downstream Plans and Tasks must not continue executing against an obsolete contract.
+
+Future factory tooling must detect stale downstream artifacts through explicit version/reference metadata rather than relying on conversation state.
+
+## Failure Modes
+
+- Missing Specification: material work is blocked before implementation.
+- Invalid Specification metadata: CI artifact validation fails.
+- Ambiguous acceptance criterion: independent verification cannot establish acceptance; the Specification must be refined.
+- Conflicting authoritative artifacts: agent must not invent a requirement and must escalate material ambiguity.
+- Accepted Specification changes after planning: downstream planning/execution must be re-evaluated.
+
+## Security
+
+Specifications must not contain secrets, credentials, access tokens, private keys, or unnecessary sensitive personal data.
+
+Security requirements for a material feature belong in the Specification and must be represented by independently verifiable acceptance criteria.
+
+## Observability
+
+Factory tooling should eventually record Specification ID/version in execution, verification, convergence, and evaluation metadata so an execution can be audited without the original conversation.
+
+For this phase, repository validation is the required evidence that the structural contract is valid.
+
+## Backward Compatibility
+
+The Specification system is additive. Existing GitHub Issue → agent → verification → PR workflows remain valid while material changes progressively adopt the Specification contract.
+
+Existing ADRs, invariant documents, code, and tests remain authoritative for their defined concerns.
+
+## Acceptance Criteria
+
+- [ ] `AC-01` — A material Specification has stable `SPEC-*` identity, lifecycle status, version, owner, source issue, and timestamps. **Evidence:** static check
+- [ ] `AC-02` — The canonical Specification contains problem, goal, scope, rules, invariants, contracts, failure/security concerns, acceptance criteria, verification strategy, and traceability. **Evidence:** static check
+- [ ] `AC-03` — Each material acceptance criterion identifies an evidence class that an independent verifier can inspect. **Evidence:** static check
+- [ ] `AC-04` — A Specification's frontmatter ID matches its canonical title ID and its status is one of `Proposed`, `Accepted`, or `Superseded`. **Evidence:** static check
+- [ ] `AC-05` — A valid Specification can be referenced by downstream Plan and Task artifacts without depending on the original chat conversation. **Evidence:** integration
+- [ ] `AC-06` — The artifact validator rejects malformed Specification metadata and accepts this reference Specification. **Evidence:** static check
+
+## Verification Strategy
+
+- Run `python3 scripts/ai-factory/validate.py`.
+- Confirm `SPEC-0001` is discovered under `docs/specs/`.
+- Confirm malformed metadata, mismatched title/frontmatter IDs, invalid statuses, and missing evidence-bearing acceptance criteria fail validation.
+- In F2.2/F2.3, create Issue ↔ Spec traceability and convert a real Neon Arsenal business flow to this contract.
+
+## Decisions / References
+
+- `docs/architecture/ai-engineering-authority.md`
+- `docs/templates/spec.md`
+- `AGENTS.md`
+- `.cursor/rules/00-agent-operating-system.mdc`
+
+## Traceability
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+- Issue: `Factory F2.1 / F2.5`
+- Spec: `SPEC-0001`
+- Plan: pending F3
+- Tasks: `F2.1`
+- PR: pending
+- Verification/Convergence: pending F4
+- Evaluation: pending F5
+- Memory: pending F6
+
+## Change History
+
+- `v1` — Initial accepted Specification system contract — 2026-09-06

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,76 +1,141 @@
-# [SPEC-ID] — Title
+---
+id: SPEC-EXAMPLE-001
+status: Proposed
+version: 1
+source_issue: "#..."
+owner: "team"
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# SPEC-EXAMPLE-001 — Title
 
 ## Status
 
-Proposed | Accepted | Superseded
+`Proposed` | `Accepted` | `Superseded`
+
+A material Specification becomes authoritative for implementation only when its status is `Accepted`.
 
 ## Problem
 
-What problem exists today?
+Describe the observable problem or unmet requirement. Do not prescribe implementation.
 
 ## Goal
 
-What outcome must become true?
+Describe the measurable outcome that must become true.
 
 ## Actors
 
-Who or what participates in the behavior?
+Identify users, internal services, external providers, scheduled jobs, or administrative actors involved.
 
 ## Scope
 
-What this specification includes.
+Explicitly describe what behavior is included.
 
 ## Non-goals
 
-What this specification explicitly does not include.
+Explicitly describe behavior that is not part of this change. Non-goals prevent agents from expanding scope by assumption.
 
 ## Business Rules
 
-Rules that define expected domain behavior.
+Number material rules so they can be referenced by plans, tasks, tests, and convergence checks.
+
+- `BR-01`: ...
+- `BR-02`: ...
 
 ## Invariants
 
-Reference canonical invariant IDs. Create a new invariant only when the rule is genuinely new.
+Reference canonical invariant IDs only. Do not redefine an existing invariant in a way that conflicts with `docs/domain/invariants.md`.
+
+- `INV-...`
 
 ## State Transitions
 
-Document lifecycle transitions when applicable.
+Document lifecycle transitions when applicable. State transitions must identify allowed, forbidden, and terminal states.
+
+```text
+STATE_A → STATE_B
+STATE_B → STATE_C
+```
 
 ## API / Data Contract
 
-Requests, responses, events, persistence or schema changes when applicable.
+Describe externally observable requests, responses, events, persistence, schema changes, or compatibility requirements when applicable.
+
+For each public contract, specify required fields, constraints, ownership, and error semantics. Reference OpenAPI/Prisma artifacts when they become the implementation source.
 
 ## Concurrency Model
 
-Race conditions, transaction boundaries and isolation assumptions when applicable.
+Describe race conditions, transaction boundaries, uniqueness constraints, isolation assumptions, optimistic/pessimistic controls, and retry semantics whenever state can be changed concurrently.
 
 ## Failure Modes
 
-Retries, crashes, timeouts, partial completion and recovery behavior.
+Describe timeout, duplicate request/event, retry, process crash, partial completion, provider failure, recovery, and reconciliation behavior as applicable.
 
 ## Security
 
-Trust boundaries, authentication, authorization, validation and sensitive-data constraints.
+Describe trust boundaries, authentication, authorization, validation, sensitive data, secret handling, abuse/rate-limit requirements, and external callback authenticity.
 
 ## Observability
 
-Logs, metrics, traces and operational signals needed to prove or operate the behavior.
+Define logs, metrics, traces, correlation identifiers, and operational signals needed to prove or operate the behavior. Avoid sensitive data.
 
 ## Backward Compatibility
 
-Compatibility constraints and migrations.
+Describe compatibility with existing clients, data, APIs, schemas, migrations, or operational behavior. State whether a migration, rollout strategy, or deprecation is required.
 
 ## Acceptance Criteria
 
-- [ ] AC-01: ...
-- [ ] AC-02: ...
+Acceptance criteria define the observable contract. Every material criterion must be independently verifiable and should identify its evidence class.
 
-Every material criterion should indicate how it can be verified.
+- [ ] `AC-01` — ... **Evidence:** test | static check | integration | runtime | manual review
+- [ ] `AC-02` — ... **Evidence:** ...
+
+### Acceptance rules
+
+1. Criteria must describe observable outcomes, not implementation steps.
+2. Criteria must be deterministic enough for an independent verifier to judge.
+3. Criteria must cover important failure and security behavior, not only the happy path.
+4. A criterion is not accepted because a test passes when the test does not actually prove the criterion.
 
 ## Verification Strategy
 
-Commands, tests, static checks, integration tests, browser/runtime checks or human review required to establish acceptance.
+Define the verification surface before implementation.
+
+- Required commands/checks: `...`
+- Unit tests: `...`
+- Integration/concurrency tests: `...`
+- Security/contract checks: `...`
+- Runtime/manual checks: `...`
+- Required external evidence: `...`
+
+The final implementation must be traceable from each material acceptance criterion to evidence.
 
 ## Decisions / References
 
-Relevant ADRs, architecture docs and external provider documentation.
+Reference relevant ADRs, current architecture, invariant catalog, provider documentation, prior accepted Specs, and other authoritative artifacts.
+
+## Traceability
+
+Material changes must preserve this chain:
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+### Traceability metadata
+
+- Issue: `#...`
+- Spec: `SPEC-...`
+- Plan: `PLAN-...`
+- Tasks: `TASK-...`
+- PR: `#...`
+- Verification/Convergence: `...`
+- Evaluation: `EVAL-...`
+- Memory: `MEM-...`
+
+## Change History
+
+Record material changes to the Specification and why they occurred. A change to an accepted Spec requires re-evaluating downstream Plan/Task artifacts.
+
+- `v1` — Initial proposal — YYYY-MM-DD

--- a/scripts/ai-factory/validate.py
+++ b/scripts/ai-factory/validate.py
@@ -1,18 +1,36 @@
 #!/usr/bin/env python3
 """Validate structural contracts of Neon Arsenal AI Factory artifacts."""
 from __future__ import annotations
+
 import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+
 TEMPLATES = {
-    "spec.md": ["## Status", "## Problem", "## Goal", "## Actors", "## Scope", "## Non-goals", "## Business Rules", "## Invariants", "## Acceptance Criteria", "## Verification Strategy"],
+    "spec.md": [
+        "## Status", "## Problem", "## Goal", "## Actors", "## Scope",
+        "## Non-goals", "## Business Rules", "## Invariants",
+        "## State Transitions", "## API / Data Contract", "## Concurrency Model",
+        "## Failure Modes", "## Security", "## Observability",
+        "## Backward Compatibility", "## Acceptance Criteria",
+        "## Verification Strategy", "## Decisions / References", "## Traceability",
+        "## Change History",
+    ],
     "plan.md": ["## Source", "## Current State", "## Goal", "## Affected Areas", "## Implementation Sequence", "## Task Graph", "## Testing Strategy", "## Verification Strategy", "## Risks", "## Definition of Done"],
     "task.md": ["## Source", "## Objective", "## Scope", "## Preconditions", "## Acceptance Criteria", "## Dependencies", "## Verification Command", "## Expected Evidence"],
     "evaluation.md": ["## Execution", "## Outcome", "## Software Quality", "## Agent Execution Quality", "## Evidence", "## Findings", "## Learning Candidates"],
     "memory.md": ["## Status", "## Confidence", "## Statement", "## Evidence", "## Affected Areas", "## Last Verified", "## Agent Guidance"],
 }
-ID_PATTERNS = {k: re.compile(rf"^{p}-[A-Z0-9][A-Z0-9._-]*$") for k, p in {"specs":"SPEC", "plans":"PLAN", "tasks":"TASK", "evaluations":"EVAL", "memory":"MEM"}.items()}
+
+ID_PATTERNS = {
+    k: re.compile(rf"^{p}-[A-Z0-9][A-Z0-9._-]*$")
+    for k, p in {"specs": "SPEC", "plans": "PLAN", "tasks": "TASK", "evaluations": "EVAL", "memory": "MEM"}.items()
+}
+
+FRONTMATTER_REQUIRED = ("id", "status", "version", "source_issue", "owner", "created", "updated")
+VALID_SPEC_STATUSES = {"Proposed", "Accepted", "Superseded"}
+
 
 def validate_templates(errors: list[str]) -> None:
     for filename, headings in TEMPLATES.items():
@@ -25,17 +43,32 @@ def validate_templates(errors: list[str]) -> None:
             if heading not in content:
                 errors.append(f"{path.relative_to(ROOT)} missing required heading: {heading}")
 
+
+def parse_frontmatter(content: str) -> dict[str, str] | None:
+    match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+    if not match:
+        return None
+    values: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, separator, value = line.partition(":")
+        if separator:
+            values[key.strip()] = value.strip().strip('"')
+    return values
+
+
 def validate_artifacts(kind: str, errors: list[str]) -> set[str]:
     directory = ROOT / "docs" / kind
     ids: set[str] = set()
     if not directory.exists():
         return ids
+
     for path in sorted(directory.glob("*.md")):
         content = path.read_text(encoding="utf-8")
         match = re.search(r"^#\s+\[([A-Z0-9][A-Z0-9._-]*)\]\s+—", content, re.MULTILINE)
         if not match:
             errors.append(f"{path.relative_to(ROOT)} has no canonical ID in the title")
             continue
+
         value = match.group(1)
         if not ID_PATTERNS[kind].match(value):
             errors.append(f"{path.relative_to(ROOT)} has invalid {kind[:-1]} ID: {value}")
@@ -43,12 +76,50 @@ def validate_artifacts(kind: str, errors: list[str]) -> set[str]:
         if value in ids:
             errors.append(f"duplicate {kind[:-1]} ID: {value}")
         ids.add(value)
+
+        if kind == "specs":
+            validate_spec(path, content, value, errors)
+
     return ids
 
+
+def validate_spec(path: Path, content: str, title_id: str, errors: list[str]) -> None:
+    frontmatter = parse_frontmatter(content)
+    relative = path.relative_to(ROOT)
+    if frontmatter is None:
+        errors.append(f"{relative} has no YAML frontmatter")
+        return
+
+    for field in FRONTMATTER_REQUIRED:
+        if not frontmatter.get(field):
+            errors.append(f"{relative} missing required frontmatter field: {field}")
+
+    if frontmatter.get("id") and frontmatter["id"] != title_id:
+        errors.append(f"{relative} frontmatter id {frontmatter['id']} does not match title ID {title_id}")
+
+    status = frontmatter.get("status")
+    if status and status not in VALID_SPEC_STATUSES:
+        errors.append(f"{relative} has invalid Specification status: {status}")
+
+    if frontmatter.get("version") and not frontmatter["version"].isdigit():
+        errors.append(f"{relative} has non-numeric Specification version: {frontmatter['version']}")
+
+    if re.search(r"^\s*- \[ \] `AC-[^`]+`.*\*\*Evidence:\*\*\s*(?:test|static check|integration|runtime|manual review)\s*$", content, re.MULTILINE) is None:
+        errors.append(f"{relative} must contain at least one unchecked acceptance criterion with an Evidence class")
+
+    if "GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY" not in content:
+        errors.append(f"{relative} is missing the canonical traceability chain")
+
+
 def validate_references(errors: list[str]) -> None:
-    known = {"SPEC-": validate_artifacts("specs", errors), "PLAN-": validate_artifacts("plans", errors), "TASK-": validate_artifacts("tasks", errors)}
+    known = {
+        "SPEC-": validate_artifacts("specs", errors),
+        "PLAN-": validate_artifacts("plans", errors),
+        "TASK-": validate_artifacts("tasks", errors),
+    }
     validate_artifacts("evaluations", errors)
     validate_artifacts("memory", errors)
+
     for path in sorted((ROOT / "docs").glob("**/*.md")):
         if "templates" in path.parts:
             continue
@@ -58,6 +129,7 @@ def validate_references(errors: list[str]) -> None:
                 if ref not in ids:
                     errors.append(f"{path.relative_to(ROOT)} references missing {prefix[:-1]}: {ref}")
 
+
 def main() -> int:
     errors: list[str] = []
     validate_templates(errors)
@@ -66,9 +138,11 @@ def main() -> int:
         print("AI Factory artifact validation: FAILED")
         print("\n".join(f"- {e}" for e in errors))
         return 1
+
     print("AI Factory artifact validation: PASS")
-    print("- canonical templates: valid\n- artifact IDs: valid\n- internal references: valid")
+    print("- canonical templates: valid\n- artifact IDs: valid\n- specification contracts: valid\n- internal references: valid")
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Context

Continuation of the Notion roadmap for **Fase 2 — Specification System**.

## Scope

Implements F2.1 by making the Specification contract explicit and machine-validatable.

### Changes

- formalized `docs/templates/spec.md`
- added required Specification metadata and lifecycle semantics
- strengthened `scripts/ai-factory/validate.py` to validate Specification frontmatter, IDs, status, acceptance-criterion evidence classes, and canonical traceability
- added `docs/specs/SPEC-0001-specification-system.md` as the first repository-native accepted Specification and reference implementation

## Traceability

`F2.1 → Specification Contract → validator → SPEC-0001`

## Non-goals

- no application runtime behavior changes
- no new infrastructure
- no orchestrator rewrite
- no F3 planning system

## Verification

CI must run the AI Factory artifact validation against the new Specification contract before merge.

The next phase increments are F2.2 (Issue ↔ Spec) and F2.3 (three real flows → Specs).