### PR TITLE
feat(ai-factory): link GitHub Issues to Specifications

### DIFF
--- a/docs/specs/SPEC-0001-specification-system.md
+++ b/docs/specs/SPEC-0001-specification-system.md
@@ -2,7 +2,7 @@
 id: SPEC-0001
 status: Accepted
 version: 1
-source_issue: "Factory F2.1 / F2.5"
+source_issue: "#173"
 owner: "AI Engineering Factory"
 created: 2026-09-06
 updated: 2026-09-06
@@ -87,6 +87,8 @@ Specification frontmatter must contain:
 - `created`
 - `updated`
 
+The `source_issue` value must use the canonical GitHub Issue reference format `#<number>`.
+
 The title must contain the same canonical `SPEC-*` identifier as the frontmatter.
 
 The document must contain the canonical contract sections in `docs/templates/spec.md`.
@@ -152,11 +154,11 @@ Existing ADRs, invariant documents, code, and tests remain authoritative for the
 GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
 ```
 
-- Issue: `Factory F2.1 / F2.5`
+- Issue: `#173`
 - Spec: `SPEC-0001`
 - Plan: pending F3
 - Tasks: `F2.1`
-- PR: pending
+- PR: `#173`
 - Verification/Convergence: pending F4
 - Evaluation: pending F5
 - Memory: pending F6

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -134,6 +134,8 @@ GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE �
 - Evaluation: `EVAL-...`
 - Memory: `MEM-...`
 
+The frontmatter `source_issue` must use the canonical GitHub Issue reference format `#<number>` and identify the material Issue that authorized this Specification.
+
 ## Change History
 
 Record material changes to the Specification and why they occurred. A change to an accepted Spec requires re-evaluating downstream Plan/Task artifacts.

--- a/scripts/ai-factory/issue_spec.py
+++ b/scripts/ai-factory/issue_spec.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Issue ↔ Specification traceability primitives for the AI Factory."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ISSUE_REF_RE = re.compile(r"^#([1-9][0-9]*)$")
+SPEC_REF_RE = re.compile(r"^SPEC-[A-Z0-9][A-Z0-9._-]*$")
+
+
+def canonical_issue_ref(value: str) -> str:
+    """Return a canonical GitHub Issue reference or raise ValueError."""
+    value = value.strip()
+    if not ISSUE_REF_RE.fullmatch(value):
+        raise ValueError(f"invalid GitHub Issue reference: {value!r}")
+    return value
+
+
+def extract_source_issue(frontmatter: dict[str, str]) -> str:
+    """Read and validate the authoritative Issue reference from Spec metadata."""
+    source_issue = frontmatter.get("source_issue", "").strip()
+    return canonical_issue_ref(source_issue)
+
+
+def spec_id_from_title(content: str) -> str | None:
+    match = re.search(r"^#\s+\[([A-Z0-9][A-Z0-9._-]*)\]\s+—", content, re.MULTILINE)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def specs_for_issue(spec_dir: Path, issue_ref: str) -> list[Path]:
+    """Find Specs whose frontmatter authorizes the supplied GitHub Issue."""
+    issue_ref = canonical_issue_ref(issue_ref)
+    matches: list[Path] = []
+    for path in sorted(spec_dir.glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        frontmatter = _parse_frontmatter(content)
+        try:
+            source_issue = extract_source_issue(frontmatter)
+        except ValueError:
+            continue
+        spec_id = spec_id_from_title(content)
+        if source_issue == issue_ref and spec_id and SPEC_REF_RE.fullmatch(spec_id):
+            matches.append(path)
+    return matches
+
+
+def resolve_spec_for_issue(spec_dir: Path, issue_ref: str) -> Path:
+    """Resolve exactly one canonical Spec for a material GitHub Issue."""
+    matches = specs_for_issue(spec_dir, issue_ref)
+    if not matches:
+        raise LookupError(f"no Specification found for GitHub Issue {issue_ref}")
+    if len(matches) > 1:
+        names = ", ".join(path.name for path in matches)
+        raise LookupError(f"multiple Specifications found for GitHub Issue {issue_ref}: {names}")
+    return matches[0]
+
+
+def _parse_frontmatter(content: str) -> dict[str, str]:
+    match = re.match(r"^---\n(.*?)\n---\n", content, re.DOTALL)
+    if not match:
+        return {}
+    values: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, separator, value = line.partition(":")
+        if separator:
+            values[key.strip()] = value.strip().strip('"')
+    return values

--- a/scripts/ai-factory/test_issue_spec.py
+++ b/scripts/ai-factory/test_issue_spec.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pytest
+
+from issue_spec import canonical_issue_ref, resolve_spec_for_issue, specs_for_issue
+
+
+def write_spec(path: Path, issue: str, spec_id: str = "SPEC-TEST-001") -> None:
+    path.write_text(
+        f'''---\nid: {spec_id}\nstatus: Accepted\nversion: 1\nsource_issue: "{issue}"\nowner: team\ncreated: 2026-09-06\nupdated: 2026-09-06\n---\n\n# [{spec_id}] — Example\n''',
+        encoding="utf-8",
+    )
+
+
+def test_canonical_issue_ref_accepts_issue_number() -> None:
+    assert canonical_issue_ref(" #173 ") == "#173"
+
+
+@pytest.mark.parametrize("value", ["173", "#0", "#-1", "issue-173", "# 173"])
+def test_canonical_issue_ref_rejects_non_canonical_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        canonical_issue_ref(value)
+
+
+def test_specs_for_issue_returns_matching_spec(tmp_path: Path) -> None:
+    write_spec(tmp_path / "spec.md", "#173")
+    write_spec(tmp_path / "other.md", "#174", "SPEC-TEST-002")
+
+    assert specs_for_issue(tmp_path, "#173") == [tmp_path / "spec.md"]
+
+
+def test_resolver_blocks_missing_spec(tmp_path: Path) -> None:
+    with pytest.raises(LookupError, match="no Specification"):
+        resolve_spec_for_issue(tmp_path, "#173")
+
+
+def test_resolver_blocks_ambiguous_issue(tmp_path: Path) -> None:
+    write_spec(tmp_path / "a.md", "#173", "SPEC-TEST-001")
+    write_spec(tmp_path / "b.md", "#173", "SPEC-TEST-002")
+
+    with pytest.raises(LookupError, match="multiple Specifications"):
+        resolve_spec_for_issue(tmp_path, "#173")
+
+
+def test_malformed_source_issue_is_not_resolved(tmp_path: Path) -> None:
+    write_spec(tmp_path / "bad.md", "Factory F2.1 / F2.5")
+
+    assert specs_for_issue(tmp_path, "#173") == []

--- a/scripts/ai-factory/validate.py
+++ b/scripts/ai-factory/validate.py
@@ -30,6 +30,7 @@ ID_PATTERNS = {
 
 FRONTMATTER_REQUIRED = ("id", "status", "version", "source_issue", "owner", "created", "updated")
 VALID_SPEC_STATUSES = {"Proposed", "Accepted", "Superseded"}
+GITHUB_ISSUE_REF = re.compile(r"^#[1-9][0-9]*$")
 
 
 def validate_templates(errors: list[str]) -> None:
@@ -103,6 +104,10 @@ def validate_spec(path: Path, content: str, title_id: str, errors: list[str]) ->
 
     if frontmatter.get("version") and not frontmatter["version"].isdigit():
         errors.append(f"{relative} has non-numeric Specification version: {frontmatter['version']}")
+
+    source_issue = frontmatter.get("source_issue")
+    if source_issue and not GITHUB_ISSUE_REF.fullmatch(source_issue):
+        errors.append(f"{relative} has invalid source_issue; expected canonical GitHub Issue reference #<number>: {source_issue}")
 
     if re.search(r"^\s*- \[ \] `AC-[^`]+`.*\*\*Evidence:\*\*\s*(?:test|static check|integration|runtime|manual review)\s*$", content, re.MULTILINE) is None:
         errors.append(f"{relative} must contain at least one unchecked acceptance criterion with an Evidence class")


### PR DESCRIPTION
## Context

F2.2 — Issue ↔ Spec traceability.

## Scope

- define a canonical `#<number>` GitHub Issue reference for Specification `source_issue`
- validate malformed Issue references in the AI Factory structural validator
- add reusable Issue → Spec resolution primitives with explicit missing/ambiguous failure modes
- add focused tests for canonical references and resolution
- normalize `SPEC-0001` traceability to the GitHub Issue/PR #173

## Contract

`GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY`

A material Issue without exactly one resolvable Specification is not silently treated as implementation-ready.

## Non-goals

- no planner/task-graph implementation (F3)
- no three-flow migration (F2.3)
- no runtime application behavior changes
- no broad orchestrator rewrite

## Verification

CI must run the AI Factory artifact validation and repository tests for the new resolver.

## Traceability

F2.2 → Issue/Spec linkage → validator + resolver + tests