### PR TITLE
docs(ai-factory): specify three real flows for F2.3

### DIFF
--- a/docs/specs/SPEC-0002-order-idempotency.md
+++ b/docs/specs/SPEC-0002-order-idempotency.md
@@ -1,0 +1,120 @@
+---
+id: SPEC-0002
+status: Proposed
+version: 1
+source_issue: "#5"
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [SPEC-0002] — Order creation idempotency
+
+## Status
+
+`Proposed`. F2.3 retrospective contract for existing behavior, pending human review; this document does not reopen issue #5 or authorize runtime changes.
+
+## Problem
+
+A lost checkout response makes a buyer retry an operation that reserves unique inventory. Repeating that operation must not create another order.
+
+## Goal
+
+One committed order per authenticated customer and idempotency key, with deterministic replay or conflict across processes.
+
+## Actors
+
+Authenticated CUSTOMER, HTTP API, PostgreSQL, retrying checkout client.
+
+## Scope
+
+POST /orders key validation, canonical request identity, reservation transaction, durable replay and conflicting reuse.
+
+## Non-goals
+
+Payment capture, webhook processing, changing reservation TTL, new key retention policies, and frontend checkout changes (#82).
+
+## Business Rules
+
+- `BR-01`: Require a trimmed, nonempty Idempotency-Key of at most 128 characters.
+- `BR-02`: Scope a key to the authenticated customer. Compare SHA-256 of the versioned, sorted listing ID set; reject duplicate listing IDs before writing.
+- `BR-03`: Same key and listing set returns the original order identity, read in its current state; this is not a byte-for-byte cached HTTP response.
+- `BR-04`: Different listing set with the same customer/key returns 409 without reserving new inventory.
+- `BR-05`: Commit key, order, items, price snapshots and listing reservations together; payment is a separate workflow.
+
+## Invariants
+
+Canonical references in docs/domain/invariants.md:
+
+- `INV-ORDER-ATOMIC-CREATE`
+- `INV-LISTING-EXCLUSIVE-RESERVE`
+- `INV-ORDER-TOTAL-COMPOSITION`
+- `INV-AUTH-OWNERSHIP`
+
+## State Transitions
+
+Within one transaction: absent key → in-progress key → COMPLETED key linked to order. Failure rolls back to absent. A committed key is not reset by replay or order expiration. Listing ACTIVE → RESERVED remains conditional; replay must not reacquire an expired hold.
+
+## API / Data Contract
+
+POST /orders requires CUSTOMER authentication, Idempotency-Key and body `{ "items": [{ "listingId": "..." }] }`; items must be nonempty. DTO: server/src/modules/orders/orders.dto.ts. Controller returns 201 and the order for both creation and successful replay. Missing/oversized key or duplicate IDs returns 400. Missing listing returns 404; unavailable/trade-locked listing returns 400. Conflicting key, incomplete durable link or missing linked order returns 409. Existing authentication middleware governs 401/403.
+
+OrderIdempotencyKey has unique (customerId, key), requestHash, status and orderId; server/prisma/schema.prisma is the persistence contract. Prices and totals retain Decimal semantics.
+
+## Concurrency Model
+
+PostgreSQL unique (customerId, key) serializes matching attempts. The loser handles only that specific unique violation and reads the committed result outside the failed transaction. Other database errors propagate. Conditional ACTIVE reservation updates protect different keys competing for the same listing. No external call runs in this creation transaction.
+
+## Failure Modes
+
+Before commit, a crash or reservation failure leaves no partial order/key/hold. After commit but before response, retry resolves the linked order. An unavailable database is not interpreted as success. An incomplete or missing order link returns 409 rather than silently creating a replacement. No new automatic retries or retention cleanup are specified.
+
+## Security
+
+Derive customerId from authentication, never request ownership fields. A shared key string across customers must not disclose another customer's order. Preserve validation, rate limits and secret redaction.
+
+## Observability
+
+Existing ordersService tracing distinguishes created, idempotency_replay and idempotency_conflict. Existing appMetrics records creation, failure, replay, conflict and reservations; do not add raw keys or request bodies to logs.
+
+## Backward Compatibility
+
+Documents ADR 0003 and current code; no API, schema or migration change. Successful replay remains 201 and may reflect later order state.
+
+## Acceptance Criteria
+
+- [ ] `AC-01` — Missing/blank/oversized key and repeated listing IDs fail before business writes. **Evidence:** test
+- [ ] `AC-02` — Same customer/key and equivalent reordered listing set returns one original order. **Evidence:** integration
+- [ ] `AC-03` — Conflicting reuse returns 409 and leaves the new listing ACTIVE. **Evidence:** integration
+- [ ] `AC-04` — Two customers may use the same key without sharing results. **Evidence:** integration
+- [ ] `AC-05` — Concurrent matching attempts create exactly one order and one durable key; different requests cannot reserve the same listing twice. **Evidence:** integration
+- [ ] `AC-06` — Failure after key insertion rolls back the key and all related writes; a committed retry uses the original identity. **Evidence:** integration
+- [ ] `AC-07` — Replay does not recreate or extend reservations, and the controller preserves 201. **Evidence:** static check
+
+## Verification Strategy
+
+AC-01: server/src/modules/orders/__tests__/orders.service.test.ts plus key-boundary inspection. AC-02–06: server/src/__tests__/order.idempotency.integration.test.ts (replay, ordering, conflict, customer scope, rollback and concurrent cases). AC-07: orders.service.ts replay branch and orders.controller.ts.
+
+Run `npm --prefix server run test:unit -- src/modules/orders/__tests__/orders.service.test.ts src/modules/orders/__tests__/orders.controller.test.ts`. Against a dedicated migrated PostgreSQL test database, run `npm --prefix server run test:integration -- src/__tests__/order.idempotency.integration.test.ts`. Existing test source is a verification map, not evidence that these commands ran for F2.3. Crash boundaries additionally require transaction inspection; the replay test is not a process-kill experiment.
+
+## Decisions / References
+
+- docs/adr/0003-order-creation-idempotency.md
+- docs/domain/invariants.md
+- server/src/modules/orders/orders.service.ts
+- server/prisma/schema.prisma
+
+## Traceability
+
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+
+- Issue: #5 (original behavior); related client integration: #82
+- Spec: SPEC-0002 v1
+- Plan/Tasks: Notion F2.3; formal Plan deferred to F3
+- PR: F2.3 documentation PR, pending publication
+- Verification/Convergence: docs/verification/f2-3-real-flow-specs.md
+- Evaluation/Memory: lightweight evidence in that verification record; no F5/F6 completion claimed
+
+## Change History
+
+- v1 — Proposed retrospective contract based on main 0d43679 and issue #5 — 2026-09-06.

--- a/docs/specs/SPEC-0003-refresh-token-families.md
+++ b/docs/specs/SPEC-0003-refresh-token-families.md
@@ -1,0 +1,116 @@
+---
+id: SPEC-0003
+status: Proposed
+version: 1
+source_issue: "#57"
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [SPEC-0003] — Refresh token families
+
+## Status
+
+`Proposed`. F2.3 retrospective description of the family-rotation portion of issue #57, pending human review. No authentication guarantees change in this increment.
+
+## Problem
+
+Revoking only a rotated token leaves its successor usable after token theft or replay.
+
+## Goal
+
+Persist refresh sessions and revoke their family upon detected reuse, with one atomic rotation claim.
+
+## Actors
+
+Session owner, API authentication service, PostgreSQL, client serializing refresh requests.
+
+## Scope
+
+Session issuance, refresh rotation, reuse detection, expiration and logout family revocation.
+
+## Non-goals
+
+Changing password policy or login throttling from ADR 0015, access-token denylisting, silent retry of refresh, or introducing a new session store.
+
+## Business Rules
+
+- `BR-01`: Login and email verification issue a new family. Store token identifiers and expiry, never the raw refresh JWT.
+- `BR-02`: A valid signed refresh JWT needs an existing, unused, unrevoked, unexpired row. Rotation consumes it and inserts a successor in the same transaction/family.
+- `BR-03`: Reuse of a used/revoked row revokes the family and returns 401. A claimed row whose stored family differs from the JWT family also revokes the stored family.
+- `BR-04`: Unknown or expired rows fail with 401; an unknown row alone does not identify a stored family to revoke.
+- `BR-05`: Logout revokes the presented valid token's family. Invalid/expired logout tokens are ignored under the existing API contract; access tokens continue until TTL.
+
+## Invariants
+
+- `INV-AUTH-REFRESH-FAMILY` — docs/domain/invariants.md
+- `INV-AUTH-OWNERSHIP` — docs/domain/invariants.md
+
+## State Transitions
+
+Unused/unrevoked/unexpired → used plus unused successor in the same family. Reuse → family rows revoked. Logout → family rows revoked. Expired or revoked tokens cannot rotate back to active. New login creates a separate family, not resurrection of an old one.
+
+## API / Data Contract
+
+POST /auth/refresh takes `{ "refreshToken": "signed JWT" }` validated by refreshDto, returning 200 with user, accessToken and refreshToken on success; invalid/reused/expired tokens return 401. POST /auth/logout accepts refreshToken and returns the existing success message. See auth.routes.ts, auth.controller.ts and auth.dto.ts under server/src/modules/auth/.
+
+RefreshToken in server/prisma/schema.prisma stores unique jti, familyId, userId, expiresAt, usedAt and revokedAt. No new fields, secret formats or environment variables are introduced.
+
+## Concurrency Model
+
+Conditional update requires unused, unrevoked and expiresAt greater than now. Claim and successor insertion share a PostgreSQL transaction. Two submissions of the same predecessor are treated as reuse: at most one rotation succeeds and the resulting family is revoked. Clients must serialize refresh; rotation is intentionally not idempotent. Existing tests establish same-token races, not every possible cross-token logout/rotation interleaving.
+
+## Failure Modes
+
+Database failure before commit rolls back claim and successor together. Crash or lost response after commit leaves the predecessor used: repeating it revokes the family, requiring login. Reuse revocation commits before the service throws 401, so the error cannot roll back that revocation. Invalid signature fails before trusted token processing. Do not claim immediate invalidation of already issued access tokens.
+
+## Security
+
+Verify refresh JWT signatures and expiry before trusting identifiers. Resolve user identity from stored token ownership. Never store/log JWTs, passwords or signing secrets. Preserve auth limiter, durable login throttle and the existing password rules. Tokens from separate login families must remain isolated.
+
+## Observability
+
+The existing refresh_token_reuse warning records userId and familyId, not raw tokens. Inspect correlation/error handling without adding sensitive payloads. No claim of a dedicated refresh metric in this increment.
+
+## Backward Compatibility
+
+Retains ADR 0015's existing cutover and logout/access-TTL semantics. F2.3 changes no schema or session behavior and triggers no additional logout rollout.
+
+## Acceptance Criteria
+
+- [ ] `AC-01` — Successful rotation consumes one predecessor and creates one successor in the same family. **Evidence:** integration
+- [ ] `AC-02` — Reusing the predecessor returns 401 and its successor can no longer refresh. **Evidence:** integration
+- [ ] `AC-03` — Concurrent use of the same token leaves no live token in its family. **Evidence:** integration
+- [ ] `AC-04` — Logout prevents later refresh in that family; expired stored rows fail even with a verifying JWT. **Evidence:** integration
+- [ ] `AC-05` — An unknown row fails without inventing a family; family mismatch revokes the stored family. **Evidence:** static check
+- [ ] `AC-06` — Claim and successor commit atomically; reuse revocation commits before 401; raw JWTs are not persisted. **Evidence:** static check
+
+## Verification Strategy
+
+AC-01–04: server/src/__tests__/auth.security.integration.test.ts, supported by server/src/modules/auth/__tests__/auth.service.test.ts. AC-05–06: inspect auth.service.ts, auth.repository.ts and RefreshToken schema. Do not substitute mocked tests for PostgreSQL concurrency evidence.
+
+Run `npm --prefix server run test:unit -- src/modules/auth/__tests__/auth.service.test.ts`. With a dedicated migrated test database run `npm --prefix server run test:integration -- src/__tests__/auth.security.integration.test.ts`. F2.3 records whether commands ran separately; references alone do not mark criteria passed. Broader logout-versus-successor races require dedicated evidence before asserting a stronger guarantee.
+
+## Decisions / References
+
+- docs/adr/0015-refresh-token-families.md
+- docs/domain/invariants.md
+- server/src/modules/auth/auth.service.ts
+- server/src/modules/auth/auth.repository.ts
+- server/prisma/schema.prisma
+
+## Traceability
+
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+
+- Issue: #57 (family subset; password/throttle behavior remains governed by ADR 0015)
+- Spec: SPEC-0003 v1
+- Plan/Tasks: Notion F2.3; formal Plan deferred to F3
+- PR: F2.3 documentation PR, pending publication
+- Verification/Convergence: docs/verification/f2-3-real-flow-specs.md
+- Evaluation/Memory: lightweight evidence in that record; F5/F6 remain pending
+
+## Change History
+
+- v1 — Proposed retrospective contract based on main 0d43679 and issue #57 — 2026-09-06.

--- a/docs/specs/SPEC-0004-customer-favorites.md
+++ b/docs/specs/SPEC-0004-customer-favorites.md
@@ -1,0 +1,122 @@
+---
+id: SPEC-0004
+status: Proposed
+version: 1
+source_issue: "#106"
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [SPEC-0004] — Persisted customer favorites
+
+## Status
+
+`Proposed`. Issue #106 defines intended behavior; main 0d43679 has no Favorite model or favorites API. This is a reviewable proposal, not a claim of implementation or permission to begin the feature.
+
+## Problem
+
+Customers cannot save unique listings to their account and recover that list across reloads and devices.
+
+## Goal
+
+An authenticated CUSTOMER saves/removes a listing and sees the persisted result in their account; guests are guided through login.
+
+## Actors
+
+CUSTOMER, guest, storefront client, authenticated API, PostgreSQL.
+
+## Scope
+
+Account-owned Favorite relation; list/add/remove API; listing card and detail heart controls; /account/favorites; optimistic feedback and rollback; guest return path.
+
+## Non-goals
+
+Price alerts, outbox events, workers, sharing lists, reservations, payment changes or localStorage as account persistence. Automatic pending favorite after login is optional in #106 and is not required here.
+
+## Business Rules
+
+- `BR-01`: Derive owner from authenticated CUSTOMER identity, never from userId in client input. Favorites of another user are inaccessible.
+- `BR-02`: At most one Favorite exists per (userId, listingId); repeated POST is 200/no-op.
+- `BR-03`: Saving does not reserve or buy a listing, change availability or grant ownership.
+- `BR-04`: A saved SOLD listing remains visible with a Vendido badge and a link to related listings.
+- `BR-05`: Guest favorite intent opens login and returns to the relevant listing; persistence requires authentication.
+- `BR-06`: Optimistic toggles roll back on error; reload reads server state. Missing listings cannot be added.
+
+## Invariants
+
+- `INV-AUTH-OWNERSHIP` — private customer data remains owner-scoped.
+- `INV-LISTING-EXCLUSIVE-RESERVE` — favorites do not participate in reservation.
+- `INV-LISTING-SOLD-IRREVERSIBLE` — saving/removing never changes SOLD.
+
+These IDs come from docs/domain/invariants.md. Favorite uniqueness is the proposed BR-02, not an invented canonical invariant ID; catalog/schema/test updates belong to feature implementation.
+
+## State Transitions
+
+Not saved → saved through POST. Saved → not saved through DELETE. Repeated POST remains saved. Proposed repeated DELETE remains absent. Listing status evolves independently; SOLD does not remove a saved relation. Pending UI → confirmed on success or previous state on error.
+
+## API / Data Contract
+
+Issue-defined routes: authenticated GET /favorites, POST /favorites with `{ "listingId": "..." }`, DELETE /favorites/:listingId. Persistence requires Favorite(userId, listingId) with database uniqueness. UI route: /account/favorites.
+
+For review, proposed details complete the issue's unspecified HTTP surface: GET 200 `{ "items": [...] }` with each item carrying listingId and the existing public listing representation; POST 200 `{ "listingId": "..." }` for both create and duplicate; DELETE 204 for present or absent own favorite. Invalid listingId input returns 400, missing listing on POST returns 404, unauthenticated access returns 401, non-CUSTOMER access returns 403. Owner identity is never selectable. Response DTOs/OpenAPI must be finalized with the implementation plan; these proposed choices are not existing APIs.
+
+## Concurrency Model
+
+Use PostgreSQL uniqueness plus an atomic insert/no-op for duplicate POST, not an unchecked read-then-insert. Removal filters by authenticated user and listing ID. Concurrent identical adds leave one row; repeated removes leave none. Opposing add/remove operations have database execution order, not client click-time ordering. UI should serialize toggles per listing and reconcile with GET after uncertain outcomes. No external side effect or queue is required.
+
+## Failure Modes
+
+Lost POST response can be retried without duplicates. Lost DELETE response can be retried under the proposed absent/no-op contract. Database failure must not be shown as persisted success. UI restores prior state on error and refetches when outcome is uncertain. Sold status is not a missing listing. Hard deletion policy and eligibility for newly saving CANCELED/RESERVED listings are not defined by #106 and must be settled before this Spec is Accepted.
+
+## Security
+
+Preserve JWT authentication, CUSTOMER authorization, input validation and rate limiting. GET/DELETE are always scoped to the caller. Login return URLs must use the existing safe local redirect handling. Do not log tokens or full private favorite lists.
+
+## Observability
+
+Use existing request IDs and structured error handling for API failures. No dedicated favorites telemetry exists today; avoid claiming it. Tests must distinguish persistence errors from optimistic UI success.
+
+## Backward Compatibility
+
+Additive proposal only. Future implementation needs Prisma schema plus a new migration, ownership tests and OpenAPI updates. It must preserve listing/payment invariants and current account routes. This F2.3 change contains no migration or runtime feature.
+
+## Acceptance Criteria
+
+- [ ] `AC-01` — CUSTOMER saves a listing and sees it after reload and in a second authenticated client. **Evidence:** integration
+- [ ] `AC-02` — Repeated and concurrent POSTs return success with exactly one database relation. **Evidence:** integration
+- [ ] `AC-03` — GET/DELETE cannot disclose or mutate another customer's favorites; guests and non-CUSTOMER roles are rejected. **Evidence:** integration
+- [ ] `AC-04` — Removing a favorite survives reload; repeated DELETE succeeds under the proposed no-op contract. **Evidence:** integration
+- [ ] `AC-05` — Guest heart action reaches login and safely returns to the listing without presenting local storage as account persistence. **Evidence:** test
+- [ ] `AC-06` — Card/detail toggle shows pending state and rolls back with error feedback when the API fails. **Evidence:** test
+- [ ] `AC-07` — Saved SOLD items retain their badge and related link; saving/removing never changes listing status or reserves inventory. **Evidence:** integration
+- [ ] `AC-08` — Account list supports loading, empty, error and success states; missing listing addition fails without a relation. **Evidence:** test
+
+## Verification Strategy
+
+No favorites tests exist on the inspected main; all feature criteria above are pending. Before implementation, accept this proposal and resolve the open decisions below. Add real PostgreSQL uniqueness/concurrent-add/ownership tests for AC-01–04/07; API missing-listing checks for AC-08; client tests for AC-05/06/08. Test response-loss retries and optimistic error recovery. Run the established server integration suite against a dedicated migrated database and frontend Vitest suite once those tests exist. F2.3 itself runs the artifact validator and Issue-to-Spec discovery only.
+
+## Decisions / References
+
+- https://github.com/Bruno2K/neon-arsenal-market/issues/106
+- docs/domain/invariants.md
+- server/prisma/schema.prisma (current baseline, not a Favorite implementation)
+- src/pages/Account.tsx
+- src/lib/redirect.ts
+
+Before acceptance: approve proposed response/error shapes and repeated DELETE semantics; decide initial save eligibility for non-ACTIVE listings and behavior if a listing is physically deleted. No decision is needed to review this documentation increment; runtime implementation remains gated.
+
+## Traceability
+
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+
+- Issue: #106
+- Spec: SPEC-0004 v1
+- Plan/Tasks: Notion F2.3 conversion; feature implementation stays in #106; formal Plan deferred to F3
+- PR: F2.3 documentation PR, pending publication
+- Verification/Convergence: docs/verification/f2-3-real-flow-specs.md
+- Evaluation/Memory: lightweight evidence in that record; feature acceptance and F5/F6 remain pending
+
+## Change History
+
+- v1 — Proposed contract transcribed from #106 with additional choices explicitly marked for review — 2026-09-06.

--- a/docs/verification/f2-3-real-flow-specs.md
+++ b/docs/verification/f2-3-real-flow-specs.md
@@ -1,0 +1,38 @@
+# F2.3 — Real-flow Specification evidence
+
+Date: 2026-09-06. Baseline: main 0d43679825fdae49d5f13d46b808eaca363bb124.
+
+## Authorization and reconciliation
+
+Notion task: https://app.notion.com/p/3d3678e54c8d81bf8176cf35d6f2e53f — convert order idempotency, refresh-token family and favorites to Specs with numbered criteria and invariants. The fetched F2.2 page includes a later Done checkpoint for PR #174 despite its stale In Progress property. Fetched origin/main and its merge history independently confirm PR #174's merge commit. Its reported CI run was not independently retrieved here.
+
+Local main was 199 commits behind and updated with git pull --ff-only origin main. Original feat/p0-order-idempotency at a3ffc20 remains intact, including its local-only commit. The existing .claude worktree was preserved. No force update or history rewrite occurred.
+
+## Deliverable and scope
+
+- SPEC-0002 → issue #5: retrospective order creation contract grounded in ADR 0003, service, controller, DTO, schema and integration test cases.
+- SPEC-0003 → issue #57: retrospective refresh-family subset grounded in ADR 0015, repository conditional update, service transaction and security integration cases.
+- SPEC-0004 → issue #106: proposed unimplemented feature, separating issue requirements from additional response/error choices and unresolved lifecycle decisions.
+
+All remain Proposed pending human review. No runtime behavior, migration, orchestrator or accepted requirement changed. Specs are at docs/specs root because current validation and Issue resolution use non-recursive globbing. This avoids silently undiscoverable domain subdirectories.
+
+## Executed evidence
+
+- python scripts/ai-factory/validate.py: PASS after correcting the initial missing literal traceability chain.
+- python scripts/ai-factory/test_validate.py: PASS, 3 tests.
+- Direct resolve_spec_for_issue assertions against the real repository: #5 resolves uniquely to SPEC-0002; #57 to SPEC-0003; #106 to SPEC-0004 (unique match).
+- git diff --check: PASS, including staged check.
+
+An initial unittest discovery command failed because test_issue_spec.py imports pytest, which is not installed locally; it also exposed the traceability omission subsequently fixed. The full pytest resolver suite was not executed. The direct resolver smoke check above passed but does not replace that suite. Runtime integration and frontend test suites were not run. After npm ci --prefix server and Prisma Client regeneration (no database migration), backend typecheck passed under bundled Node v24.19.0. Focused orders.service, orders.controller and auth.service unit suites passed: 3 files, 46 tests. The first commit hook passed frontend typecheck but failed backend typecheck against stale dependencies/generated Prisma; this was corrected without disabling hooks. Integration references remain verification maps, not executed concurrency evidence.
+
+## Review and remaining gates
+
+Implementation-side review checked ownership, money, atomicity, retry/crash boundaries and Proposed status. Independent review is pending on the PR; this record does not claim self-verification satisfies that gate.
+
+Refresh same-token races have existing integration cases; this document does not claim those prove all cross-token logout races. Favorites response shapes, repeated DELETE and non-ACTIVE/deleted listing policy need acceptance before implementation. Keep F2.3 pending review/merge and do not advance to F3 from these drafts.
+
+## Lightweight evaluation and memory
+
+The contract represents two existing backend flows and one intended product flow without conflating implemented behavior with acceptance. Practical limitation: nested Specs would escape current discovery; preserve flat files until recursive support is deliberately specified/tested. The GitHub connector works for reading source issues; local gh has no authenticated session. No credentials were copied or persisted.
+
+


### PR DESCRIPTION
F2.3 converts three real Neon Arsenal flows into repository-native Specifications: order creation idempotency (`SPEC-0002`), refresh-token families (`SPEC-0003`), and persisted customer favorites (`SPEC-0004`). The first two are retrospective contracts grounded in current code and tests; favorites remains explicitly `Proposed` because the feature is not implemented and its remaining product/API decisions require review.

The change also records reconciliation and verification evidence without advancing the factory to F3.

Validation:
- `python scripts/ai-factory/validate.py`
- `python scripts/ai-factory/test_validate.py` (3 passed)
- Issue resolver smoke check for `#5`, `#57`, and `#106`
- backend typecheck
- focused backend unit tests: 46 passed
- client and server typechecks passed in the commit hook
- `git diff --cached --check`

Integration/concurrency suites were not run for this documentation-only increment; their existing test files are mapped as future acceptance evidence. Independent review and human acceptance of the proposed Specs remain the F2.3 gate.