### PR TITLE
feat(ai-factory): define the F3.1 Plan contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -72,6 +72,10 @@ Done
 
 A task must have one clear owner at a time. Reviewers do not rewrite the implementation unless explicitly assigned to do so.
 
+## Planning artifacts
+
+Material work follows the repository-native Plan contract in [`plan-contract.md`](plan-contract.md) and the canonical template in [`../templates/plan.md`](../templates/plan.md). A `Ready` Plan is bound to one accepted Specification version; executors stop and replan when that source changes materially.
+
 ## Token-efficiency rules
 
 1. Start with the smallest relevant context. Do not load the whole repository.

--- a/docs/agents/plan-contract.md
+++ b/docs/agents/plan-contract.md
@@ -1,0 +1,57 @@
+# Plan Contract
+
+## Purpose
+
+A Plan converts one Specification version into a bounded implementation strategy. A Draft may explore a Proposed Specification for review, but only an Accepted source at the exact declared version permits transition to `Ready`. The Plan records current evidence, affected boundaries, ordering, risks, tests, verification, dependencies, and stop conditions before an executor changes product behavior.
+
+The canonical structure is `docs/templates/plan.md`. Repository Plans live directly under `docs/plans/` while artifact discovery remains non-recursive.
+
+## Authority boundary
+
+The Specification defines what must become true. A Plan defines how the repository can make it true. A Plan cannot weaken acceptance criteria, invent business behavior, override an ADR or invariant, or treat current implementation defects as requirements.
+
+If implementation evidence conflicts with the source Specification, the Planner records the conflict and stops. The conflict is resolved in the authoritative artifact before the Plan becomes `Ready`.
+
+## Identity and lifecycle
+
+Every Plan has a stable `PLAN-*` ID in frontmatter and title. Required metadata is `id`, `status`, `version`, `source_spec`, `source_spec_version`, `baseline_revision`, `owner`, `created`, and `updated`. `baseline_revision` is the exact 40-character Git commit inspected by the Planner.
+
+Allowed transitions are:
+
+```text
+Draft → Ready
+Draft → Superseded
+Ready → Superseded
+```
+
+`Draft` permits analysis and review but does not authorize execution. `Ready` means hard dependencies and blocking decisions are resolved, the source Specification is `Accepted`, and its version matches `source_spec_version`. `Superseded` is terminal for that Plan version.
+
+Draft revisions update the same file and increment `version`; Git preserves their review history. Once a Plan becomes `Ready`, its content and version are immutable except for transition to `Superseded`. Material replacement receives a new globally unique `PLAN-*` ID and may name its predecessor in Change History. This matches repository uniqueness validation while retaining ready artifacts as durable evidence.
+
+If an accepted Specification changes materially, its downstream Plan cannot remain executable. Supersede it and publish a replacement with a new Plan ID bound to the new Specification version.
+
+## Reproducibility
+
+Another Planner given the same Specification and `baseline_revision` should recover the same material boundaries, invariants, hard dependencies, and acceptance evidence. File-level sequencing may differ when alternatives preserve those constraints; such choices must be recorded when they change risk or verification.
+
+Current-state claims must cite repository evidence. Unknown paths are candidates, not promised files. External behavior that cannot be verified is a dependency or stop condition.
+
+## Task graph rules
+
+The graph is directed and acyclic. Each edge means the successor cannot begin until the predecessor's output and verification are available. Sequential execution is the default.
+
+Parallel nodes are allowed only when they have disjoint write scopes, do not mutate the same invariant or database state, and neither consumes the other's output. One task has one owner at a time.
+
+F3.1 records stable Plan-side node labels and dependency edges. F3.2 owns the canonical Task identity, lifecycle, metadata, and dependency representation. Until that contract is accepted, Plan nodes are decomposition labels rather than executable Task artifacts.
+
+## Completeness rules
+
+A reviewable Plan records its source Specification ID and exact version, relevant current state and evidence, candidate files and architectural boundaries, database and transaction implications, ordered work and task dependencies, acceptance-criterion-to-test mapping, exact verification commands and environment needs, risks, mitigations, hard dependencies, stop conditions, Definition of Done, and full artifact traceability.
+
+The Planner does not implement. Discovery that changes accepted behavior, architecture, compatibility, security, payment, or consistency returns the work to Specification or HUMAN review.
+
+## Validation
+
+`python scripts/ai-factory/validate.py` validates Plan identity, metadata, lifecycle values, baseline revision, required sections, source reference format, numeric versions, and canonical traceability. Cross-reference validation rejects a missing source Specification. A `Ready` Plan additionally requires an `Accepted` source at the exact declared version.
+
+Structural validation cannot prove that the decomposition is correct or that a source Specification is substantively accepted. Review and later planner/convergence phases provide that evidence.

--- a/docs/plans/PLAN-0001-customer-favorites.md
+++ b/docs/plans/PLAN-0001-customer-favorites.md
@@ -152,7 +152,7 @@ GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE �
 - Specification: `SPEC-0004` v1 (`Proposed`)
 - Plan: `PLAN-0001` v1 (`Draft`)
 - Tasks: Plan labels only; canonical artifacts pending F3.2 and Spec acceptance
-- PR: pending F3.1 contract PR; no favorites implementation PR
+- PR: `#176` is the F3.1 contract PR; no favorites implementation PR
 - Verification/Convergence: F3.1 structural evidence only; feature evidence pending
 - Evaluation: pending F5
 - Memory: pending F6

--- a/docs/plans/PLAN-0001-customer-favorites.md
+++ b/docs/plans/PLAN-0001-customer-favorites.md
@@ -1,0 +1,162 @@
+---
+id: PLAN-0001
+status: Draft
+version: 1
+source_spec: SPEC-0004
+source_spec_version: 1
+baseline_revision: 232c2922eca1eadc7deccf4d6509da0430566010
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [PLAN-0001] — Persisted customer favorites
+
+## Status
+
+`Draft`. `SPEC-0004` v1 remains `Proposed`, and its listing-eligibility, deletion, and final response-contract decisions are unresolved. This Plan is a reproducible decomposition example for F3.1; it does not authorize implementation.
+
+## Source
+
+- Specification: `SPEC-0004` v1 (`Proposed`)
+- Issue: `#106`
+- Planning task: F3.1 — Definir contrato de Plan
+- Baseline: `232c2922eca1eadc7deccf4d6509da0430566010`
+
+## Current State
+
+Repository search at the baseline finds no Favorite model, module, route, API client, account page, or favorite tests. `server/prisma/schema.prisma` has User and Listing but no persisted relation for this behavior. The backend follows controller → service → repository modules under `server/src/modules/`; listings and users provide adjacent conventions.
+
+The frontend renders listings through `src/components/ProductCard.tsx`, detail in `src/pages/ListingDetail.tsx`, protected account routes in `src/App.tsx`, and account navigation in `src/pages/Account.tsx` and `src/components/Header.tsx`. Existing tests cover ListingCard, ListingDetail, Account, and routing. React Query and the authenticated API client are already dependencies. `src/lib/redirect.ts` is the existing safe redirect boundary.
+
+## Goal
+
+Once the source Specification is accepted, deliver account-owned persisted favorites across the API, listing surfaces, and account page while preserving listing lifecycle and ownership invariants.
+
+## Affected Areas
+
+Candidate backend files:
+
+- `server/prisma/schema.prisma` and a new immutable migration.
+- A new `server/src/modules/favorites/` controller, DTO, service, repository, routes, and focused tests.
+- Server route registration and `server/src/shared/docs/openapi.ts`.
+- PostgreSQL integration tests for uniqueness, ownership, retries, and listing status independence.
+
+Candidate frontend files:
+
+- A new favorites API module and query/mutation hook or the nearest established equivalent.
+- `src/components/ProductCard.tsx` and `src/pages/ListingDetail.tsx` for toggle entry points.
+- A new account favorites page plus routes/navigation in `src/App.tsx`, `src/pages/Account.tsx`, and possibly `src/components/Header.tsx`.
+- Existing adjacent test suites and new page/API tests.
+
+Exact new filenames remain candidates until the accepted contract and F3.2 Task scopes exist.
+
+## Architecture
+
+Add a favorites domain module within the modular monolith. HTTP handlers validate and authenticate, the service owns business rules, the repository owns Prisma access, and PostgreSQL is the source of truth. Frontend state uses the existing API and React Query boundaries. No cache, queue, outbox, worker, microservice, or external provider is justified by `SPEC-0004`.
+
+`INV-AUTH-OWNERSHIP` governs all reads and mutations. Favorite writes never call reservation/payment services and never mutate Listing status, preserving `INV-LISTING-EXCLUSIVE-RESERVE` and `INV-LISTING-SOLD-IRREVERSIBLE`.
+
+## Database
+
+The intended relation is one Favorite row per authenticated customer and listing, protected by a database unique constraint on `(userId, listingId)` and foreign keys. The migration must be new and must not edit applied migrations.
+
+The accepted Specification must decide physical listing deletion behavior before the foreign-key action is selected. The Plan therefore does not choose cascade, restrict, or soft-delete semantics. Duplicate POST must use an atomic insert/no-op or catch only the exact uniqueness conflict; a read-before-insert alone is insufficient under concurrency. GET and DELETE filter by caller identity. No multi-aggregate transaction is expected, but integration tests must prove concurrent add and listing-state independence.
+
+## Implementation Sequence
+
+1. Resolve the open product/API decisions in `SPEC-0004`, accept its exact version, and re-evaluate this Draft against that version.
+2. After F3.2 defines Task artifacts, split backend persistence/API, backend integration evidence, frontend client/toggle, account experience, and end-to-end verification into bounded nodes.
+3. Implement schema and repository/service invariants, then API registration and OpenAPI contracts.
+4. Prove database uniqueness, ownership, idempotent retry, delete semantics, missing-listing behavior, and no Listing status mutation with PostgreSQL integration tests.
+5. Implement the client contract and server-backed state, then listing-card/detail toggles and the protected account page.
+6. Add optimistic rollback, guest safe-return, loading/empty/error/sold states, and focused frontend tests.
+7. Run narrow checks first, then integration, typecheck, lint/build and independent convergence against every accepted criterion.
+
+## Task Graph
+
+These are Plan decomposition labels, not canonical Task artifacts:
+
+```text
+FAV-A Spec decisions/acceptance → FAV-B Schema/API → FAV-C Backend integration evidence
+                              FAV-B → FAV-D Client state → FAV-E Listing toggles
+                                                  FAV-D → FAV-F Account page
+                              FAV-C + FAV-E + FAV-F → FAV-G Convergence/verification
+```
+
+FAV-E and FAV-F may run in parallel only after FAV-D stabilizes the client interface and their write scopes are made disjoint. Backend schema/API and its integration tests remain sequential because they share persistence contracts. F3.2 will decide canonical Task IDs, ownership metadata, and dependency representation.
+
+## Testing Strategy
+
+- `SPEC-0004` AC-01/02/04: PostgreSQL integration tests for persistence across clients, unique concurrent add, repeated POST, removal, and repeated DELETE under the accepted contract.
+- AC-03: authenticated route/service integration tests for CUSTOMER ownership, guest 401, non-CUSTOMER 403, and cross-user isolation.
+- AC-05: browser/component route test for guest login and safe return without account persistence in local storage.
+- AC-06: component tests for pending state, one in-flight mutation, rollback and error feedback.
+- AC-07: integration assertion that add/remove leaves Listing status unchanged; UI test retains SOLD badge and related navigation.
+- AC-08: account-page tests for loading, empty, error and success plus API test for missing listing.
+
+Tests that depend on uniqueness and concurrent writes use real PostgreSQL. Mocked repository tests may cover service branching but cannot replace database evidence.
+
+## Verification Strategy
+
+Commands remain provisional until F3.2 binds them to concrete Tasks:
+
+- `npm --prefix server run typecheck`
+- focused backend unit tests under the future favorites module
+- `npm --prefix server run test:integration -- <favorites integration files>` against a dedicated migrated PostgreSQL database
+- `npm run typecheck`, focused frontend Vitest files, `npm run lint`, and `npm run build`
+- `python scripts/ai-factory/validate.py`
+
+The verifier maps each accepted AC to executed output, inspects the migration and ownership predicates, and checks that no client-only persistence is presented as account state. Placeholder test paths must be replaced with exact commands before this Plan can become `Ready`.
+
+## Risks
+
+- Cross-user disclosure or deletion. Mitigation: derive user from auth and include it in every repository predicate; verify with two-user integration cases.
+- Duplicate concurrent rows. Mitigation: database uniqueness plus atomic conflict handling; verify simultaneous POST.
+- Listing lifecycle coupling. Mitigation: Favorite operations write only the relation; assert Listing status before/after.
+- Optimistic UI diverges after network ambiguity. Mitigation: serialize per-listing mutations, roll back known failures, and refetch after uncertain outcomes.
+- Unsafe guest return URL. Mitigation: use the existing local redirect helper and route tests.
+- Physical deletion semantics could cause data loss or stale references. Mitigation: keep this Plan Draft until the Spec selects behavior and migration rollback implications are reviewed.
+- Scope could expand into alerts or event processing. Mitigation: preserve explicit non-goals and stop on outbox/worker proposals.
+
+Residual risk: the exact public response representation and listing eligibility can change the DTO, migration policy, and UI states. Those are Specification decisions, not implementation choices.
+
+## Dependencies
+
+- Human acceptance of `SPEC-0004` and its response/error, repeated DELETE, non-ACTIVE eligibility, and physical deletion decisions.
+- A new Plan revision or replacement bound to the accepted Specification version.
+- F3.2 Task contract before executable task artifacts are emitted.
+- Dedicated PostgreSQL test database with migrations applied for concurrency evidence.
+- Existing authentication, Listing representation, React Query, account routing, and safe redirect helper remain available at implementation baseline.
+
+## Stop Conditions
+
+Stop if the accepted Specification changes from v1, a Favorite operation needs to mutate reservation/payment/listing status, ownership cannot be enforced in repository predicates, deletion behavior remains unresolved when writing the migration, exact API behavior conflicts with existing public contracts, or the work requires alerts, workers, queues, or another service. Return to HUMAN for the product decisions explicitly listed in `SPEC-0004`.
+
+## Definition of Done
+
+- Source Specification is Accepted and this Plan has been re-evaluated against its exact version and implementation baseline.
+- F3.2-derived Tasks cover all accepted criteria with explicit dependencies and one owner each.
+- Schema, API, UI, OpenAPI and documentation implement only the accepted scope.
+- PostgreSQL and frontend evidence proves every accepted criterion, including races, ownership and rollback.
+- Typecheck, relevant tests, lint/build, artifact validation, risk review and independent convergence pass.
+- PR and evidence preserve Issue → Spec → Plan → Task traceability without relying on chat context.
+
+## Traceability
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+- Issue: `#106`
+- Specification: `SPEC-0004` v1 (`Proposed`)
+- Plan: `PLAN-0001` v1 (`Draft`)
+- Tasks: Plan labels only; canonical artifacts pending F3.2 and Spec acceptance
+- PR: pending F3.1 contract PR; no favorites implementation PR
+- Verification/Convergence: F3.1 structural evidence only; feature evidence pending
+- Evaluation: pending F5
+- Memory: pending F6
+
+## Change History
+
+- `v1` — Initial Draft example from baseline `232c2922eca1eadc7deccf4d6509da0430566010`; blocked on `SPEC-0004` acceptance — 2026-09-06

--- a/docs/templates/plan.md
+++ b/docs/templates/plan.md
@@ -1,63 +1,109 @@
-# [PLAN-ID] — Title
+---
+id: PLAN-EXAMPLE-001
+status: Draft
+version: 1
+source_spec: SPEC-EXAMPLE-001
+source_spec_version: 1
+baseline_revision: 0000000000000000000000000000000000000000
+owner: "team"
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# [PLAN-EXAMPLE-001] — Title
+
+## Status
+
+`Draft` | `Ready` | `Superseded`
+
+A Plan becomes executable only when it is `Ready`, its source Specification is `Accepted`, and `source_spec_version` still matches that Specification.
 
 ## Source
 
-- Specification: [SPEC-ID]
-- Issue: #...
+- Specification: `SPEC-EXAMPLE-001` v1
+- Issue: `#...`
+- Planning task: `...`
+
+The Plan derives implementation work from the Specification. It may narrow implementation choices but must not add, remove, or reinterpret acceptance criteria.
 
 ## Current State
 
-Relevant existing behavior and constraints.
+Describe relevant executable behavior, tests, constraints, gaps, and evidence inspected. Distinguish observed facts from assumptions.
 
 ## Goal
 
-Implementation outcome, without redefining the Spec.
+State the implementation outcome this Plan will deliver without redefining the Specification.
 
 ## Affected Areas
 
-Modules, files, schema, API contracts and infrastructure.
+List candidate modules, files, schema, migrations, API contracts, documentation, infrastructure, and ownership boundaries. Mark uncertain paths as candidates.
 
 ## Architecture
 
-How the change fits the existing architecture and dependency direction.
+Explain how the change fits existing dependency direction, repository boundaries, ADRs, and invariants. State whether a new ADR is required.
 
 ## Database
 
-Schema/migration/transaction implications when applicable.
+Describe schema, migration, transaction, locking, constraint, rollback, and reconciliation implications. Use `None` with evidence when the Plan has no database impact.
 
 ## Implementation Sequence
 
-1. ...
-2. ...
-3. ...
+1. Describe the smallest reviewable unit and its output.
+2. Make dependencies and verification points explicit.
+3. Stop at the Specification boundary.
 
 ## Task Graph
+
+Use stable node labels and explicit directed edges. F3.1 defines only the Plan-side graph. F3.2 will define canonical Task identity and dependency representation; do not preempt that contract here.
 
 ```text
 Task A → Task B → Task D
        ↘ Task C ↗
 ```
 
+State which nodes may run in parallel and why their files and invariants do not overlap. Default to sequential execution.
+
 ## Testing Strategy
 
-Unit, integration, concurrency, security, contract, browser and operational checks as applicable.
+Map the source Specification's acceptance criteria to unit, integration, concurrency, security, contract, browser, and operational tests as applicable. Existing tests are evidence only when they prove the criterion.
 
 ## Verification Strategy
 
-Exact commands and acceptance evidence.
+List exact commands, required environment, evidence outputs, and the independent verifier. Separate checks that can run locally from checks that require CI, PostgreSQL, credentials, or manual review.
 
 ## Risks
 
-Material technical risks and mitigations.
+For each material risk, record impact, mitigation, detection evidence, and residual risk. Include consistency, failure, security, compatibility, and scope risks as applicable.
 
 ## Dependencies
 
-Tasks, decisions or external capabilities that must exist first.
+List accepted decisions, upstream artifacts, external capabilities, task predecessors, and environment requirements. A missing hard dependency keeps the Plan in `Draft`.
 
 ## Stop Conditions
 
-Conditions requiring HUMAN escalation.
+List conditions that require HUMAN escalation, replanning, or a new Specification version. Include source-Spec changes, conflicting authoritative artifacts, destructive operations without rollback, and material scope expansion.
 
 ## Definition of Done
 
-Observable conditions proving that the Plan has been executed without silently expanding scope.
+Define observable conditions proving all planned work and verification are complete. Include traceability, review, documentation, and evidence requirements; do not equate compilation with completion.
+
+## Traceability
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+- Issue: `#...`
+- Specification: `SPEC-EXAMPLE-001` v1
+- Plan: `PLAN-EXAMPLE-001` v1
+- Tasks: pending F3.2
+- PR: pending
+- Verification/Convergence: pending
+- Evaluation: pending
+- Memory: pending
+
+## Change History
+
+Draft revisions update this file and increment `version`. Once a Plan becomes `Ready`, its content and version are immutable except for transition to `Superseded`. Material replacement uses a new `PLAN-*` ID, preserving uniqueness and history.
+
+- `v1` — Initial draft — YYYY-MM-DD

--- a/docs/verification/f3-1-plan-contract.md
+++ b/docs/verification/f3-1-plan-contract.md
@@ -1,0 +1,34 @@
+# F3.1 — Plan contract evidence
+
+Date: 2026-09-06. Baseline: `232c2922eca1eadc7deccf4d6509da0430566010`.
+
+## Authorization and gate
+
+The user explicitly authorized starting F3 after PR `#175` merged. The Notion F2.3 item was reconciled to Done with its merge evidence, and F3.1 was set to In Progress. This increment implements only F3.1: Plan contract plus one real example. F3.2 Task semantics and F3.3 planner automation remain outside the diff.
+
+## Artifacts
+
+- `docs/agents/plan-contract.md` defines authority, lifecycle, reproducibility, graph rules, completeness and validation limits.
+- `docs/templates/plan.md` carries the canonical metadata and required sections.
+- `PLAN-0001` v1 is a real Draft for customer favorites, bound to Proposed `SPEC-0004` v1 and the exact inspected Git revision. It demonstrates that planning may proceed for review while execution remains blocked.
+- `scripts/ai-factory/validate.py` validates Plan structure, source lifecycle/version, and that the baseline resolves to a repository commit.
+- `scripts/ai-factory/test_validate.py` contains focused lifecycle and regression cases.
+
+## Executed evidence
+
+- `python -m py_compile scripts/ai-factory/validate.py scripts/ai-factory/test_validate.py`: PASS.
+- `python scripts/ai-factory/validate.py`: PASS; templates, IDs, Specification contracts, Plan contracts and internal references valid.
+- `python scripts/ai-factory/test_validate.py`: PASS, 10 tests.
+- `git diff --check`: PASS.
+
+The first validator run found that a path such as `PLAN-0001-plan-contract...` was extracted as the invalid reference `PLAN-0001-`. F3.1 fixed reference extraction to trim path and prose punctuation suffixes, tightened canonical IDs to end in an alphanumeric character, and added a regression test. Verification review then found that substring checks accepted wrong-level, suffixed, or fenced headings; exact outside-fence matching and regression cases now close that gap. The checks above are after both corrections.
+
+The repository commit hook and CI results are pending at this checkpoint. Runtime, frontend, database and PostgreSQL integration suites are not required by this documentation and dependency-free validator change; the commit hook still enforces client and server typechecks.
+
+## Review boundary
+
+Structural validation cannot judge whether a decomposition is substantively correct. It now proves that a Ready Plan names an existing Accepted Specification at the matching numeric version, records a resolvable baseline commit, and contains exact canonical headings outside code fences. Draft Plans may explore Proposed Specifications but cannot authorize execution. The first architecture review rejected a self-authorizing Ready example based on `SPEC-0001`; the corrected example is Draft against `SPEC-0004`, defines no F3.2 Task metadata, and resolves revision history through immutable Ready IDs. The factory CI checkout fetches full history so committed baselines remain resolvable there.
+
+## Remaining gate
+
+F3.1 becomes Done only after review findings are resolved, the commit hook and CI pass, and the PR merges. Do not start F3.2 from this evidence alone.

--- a/docs/verification/f3-1-plan-contract.md
+++ b/docs/verification/f3-1-plan-contract.md
@@ -23,7 +23,7 @@ The user explicitly authorized starting F3 after PR `#175` merged. The Notion F2
 
 The first validator run found that a path such as `PLAN-0001-plan-contract...` was extracted as the invalid reference `PLAN-0001-`. F3.1 fixed reference extraction to trim path and prose punctuation suffixes, tightened canonical IDs to end in an alphanumeric character, and added a regression test. Verification review then found that substring checks accepted wrong-level, suffixed, or fenced headings; exact outside-fence matching and regression cases now close that gap. The checks above are after both corrections.
 
-The repository commit hook passed client and server typechecks. PR `#176` is open; CI results are pending at this checkpoint. Runtime, frontend, database and PostgreSQL integration suites are not required by this documentation and dependency-free validator change.
+The repository commit hook passed client and server typechecks. GitHub Actions CI run `#197` (`34041581197`) passed all jobs for head `e1e3360a00e317f4500742d664692f317ff1e9d4`: AI Factory validation/tests, frontend lint/typecheck/unit tests, backend typecheck/unit/PostgreSQL integration tests, and frontend build. This evidence-only follow-up changes no contract or validator behavior and receives its own CI run.
 
 ## Review boundary
 
@@ -31,4 +31,4 @@ Structural validation cannot judge whether a decomposition is substantively corr
 
 ## Remaining gate
 
-Architecture and verification reviewers reported no remaining blockers after the corrections. F3.1 becomes Done only after CI passes and PR `#176` merges. Do not start F3.2 from this evidence alone.
+Architecture and verification reviewers reported no remaining blockers after the corrections. F3.1 becomes Done only after PR `#176` merges. Do not start F3.2 from this evidence alone.

--- a/docs/verification/f3-1-plan-contract.md
+++ b/docs/verification/f3-1-plan-contract.md
@@ -23,7 +23,7 @@ The user explicitly authorized starting F3 after PR `#175` merged. The Notion F2
 
 The first validator run found that a path such as `PLAN-0001-plan-contract...` was extracted as the invalid reference `PLAN-0001-`. F3.1 fixed reference extraction to trim path and prose punctuation suffixes, tightened canonical IDs to end in an alphanumeric character, and added a regression test. Verification review then found that substring checks accepted wrong-level, suffixed, or fenced headings; exact outside-fence matching and regression cases now close that gap. The checks above are after both corrections.
 
-The repository commit hook and CI results are pending at this checkpoint. Runtime, frontend, database and PostgreSQL integration suites are not required by this documentation and dependency-free validator change; the commit hook still enforces client and server typechecks.
+The repository commit hook passed client and server typechecks. PR `#176` is open; CI results are pending at this checkpoint. Runtime, frontend, database and PostgreSQL integration suites are not required by this documentation and dependency-free validator change.
 
 ## Review boundary
 
@@ -31,4 +31,4 @@ Structural validation cannot judge whether a decomposition is substantively corr
 
 ## Remaining gate
 
-F3.1 becomes Done only after review findings are resolved, the commit hook and CI pass, and the PR merges. Do not start F3.2 from this evidence alone.
+Architecture and verification reviewers reported no remaining blockers after the corrections. F3.1 becomes Done only after CI passes and PR `#176` merges. Do not start F3.2 from this evidence alone.

--- a/scripts/ai-factory/test_validate.py
+++ b/scripts/ai-factory/test_validate.py
@@ -7,13 +7,37 @@ import sys
 import unittest
 from pathlib import Path
 
-from validate import ID_PATTERNS, TEMPLATES
+from validate import (
+    ID_PATTERNS,
+    TEMPLATES,
+    TRACEABILITY_CHAIN,
+    artifact_references,
+    has_markdown_heading,
+    validate_plan,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 VALIDATOR = ROOT / "scripts" / "ai-factory" / "validate.py"
 
 
 class ValidatorTests(unittest.TestCase):
+    def valid_plan(self, **overrides: str) -> str:
+        metadata = {
+            "id": "PLAN-TEST-001",
+            "status": "Ready",
+            "version": "1",
+            "source_spec": "SPEC-0001",
+            "source_spec_version": "1",
+            "baseline_revision": "232c2922eca1eadc7deccf4d6509da0430566010",
+            "owner": "test",
+            "created": "2026-09-06",
+            "updated": "2026-09-06",
+        }
+        metadata.update(overrides)
+        frontmatter = "\n".join(f"{key}: {value}" for key, value in metadata.items())
+        headings = "\n\n".join(f"{heading}\n\nContent." for heading in TEMPLATES["plan.md"])
+        return f"---\n{frontmatter}\n---\n\n# [PLAN-TEST-001] — Test\n\n{headings}\n\n{TRACEABILITY_CHAIN}\n"
+
     def test_canonical_id_patterns(self) -> None:
         valid = {
             "specs": "SPEC-ORDERS-001",
@@ -27,6 +51,17 @@ class ValidatorTests(unittest.TestCase):
 
         self.assertNotRegex("SPEC-orders-001", ID_PATTERNS["specs"])
         self.assertNotRegex("ORDER-001", ID_PATTERNS["specs"])
+        self.assertNotRegex("PLAN-ORDERS-", ID_PATTERNS["plans"])
+
+    def test_artifact_reference_extraction_trims_paths_and_punctuation(self) -> None:
+        content = "docs/plans/PLAN-0001-plan.md references PLAN-0001."
+        self.assertEqual(artifact_references(content, "PLAN-"), ["PLAN-0001"])
+
+    def test_heading_match_is_exact_and_ignores_fences(self) -> None:
+        self.assertTrue(has_markdown_heading("## Database\n", "## Database"))
+        self.assertFalse(has_markdown_heading("### Database\n", "## Database"))
+        self.assertFalse(has_markdown_heading("## Database extra\n", "## Database"))
+        self.assertFalse(has_markdown_heading("```text\n## Database\n```\n", "## Database"))
 
     def test_template_contracts_are_non_empty(self) -> None:
         for filename, headings in TEMPLATES.items():
@@ -35,6 +70,109 @@ class ValidatorTests(unittest.TestCase):
             content = path.read_text(encoding="utf-8")
             for heading in headings:
                 self.assertIn(heading, content)
+
+    def test_valid_ready_plan_matches_accepted_source_version(self) -> None:
+        errors: list[str] = []
+        validate_plan(Path("plan.md"), self.valid_plan(), "PLAN-TEST-001", errors)
+        self.assertEqual(errors, [])
+
+    def test_plan_rejects_invalid_status_and_source_version(self) -> None:
+        errors: list[str] = []
+        content = self.valid_plan(status="Executing", source_spec_version="2")
+        validate_plan(Path("plan.md"), content, "PLAN-TEST-001", errors)
+        self.assertIn("plan.md has invalid Plan status: Executing", errors)
+
+        errors = []
+        validate_plan(
+            Path("plan.md"),
+            self.valid_plan(source_spec_version="2"),
+            "PLAN-TEST-001",
+            errors,
+        )
+        self.assertTrue(any("does not match SPEC-0001 version 1" in error for error in errors))
+
+    def test_ready_plan_requires_an_accepted_source_specification(self) -> None:
+        errors: list[str] = []
+        validate_plan(
+            Path("plan.md"),
+            self.valid_plan(source_spec="SPEC-0004"),
+            "PLAN-TEST-001",
+            errors,
+        )
+        self.assertIn("plan.md is Ready but source Specification SPEC-0004 is not Accepted", errors)
+
+        errors = []
+        validate_plan(
+            Path("plan.md"),
+            self.valid_plan(status="Draft", source_spec="SPEC-0004"),
+            "PLAN-TEST-001",
+            errors,
+        )
+        self.assertEqual(errors, [])
+
+    def test_plan_rejects_malformed_source_metadata(self) -> None:
+        errors: list[str] = []
+        validate_plan(
+            Path("plan.md"),
+            self.valid_plan(source_spec="spec-0001", source_spec_version="latest"),
+            "PLAN-TEST-001",
+            errors,
+        )
+        self.assertIn("plan.md has invalid source_spec: spec-0001", errors)
+        self.assertIn("plan.md has non-numeric Plan source_spec_version: latest", errors)
+
+        errors = []
+        validate_plan(
+            Path("plan.md"),
+            self.valid_plan(baseline_revision="main"),
+            "PLAN-TEST-001",
+            errors,
+        )
+        self.assertIn(
+            "plan.md has invalid baseline_revision; expected a 40-character Git commit",
+            errors,
+        )
+
+        errors = []
+        missing_commit = "0" * 40
+        validate_plan(
+            Path("plan.md"),
+            self.valid_plan(baseline_revision=missing_commit),
+            "PLAN-TEST-001",
+            errors,
+        )
+        self.assertIn(
+            f"plan.md baseline_revision does not resolve to a repository commit: {missing_commit}",
+            errors,
+        )
+
+    def test_plan_requires_metadata_sections_and_traceability(self) -> None:
+        errors: list[str] = []
+        content = self.valid_plan(owner="").replace("## Database", "## Data")
+        content = content.replace(TRACEABILITY_CHAIN, "Issue to implementation")
+        validate_plan(Path("plan.md"), content, "PLAN-TEST-001", errors)
+        self.assertIn("plan.md missing required Plan frontmatter field: owner", errors)
+        self.assertIn("plan.md missing required Plan heading: ## Database", errors)
+        self.assertIn("plan.md is missing the canonical traceability chain", errors)
+
+        for replacement in ("### Database", "## Database extra"):
+            with self.subTest(replacement=replacement):
+                errors = []
+                validate_plan(
+                    Path("plan.md"),
+                    self.valid_plan().replace("## Database", replacement),
+                    "PLAN-TEST-001",
+                    errors,
+                )
+                self.assertIn("plan.md missing required Plan heading: ## Database", errors)
+
+        errors = []
+        fenced_only = self.valid_plan().replace(
+            "## Database\n\nContent.",
+            "```text\n## Database\n```",
+        )
+        validate_plan(Path("plan.md"), fenced_only, "PLAN-TEST-001", errors)
+        self.assertIn("plan.md missing required Plan heading: ## Database", errors)
 
     def test_repository_validation_passes(self) -> None:
         result = subprocess.run(

--- a/scripts/ai-factory/validate.py
+++ b/scripts/ai-factory/validate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -17,7 +18,14 @@ TEMPLATES = {
         "## Verification Strategy", "## Decisions / References", "## Traceability",
         "## Change History",
     ],
-    "plan.md": ["## Source", "## Current State", "## Goal", "## Affected Areas", "## Implementation Sequence", "## Task Graph", "## Testing Strategy", "## Verification Strategy", "## Risks", "## Definition of Done"],
+    "plan.md": [
+        "## Status", "## Source", "## Current State", "## Goal",
+        "## Affected Areas", "## Architecture", "## Database",
+        "## Implementation Sequence", "## Task Graph", "## Testing Strategy",
+        "## Verification Strategy", "## Risks", "## Dependencies",
+        "## Stop Conditions", "## Definition of Done", "## Traceability",
+        "## Change History",
+    ],
     "task.md": ["## Source", "## Objective", "## Scope", "## Preconditions", "## Acceptance Criteria", "## Dependencies", "## Verification Command", "## Expected Evidence"],
     "evaluation.md": ["## Execution", "## Outcome", "## Software Quality", "## Agent Execution Quality", "## Evidence", "## Findings", "## Learning Candidates"],
     "memory.md": ["## Status", "## Confidence", "## Statement", "## Evidence", "## Affected Areas", "## Last Verified", "## Agent Guidance"],
@@ -27,10 +35,39 @@ ID_PATTERNS = {
     k: re.compile(rf"^{p}-[A-Z0-9][A-Z0-9._-]*$")
     for k, p in {"specs": "SPEC", "plans": "PLAN", "tasks": "TASK", "evaluations": "EVAL", "memory": "MEM"}.items()
 }
+ID_PATTERNS["plans"] = re.compile(r"^PLAN-[A-Z0-9](?:[A-Z0-9._-]*[A-Z0-9])?$")
 
 FRONTMATTER_REQUIRED = ("id", "status", "version", "source_issue", "owner", "created", "updated")
 VALID_SPEC_STATUSES = {"Proposed", "Accepted", "Superseded"}
+PLAN_FRONTMATTER_REQUIRED = (
+    "id", "status", "version", "source_spec", "source_spec_version",
+    "baseline_revision", "owner", "created", "updated",
+)
+VALID_PLAN_STATUSES = {"Draft", "Ready", "Superseded"}
 GITHUB_ISSUE_REF = re.compile(r"^#[1-9][0-9]*$")
+SPEC_REF = re.compile(r"^SPEC-[A-Z0-9](?:[A-Z0-9._-]*[A-Z0-9])?$")
+GIT_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+TRACEABILITY_CHAIN = "GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY"
+
+
+def has_markdown_heading(content: str, heading: str) -> bool:
+    """Match an exact Markdown heading line outside fenced code blocks."""
+    in_fence = False
+    fence_marker = ""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            continue
+        if not in_fence and line.rstrip() == heading:
+            return True
+    return False
 
 
 def validate_templates(errors: list[str]) -> None:
@@ -41,7 +78,7 @@ def validate_templates(errors: list[str]) -> None:
             continue
         content = path.read_text(encoding="utf-8")
         for heading in headings:
-            if heading not in content:
+            if not has_markdown_heading(content, heading):
                 errors.append(f"{path.relative_to(ROOT)} missing required heading: {heading}")
 
 
@@ -80,6 +117,8 @@ def validate_artifacts(kind: str, errors: list[str]) -> set[str]:
 
         if kind == "specs":
             validate_spec(path, content, value, errors)
+        elif kind == "plans":
+            validate_plan(path, content, value, errors)
 
     return ids
 
@@ -112,8 +151,97 @@ def validate_spec(path: Path, content: str, title_id: str, errors: list[str]) ->
     if re.search(r"^\s*- \[ \] `AC-[^`]+`.*\*\*Evidence:\*\*\s*(?:test|static check|integration|runtime|manual review)\s*$", content, re.MULTILINE) is None:
         errors.append(f"{relative} must contain at least one unchecked acceptance criterion with an Evidence class")
 
-    if "GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY" not in content:
+    if TRACEABILITY_CHAIN not in content:
         errors.append(f"{relative} is missing the canonical traceability chain")
+
+
+def validate_plan(path: Path, content: str, title_id: str, errors: list[str]) -> None:
+    frontmatter = parse_frontmatter(content)
+    try:
+        relative: Path | str = path.relative_to(ROOT)
+    except ValueError:
+        relative = path
+    if frontmatter is None:
+        errors.append(f"{relative} has no YAML frontmatter")
+        return
+
+    for field in PLAN_FRONTMATTER_REQUIRED:
+        if not frontmatter.get(field):
+            errors.append(f"{relative} missing required Plan frontmatter field: {field}")
+
+    if frontmatter.get("id") and frontmatter["id"] != title_id:
+        errors.append(f"{relative} frontmatter id {frontmatter['id']} does not match title ID {title_id}")
+
+    status = frontmatter.get("status")
+    if status and status not in VALID_PLAN_STATUSES:
+        errors.append(f"{relative} has invalid Plan status: {status}")
+
+    for field in ("version", "source_spec_version"):
+        if frontmatter.get(field) and not frontmatter[field].isdigit():
+            errors.append(f"{relative} has non-numeric Plan {field}: {frontmatter[field]}")
+
+    source_spec = frontmatter.get("source_spec")
+    if source_spec and not SPEC_REF.fullmatch(source_spec):
+        errors.append(f"{relative} has invalid source_spec: {source_spec}")
+
+    baseline_revision = frontmatter.get("baseline_revision")
+    if baseline_revision and not GIT_COMMIT.fullmatch(baseline_revision):
+        errors.append(f"{relative} has invalid baseline_revision; expected a 40-character Git commit")
+    elif baseline_revision:
+        result = subprocess.run(
+            [
+                "git",
+                "-c",
+                f"safe.directory={ROOT.resolve().as_posix()}",
+                "cat-file",
+                "-e",
+                f"{baseline_revision}^{{commit}}",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "unknown Git error"
+            missing_object = any(
+                marker in result.stderr.lower()
+                for marker in ("not a valid object", "bad object", "unknown revision")
+            )
+            if missing_object:
+                errors.append(
+                    f"{relative} baseline_revision does not resolve to a repository commit: {baseline_revision}"
+                )
+            else:
+                errors.append(f"{relative} could not verify baseline_revision with Git: {detail}")
+
+    for heading in TEMPLATES["plan.md"]:
+        if not has_markdown_heading(content, heading):
+            errors.append(f"{relative} missing required Plan heading: {heading}")
+
+    if TRACEABILITY_CHAIN not in content:
+        errors.append(f"{relative} is missing the canonical traceability chain")
+
+    if status != "Ready" or not source_spec or not frontmatter.get("source_spec_version"):
+        return
+
+    source_metadata = None
+    for spec_path in sorted((ROOT / "docs" / "specs").glob("*.md")):
+        candidate = parse_frontmatter(spec_path.read_text(encoding="utf-8"))
+        if candidate and candidate.get("id") == source_spec:
+            source_metadata = candidate
+            break
+    if source_metadata is None:
+        return  # Cross-reference validation reports the missing Specification.
+    if source_metadata.get("status") != "Accepted":
+        errors.append(f"{relative} is Ready but source Specification {source_spec} is not Accepted")
+    if source_metadata.get("version") != frontmatter["source_spec_version"]:
+        errors.append(
+            f"{relative} source_spec_version {frontmatter['source_spec_version']} does not match "
+            f"{source_spec} version {source_metadata.get('version', '<missing>')}"
+        )
 
 
 def validate_references(errors: list[str]) -> None:
@@ -130,9 +258,15 @@ def validate_references(errors: list[str]) -> None:
             continue
         content = path.read_text(encoding="utf-8")
         for prefix, ids in known.items():
-            for ref in sorted(set(re.findall(rf"{prefix}[A-Z0-9][A-Z0-9._-]*", content))):
+            for ref in artifact_references(content, prefix):
                 if ref not in ids:
                     errors.append(f"{path.relative_to(ROOT)} references missing {prefix[:-1]}: {ref}")
+
+
+def artifact_references(content: str, prefix: str) -> list[str]:
+    """Extract canonical-looking references without swallowing path/punctuation suffixes."""
+    raw = re.findall(rf"{prefix}[A-Z0-9][A-Z0-9._-]*", content)
+    return sorted({value.rstrip("._-") for value in raw})
 
 
 def main() -> int:
@@ -145,7 +279,7 @@ def main() -> int:
         return 1
 
     print("AI Factory artifact validation: PASS")
-    print("- canonical templates: valid\n- artifact IDs: valid\n- specification contracts: valid\n- internal references: valid")
+    print("- canonical templates: valid\n- artifact IDs: valid\n- specification contracts: valid\n- plan contracts: valid\n- internal references: valid")
     return 0
 
 


### PR DESCRIPTION
F3.1 turns Plan from a heading-only template into a repository-native, version-bound contract.

The change defines Draft/Ready/Superseded semantics, binds Plans to an exact Specification version and Git baseline, records architecture/database/test/risk/dependency/sequence requirements, and validates Ready source status/version plus baseline commit existence. `PLAN-0001` is a real Draft for persisted favorites (`SPEC-0004`), so it demonstrates planning from a Proposed Spec while correctly blocking execution.

This PR also fixes two validator edge cases found during review: artifact references embedded in filenames/punctuation and false heading matches from H3/suffixed/fenced text. The factory CI checkout now fetches history so committed Plan baselines can be resolved.

Validation:
- `python -m py_compile scripts/ai-factory/validate.py scripts/ai-factory/test_validate.py`
- `python scripts/ai-factory/validate.py`
- `python scripts/ai-factory/test_validate.py` — 10 passed
- `git diff --check`
- independent architecture review — no remaining blockers
- independent test/verification review — no remaining blockers
- commit hook — client and server typechecks passed

F3.2 Task identity/metadata and F3.3 planner automation remain out of scope.