### PR TITLE
#100 — [Product] Exibir avaliações do produto na página de listing usando GET/POST /reviews

### DIFF
--- a/src/api/__tests__/reviews.test.ts
+++ b/src/api/__tests__/reviews.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createReview,
+  deleteReview,
+  getReview,
+  listProductReviews,
+  updateReview,
+} from "../reviews";
+
+const get = vi.fn();
+const post = vi.fn();
+const patch = vi.fn();
+const del = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+    patch: (...args: unknown[]) => patch(...args),
+    delete: (...args: unknown[]) => del(...args),
+  },
+}));
+
+describe("reviews API", () => {
+  beforeEach(() => {
+    get.mockReset();
+    post.mockReset();
+    patch.mockReset();
+    del.mockReset();
+    get.mockResolvedValue([]);
+    post.mockResolvedValue({ id: "rev-1" });
+    patch.mockResolvedValue({ id: "rev-1" });
+    del.mockResolvedValue({});
+  });
+
+  it("lists reviews from GET /reviews/product/:productId", async () => {
+    await listProductReviews("ak-redline-ft");
+    expect(get).toHaveBeenCalledWith("/reviews/product/ak-redline-ft");
+  });
+
+  it("encodes productId in the list path", async () => {
+    await listProductReviews("skin/with space");
+    expect(get).toHaveBeenCalledWith("/reviews/product/skin%2Fwith%20space");
+  });
+
+  it("reads one review from GET /reviews/:id", async () => {
+    await getReview("rev-1");
+    expect(get).toHaveBeenCalledWith("/reviews/rev-1");
+  });
+
+  it("creates a review with POST /reviews", async () => {
+    await createReview({
+      productId: "prod-1",
+      rating: 4,
+      comment: "Boa skin",
+    });
+    expect(post).toHaveBeenCalledWith("/reviews", {
+      productId: "prod-1",
+      rating: 4,
+      comment: "Boa skin",
+    });
+  });
+
+  it("updates with PATCH /reviews/:id and deletes with DELETE /reviews/:id", async () => {
+    await updateReview("rev-1", { rating: 5, comment: "Atualizado" });
+    expect(patch).toHaveBeenCalledWith("/reviews/rev-1", {
+      rating: 5,
+      comment: "Atualizado",
+    });
+    await deleteReview("rev-1");
+    expect(del).toHaveBeenCalledWith("/reviews/rev-1");
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,3 +8,4 @@ export * from "./orders";
 export * from "./payments";
 export * from "./sellers";
 export * from "./commissions";
+export * from "./reviews";

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -1,0 +1,34 @@
+import { api } from "./client";
+import type { CreateReviewBody, Review, UpdateReviewBody } from "@/types/api";
+
+function reviewPath(id: string): string {
+  return `/reviews/${encodeURIComponent(id)}`;
+}
+
+/** GET /reviews/product/:productId — public list, newest first. */
+export function listProductReviews(productId: string): Promise<Review[]> {
+  return api.get<Review[]>(`/reviews/product/${encodeURIComponent(productId)}`);
+}
+
+/** GET /reviews/:id */
+export function getReview(id: string): Promise<Review> {
+  return api.get<Review>(reviewPath(id));
+}
+
+/** POST /reviews — authenticated; unique per (productId, userId). */
+export function createReview(body: CreateReviewBody): Promise<Review> {
+  return api.post<Review>("/reviews", body);
+}
+
+/** PATCH /reviews/:id — owner only. */
+export function updateReview(
+  id: string,
+  body: UpdateReviewBody,
+): Promise<Review> {
+  return api.patch<Review>(reviewPath(id), body);
+}
+
+/** DELETE /reviews/:id — owner only. */
+export function deleteReview(id: string): Promise<void> {
+  return api.delete(reviewPath(id));
+}

--- a/src/components/ProductReviews.tsx
+++ b/src/components/ProductReviews.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Star } from "lucide-react";
+import {
+  createReview,
+  deleteReview,
+  listProductReviews,
+  updateReview,
+} from "@/api/reviews";
+import { useAuth } from "@/contexts/AuthContext";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  isAlreadyReviewedApiError,
+  isRetryableReadError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
+import type { Review } from "@/types/api";
+
+export const PRODUCT_REVIEWS_HEADING = "Avaliações desta skin";
+export const PRODUCT_REVIEWS_SCOPE =
+  "Notas e comentários sobre esta skin no catálogo — não sobre este listing específico.";
+export const PRODUCT_REVIEWS_EMPTY = "Nenhuma avaliação ainda";
+export const PRODUCT_REVIEWS_LOGIN_CTA = "Entrar para avaliar";
+export const PRODUCT_REVIEWS_SUBMIT = "Publicar avaliação";
+export const PRODUCT_REVIEWS_SAVE = "Salvar alterações";
+export const PRODUCT_REVIEWS_DELETE = "Excluir avaliação";
+export const PRODUCT_REVIEWS_RETRY = "Tentar novamente";
+
+export function productReviewsQueryKey(productId: string) {
+  return ["reviews", "product", productId] as const;
+}
+
+function formatReviewDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("pt-BR");
+}
+
+function StarRating({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  onChange?: (rating: number) => void;
+  disabled?: boolean;
+}) {
+  const interactive = Boolean(onChange) && !disabled;
+  return (
+    <div
+      className="flex items-center gap-1"
+      role={interactive ? "radiogroup" : "img"}
+      aria-label={
+        interactive ? "Nota de 1 a 5 estrelas" : `${value} de 5 estrelas`
+      }
+    >
+      {[1, 2, 3, 4, 5].map((star) => {
+        const filled = star <= value;
+        if (!interactive) {
+          return (
+            <Star
+              key={star}
+              className={
+                filled
+                  ? "h-4 w-4 fill-foreground text-foreground"
+                  : "h-4 w-4 text-muted-foreground"
+              }
+              aria-hidden
+            />
+          );
+        }
+        return (
+          <button
+            key={star}
+            type="button"
+            role="radio"
+            aria-checked={value === star}
+            aria-label={`${star} ${star === 1 ? "estrela" : "estrelas"}`}
+            disabled={disabled}
+            onClick={() => onChange?.(star)}
+            className="rounded-sm p-0.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            <Star
+              className={
+                filled ? "h-5 w-5 fill-foreground text-foreground" : "h-5 w-5"
+              }
+              aria-hidden
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ReviewForm({
+  productId,
+  existing,
+  onSuccess,
+}: {
+  productId: string;
+  existing?: Review;
+  onSuccess: () => void;
+}) {
+  const [rating, setRating] = useState(existing?.rating ?? 0);
+  const [comment, setComment] = useState(existing?.comment ?? "");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRating(existing?.rating ?? 0);
+    setComment(existing?.comment ?? "");
+    setSubmitError(null);
+  }, [existing?.id, existing?.rating, existing?.comment]);
+
+  const create = useMutation({
+    mutationFn: () =>
+      createReview({
+        productId,
+        rating,
+        comment: comment.trim() || undefined,
+      }),
+    onSuccess: () => {
+      setSubmitError(null);
+      onSuccess();
+    },
+    onError: (error) => {
+      setSubmitError(userFacingApiError(error));
+      if (isAlreadyReviewedApiError(error)) {
+        onSuccess();
+      }
+    },
+  });
+
+  const update = useMutation({
+    mutationFn: () =>
+      updateReview(existing!.id, {
+        rating,
+        comment: comment.trim(),
+      }),
+    onSuccess: () => {
+      setSubmitError(null);
+      onSuccess();
+    },
+    onError: (error) => {
+      setSubmitError(userFacingApiError(error));
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: () => deleteReview(existing!.id),
+    onSuccess: () => {
+      setSubmitError(null);
+      setRating(0);
+      setComment("");
+      onSuccess();
+    },
+    onError: (error) => {
+      setSubmitError(userFacingApiError(error));
+    },
+  });
+
+  const pending = create.isPending || update.isPending || remove.isPending;
+  const canSubmit = rating >= 1 && rating <= 5 && !pending;
+  const editing = Boolean(existing);
+
+  return (
+    <form
+      className="space-y-4 rounded-md border border-border bg-card p-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!canSubmit) return;
+        if (editing) {
+          update.mutate();
+          return;
+        }
+        create.mutate();
+      }}
+    >
+      <div className="space-y-2">
+        <Label id="review-rating-label">Sua nota</Label>
+        <StarRating value={rating} onChange={setRating} disabled={pending} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="review-comment">Comentário (opcional)</Label>
+        <Textarea
+          id="review-comment"
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          disabled={pending}
+          maxLength={2000}
+          placeholder="Como foi a experiência com esta skin?"
+        />
+      </div>
+      {submitError ? (
+        <p className="text-sm text-destructive" role="alert">
+          {submitError}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        <Button type="submit" disabled={!canSubmit}>
+          {editing ? PRODUCT_REVIEWS_SAVE : PRODUCT_REVIEWS_SUBMIT}
+        </Button>
+        {editing ? (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={pending}
+            onClick={() => remove.mutate()}
+          >
+            {PRODUCT_REVIEWS_DELETE}
+          </Button>
+        ) : null}
+      </div>
+    </form>
+  );
+}
+
+export function ProductReviews({ productId }: { productId: string }) {
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const {
+    data: reviews,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: productReviewsQueryKey(productId),
+    queryFn: () => listProductReviews(productId),
+    enabled: Boolean(productId),
+  });
+
+  const ownReview = reviews?.find((review) => review.userId === user?.id);
+  const canCreate = isAuthenticated && user?.role === "CUSTOMER" && !ownReview;
+  const canEditOwn = Boolean(ownReview);
+
+  const refresh = () => {
+    void queryClient.invalidateQueries({
+      queryKey: productReviewsQueryKey(productId),
+    });
+  };
+
+  return (
+    <section
+      className="mt-12 border-t border-border pt-10"
+      aria-labelledby="product-reviews-heading"
+    >
+      <h2
+        id="product-reviews-heading"
+        className="text-xl font-semibold tracking-tight text-foreground"
+      >
+        {PRODUCT_REVIEWS_HEADING}
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {PRODUCT_REVIEWS_SCOPE}
+      </p>
+
+      {isLoading ? (
+        <div
+          className="mt-6 space-y-3"
+          role="status"
+          aria-label="Carregando avaliações"
+        >
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : null}
+
+      {isError ? (
+        <div className="mt-6" role="alert">
+          <p className="text-sm text-muted-foreground">
+            {userFacingApiError(error)}
+          </p>
+          {isRetryableReadError(error) ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-3"
+              onClick={() => refetch()}
+            >
+              {PRODUCT_REVIEWS_RETRY}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {!isLoading && !isError && reviews && reviews.length === 0 ? (
+        <p className="mt-6 text-sm text-muted-foreground" role="status">
+          {PRODUCT_REVIEWS_EMPTY}
+        </p>
+      ) : null}
+
+      {!isLoading && !isError && reviews && reviews.length > 0 ? (
+        <ul className="mt-6 space-y-4">
+          {reviews.map((review) => (
+            <li
+              key={review.id}
+              className="rounded-md border border-border bg-card p-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm font-medium text-foreground">
+                  {review.user?.name || "Comprador"}
+                </p>
+                <time
+                  className="text-xs text-muted-foreground"
+                  dateTime={review.createdAt}
+                >
+                  {formatReviewDate(review.createdAt)}
+                </time>
+              </div>
+              <div className="mt-2">
+                <StarRating value={review.rating} />
+              </div>
+              {review.comment ? (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {review.comment}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {!authLoading && !isAuthenticated ? (
+        <div className="mt-6">
+          <Button asChild>
+            <Link to="/login" state={{ from: { pathname: location.pathname } }}>
+              {PRODUCT_REVIEWS_LOGIN_CTA}
+            </Link>
+          </Button>
+        </div>
+      ) : null}
+
+      {!authLoading && (canCreate || canEditOwn) ? (
+        <div className="mt-6">
+          <ReviewForm
+            productId={productId}
+            existing={ownReview}
+            onSuccess={refresh}
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/lib/__tests__/userFacingApiError.test.ts
+++ b/src/lib/__tests__/userFacingApiError.test.ts
@@ -13,6 +13,7 @@ import {
   USER_FACING_NOT_FOUND,
   USER_FACING_PAYPAL_CLIENT_AUTH,
   USER_FACING_RATE_LIMIT,
+  USER_FACING_REVIEW_EXISTS,
   USER_FACING_SERVER,
   USER_FACING_UNAUTHORIZED,
   USER_FACING_VALIDATION,
@@ -125,6 +126,13 @@ describe("userFacingApiError", () => {
         }),
       ),
     ).toBe(USER_FACING_CONFLICT);
+    expect(
+      userFacingApiError(
+        new ApiClientError("You already reviewed this product", {
+          status: 409,
+        }),
+      ),
+    ).toBe(USER_FACING_REVIEW_EXISTS);
     expect(
       userFacingApiError(
         new ApiClientError("Email already registered", { status: 409 }),

--- a/src/lib/userFacingApiError.ts
+++ b/src/lib/userFacingApiError.ts
@@ -24,6 +24,8 @@ export const USER_FACING_NOT_FOUND =
 export const USER_FACING_CONFLICT =
   "Este recurso mudou. Recarregue a página e tente de novo.";
 
+export const USER_FACING_REVIEW_EXISTS = "Você já avaliou este produto.";
+
 export const USER_FACING_RATE_LIMIT =
   "Muitas tentativas. Espere um momento e tente de novo.";
 
@@ -156,6 +158,15 @@ export function isRetryableReadError(error: unknown): boolean {
   );
 }
 
+export function isAlreadyReviewedApiError(error: unknown): boolean {
+  const status = apiErrorStatus(error);
+  const message = technicalMessage(error);
+  return (
+    (status === 409 || status == null) &&
+    /already reviewed|já avaliou/i.test(message)
+  );
+}
+
 function isListingConflict(error: unknown): boolean {
   const status = apiErrorStatus(error);
   const message = technicalMessage(error);
@@ -185,6 +196,8 @@ export function userFacingApiError(error: unknown): string {
     copy = USER_FACING_NETWORK;
   } else if (isListingConflict(error)) {
     copy = USER_FACING_LISTING_CONFLICT;
+  } else if (isAlreadyReviewedApiError(error)) {
+    copy = USER_FACING_REVIEW_EXISTS;
   } else if (
     status === 409 &&
     /email already|already registered|already exists/i.test(message)

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { ListingCard, SkinVisual } from "@/components/ProductCard";
 import { ListingCartCta } from "@/components/ListingCartCta";
+import { ProductReviews } from "@/components/ProductReviews";
 import { ErrorState } from "@/components/page-state";
 import { getListing, listListings } from "@/api/listings";
 import { getPriceHistory } from "@/api/price-history";
@@ -177,9 +178,9 @@ export default function ListingDetail() {
                 <p className="text-sm font-medium text-foreground">
                   {sellerName}
                 </p>
-                {listing.seller.rating ? (
+                {listing.seller.rating != null ? (
                   <p className="text-xs text-muted-foreground">
-                    Avaliação: {Number(listing.seller.rating).toFixed(1)}
+                    Nota da loja: {Number(listing.seller.rating).toFixed(1)}
                   </p>
                 ) : null}
               </div>
@@ -228,6 +229,8 @@ export default function ListingDetail() {
           ) : null}
         </div>
       </div>
+
+      <ProductReviews productId={listing.productId} />
 
       {related.length > 0 ? (
         <section className="mt-12 border-t border-border pt-10">

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -4,8 +4,12 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ListingDetail from "../ListingDetail";
 import { CartProvider, useCart } from "@/contexts/CartContext";
-import type { Listing, PriceHistory } from "@/types/api";
-import { USER_FACING_NOT_FOUND } from "@/lib/userFacingApiError";
+import type { Listing, PriceHistory, Review, User } from "@/types/api";
+import {
+  ApiClientError,
+  USER_FACING_NOT_FOUND,
+  USER_FACING_REVIEW_EXISTS,
+} from "@/lib/userFacingApiError";
 import {
   CART_ADDED_MESSAGE,
   CART_CTA_ADD,
@@ -14,12 +18,30 @@ import {
   CART_CTA_VIEW_CART,
 } from "@/lib/listingCartCta";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
+import {
+  PRODUCT_REVIEWS_DELETE,
+  PRODUCT_REVIEWS_EMPTY,
+  PRODUCT_REVIEWS_HEADING,
+  PRODUCT_REVIEWS_LOGIN_CTA,
+  PRODUCT_REVIEWS_SCOPE,
+  PRODUCT_REVIEWS_SUBMIT,
+} from "@/components/ProductReviews";
 
 const getListing = vi.fn();
 const listListings = vi.fn();
 const getPriceHistory = vi.fn();
 const reserveListing = vi.fn();
+const listProductReviews = vi.fn();
+const createReview = vi.fn();
+const updateReview = vi.fn();
+const deleteReview = vi.fn();
 const toast = vi.fn();
+
+const authState = {
+  user: null as User | null,
+  isAuthenticated: false,
+  isLoading: false,
+};
 
 vi.mock("@/api/listings", () => ({
   getListing: (...args: unknown[]) => getListing(...args),
@@ -33,6 +55,17 @@ vi.mock("@/api/price-history", () => ({
 
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/api/reviews", () => ({
+  listProductReviews: (...args: unknown[]) => listProductReviews(...args),
+  createReview: (...args: unknown[]) => createReview(...args),
+  updateReview: (...args: unknown[]) => updateReview(...args),
+  deleteReview: (...args: unknown[]) => deleteReview(...args),
 }));
 
 function makeListing(overrides: Partial<Listing> = {}): Listing {
@@ -85,6 +118,19 @@ function history(): PriceHistory[] {
   ];
 }
 
+function makeReview(overrides: Partial<Review> = {}): Review {
+  return {
+    id: "rev-1",
+    productId: "ak-redline-ft",
+    userId: "buyer-1",
+    rating: 4,
+    comment: "Float honesto, entrega rápida.",
+    createdAt: "2026-08-15T12:00:00.000Z",
+    user: { id: "buyer-1", name: "Ana" },
+    ...overrides,
+  };
+}
+
 function CartProbe() {
   const { totalItems } = useCart();
   return <span data-testid="cart-count">{totalItems}</span>;
@@ -114,10 +160,18 @@ describe("ListingDetail", () => {
     listListings.mockReset();
     getPriceHistory.mockReset();
     reserveListing.mockReset();
+    listProductReviews.mockReset();
+    createReview.mockReset();
+    updateReview.mockReset();
+    deleteReview.mockReset();
     toast.mockReset();
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
     localStorage.removeItem(CART_STORAGE_KEY);
     listListings.mockResolvedValue({ items: [], total: 0, page: 1, limit: 4 });
     getPriceHistory.mockResolvedValue([]);
+    listProductReviews.mockResolvedValue([]);
   });
 
   it("keeps listing facts, history, related cards and add to cart", async () => {
@@ -237,5 +291,124 @@ describe("ListingDetail", () => {
     });
     expect(screen.queryByText(/SKINMARKET/i)).toBeNull();
     expect(document.querySelector(".scan-lines")).toBeNull();
+  });
+
+  it("loads product reviews from GET /reviews/product/:productId and does not call seller.rating a review average", async () => {
+    getListing.mockResolvedValue(makeListing());
+    listProductReviews.mockResolvedValue([makeReview()]);
+
+    renderDetail();
+
+    expect(
+      await screen.findByRole("heading", { name: PRODUCT_REVIEWS_HEADING }),
+    ).toBeTruthy();
+    expect(screen.getByText(PRODUCT_REVIEWS_SCOPE)).toBeTruthy();
+    expect(screen.getByText("Ana")).toBeTruthy();
+    expect(screen.getByText("Float honesto, entrega rápida.")).toBeTruthy();
+    expect(screen.getByText("Nota da loja: 4.5")).toBeTruthy();
+    expect(screen.queryByText(/média das avaliações/i)).toBeNull();
+    expect(listProductReviews).toHaveBeenCalledWith("ak-redline-ft");
+  });
+
+  it("shows empty copy and a login invite for guests, without the review form", async () => {
+    getListing.mockResolvedValue(makeListing());
+    renderDetail();
+
+    expect(await screen.findByText(PRODUCT_REVIEWS_EMPTY)).toBeTruthy();
+    const login = screen.getByRole("link", { name: PRODUCT_REVIEWS_LOGIN_CTA });
+    expect(login).toHaveAttribute("href", "/login");
+    expect(
+      screen.queryByRole("button", { name: PRODUCT_REVIEWS_SUBMIT }),
+    ).toBeNull();
+    expect(screen.queryByLabelText("Comentário (opcional)")).toBeNull();
+  });
+
+  it("lets a CUSTOMER create a review and then switch to edit after success", async () => {
+    authState.user = {
+      id: "buyer-1",
+      name: "Ana",
+      email: "ana@test.com",
+      role: "CUSTOMER",
+    };
+    authState.isAuthenticated = true;
+    getListing.mockResolvedValue(makeListing());
+    listProductReviews
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeReview()]);
+    createReview.mockResolvedValue(makeReview());
+
+    renderDetail();
+
+    expect(await screen.findByText(PRODUCT_REVIEWS_EMPTY)).toBeTruthy();
+    expect(
+      screen.queryByRole("link", { name: PRODUCT_REVIEWS_LOGIN_CTA }),
+    ).toBeNull();
+    const submit = screen.getByRole("button", { name: PRODUCT_REVIEWS_SUBMIT });
+    expect(submit).toHaveProperty("disabled", true);
+
+    fireEvent.click(screen.getByRole("radio", { name: "4 estrelas" }));
+    fireEvent.change(screen.getByLabelText("Comentário (opcional)"), {
+      target: { value: "Float honesto, entrega rápida." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: PRODUCT_REVIEWS_SUBMIT }),
+    );
+
+    await waitFor(() => {
+      expect(createReview).toHaveBeenCalledWith({
+        productId: "ak-redline-ft",
+        rating: 4,
+        comment: "Float honesto, entrega rápida.",
+      });
+    });
+    expect(
+      await screen.findByRole("button", { name: PRODUCT_REVIEWS_DELETE }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: PRODUCT_REVIEWS_SUBMIT }),
+    ).toBeNull();
+  });
+
+  it("maps POST 409 unique conflict to você já avaliou", async () => {
+    authState.user = {
+      id: "buyer-1",
+      name: "Ana",
+      email: "ana@test.com",
+      role: "CUSTOMER",
+    };
+    authState.isAuthenticated = true;
+    getListing.mockResolvedValue(makeListing());
+    createReview.mockRejectedValue(
+      new ApiClientError("You already reviewed this product", { status: 409 }),
+    );
+
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "4 estrelas" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: PRODUCT_REVIEWS_SUBMIT }),
+    );
+
+    expect(await screen.findByText(USER_FACING_REVIEW_EXISTS)).toBeTruthy();
+    expect(USER_FACING_REVIEW_EXISTS.toLowerCase()).toContain(
+      "você já avaliou",
+    );
+  });
+
+  it("retries a failed reviews list without inventing seller review aggregation", async () => {
+    getListing.mockResolvedValue(makeListing());
+    listProductReviews.mockRejectedValue(
+      new ApiClientError("Internal server error.", { status: 500 }),
+    );
+
+    renderDetail();
+
+    expect(
+      await screen.findByRole("button", { name: "Tentar novamente" }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/média das avaliações/i)).toBeNull();
+    listProductReviews.mockResolvedValue([makeReview()]);
+    fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
+    expect(await screen.findByText("Ana")).toBeTruthy();
   });
 });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -182,3 +182,31 @@ export interface Order {
 export interface ApiError {
   error: string;
 }
+
+/** GET /reviews/product/:productId — review of a catalog Product, not a listing. */
+export interface ReviewUser {
+  id: string;
+  name: string;
+}
+
+export interface Review {
+  id: string;
+  productId: string;
+  userId: string;
+  rating: number;
+  comment?: string | null;
+  createdAt: string;
+  user: ReviewUser;
+  product?: { id: string; skinName: string };
+}
+
+export interface CreateReviewBody {
+  productId: string;
+  rating: number;
+  comment?: string;
+}
+
+export interface UpdateReviewBody {
+  rating?: number;
+  comment?: string;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #100

Add catalog-product reviews to the listing PDP using the existing reviews API. No `server/` changes.

## What changed

- `src/api/reviews.ts` aligned with `GET/POST/PATCH/DELETE /reviews`
- PDP section “Avaliações desta skin”: rating, name, date, comment
- Guest sees login invite; CUSTOMER can create one review, then edit/delete
- 409 unique-review maps to “Você já avaliou este produto.”
- `seller.rating` labeled **Nota da loja**, never “média das avaliações”

## Acceptance

- Reviews come from `GET /reviews/product/:productId`
- POST unique 409 has user-facing copy
- Visitors do not see the form
- UI does not present seller.rating as the review average

## Verification

- `npm run typecheck` → PASS
- `npm run lint` → PASS (0 errors)
- `npm test` → PASS (285 tests)
- Browser: guest empty/list + login CTA; authenticated create 4★ + comment; persists on reload

[issue-100-pdp-reviews-walkthrough.mp4](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-100-pdp-reviews-walkthrough.mp4)
[Guest PDP empty reviews with login CTA](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-100-guest-empty-reviews.png)
[Guest PDP existing catalog reviews](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-100-guest-existing-reviews.png)
[Authenticated review persists after reload](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-100-customer-review-persists.png)

## Risks

- Backend still allows any authenticated role to POST; UI only offers create to CUSTOMER
- API does not require a purchase; UI does not invent that gate

Do not merge from this agent. Do not close the issue from `gh`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

