### PR TITLE
#102 — [Analytics] Instrumentar o funil Home → PDP → Cart → Checkout → PayPal → Order

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,18 +2,20 @@
 
 Neon Arsenal Market uses OpenTelemetry for traces and metrics, and Pino for logs. The goal is to diagnose latency, errors and business failures on the checkout path without running an observability platform locally.
 
+Storefront funnel events (`page_view` → PayPal → `order_viewed`) live in the frontend wrapper documented in [`docs/product-analytics.md`](./product-analytics.md). They are not OTel spans and do not use `OTEL_*`.
+
 ## Defaults
 
 Telemetry is **off** unless `OTEL_ENABLED=true`.
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `OTEL_ENABLED` | unset/false | Start the SDK |
-| `OTEL_EXPORTER` | `none` | `none`, `console`, or `otlp` |
-| `OTEL_SERVICE_NAME` | `neon-arsenal-api` | Resource service name |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | Base OTLP HTTP endpoint |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Overrides the traces URL |
-| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset | Overrides the metrics URL |
+| Variable                              | Default            | Purpose                      |
+| ------------------------------------- | ------------------ | ---------------------------- |
+| `OTEL_ENABLED`                        | unset/false        | Start the SDK                |
+| `OTEL_EXPORTER`                       | `none`             | `none`, `console`, or `otlp` |
+| `OTEL_SERVICE_NAME`                   | `neon-arsenal-api` | Resource service name        |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`         | unset              | Base OTLP HTTP endpoint      |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | unset              | Overrides the traces URL     |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset              | Overrides the metrics URL    |
 
 `npm run dev` does not need Docker extras, Jaeger, Grafana, Prometheus or a collector. If the chosen exporter is unreachable, request handling continues.
 
@@ -31,34 +33,34 @@ Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second
 
 ## Spans
 
-| Span | Meaning |
-|---|---|
-| `http.server.request` | Inbound HTTP, except `/health` and `/ready` |
-| `orders.create` | Order creation, including idempotency outcomes |
-| `orders.create.transaction` | PostgreSQL transaction that reserves listings and writes the order |
-| `listings.reserve` | Reservation attempt (order path or standalone reserve) |
-| `listings.expire` | Expired-reservation sweep |
-| `payments.confirm` | Payment confirmation |
-| `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
-| `payments.reconcile` | PayPal GET reconciliation batch |
-| `seller.ledger.reconcile` | Seller.balance vs PAID ledger SUM |
-| `outbox.dispatch` | Claim and publish transactional outbox rows |
-| `paypal.webhook.verify` | Webhook signature verification |
-| `paypal.webhook.handle` | Event claim, ignore, confirm or fail |
-| `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP |
-| `db.prisma` | Prisma operation (`db.operation` + `db.collection` only) |
+| Span                                                                     | Meaning                                                            |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `http.server.request`                                                    | Inbound HTTP, except `/health` and `/ready`                        |
+| `orders.create`                                                          | Order creation, including idempotency outcomes                     |
+| `orders.create.transaction`                                              | PostgreSQL transaction that reserves listings and writes the order |
+| `listings.reserve`                                                       | Reservation attempt (order path or standalone reserve)             |
+| `listings.expire`                                                        | Expired-reservation sweep                                          |
+| `payments.confirm`                                                       | Payment confirmation                                               |
+| `payments.confirm.transaction`                                           | Claim order, sell listings, write seller transactions              |
+| `payments.reconcile`                                                     | PayPal GET reconciliation batch                                    |
+| `seller.ledger.reconcile`                                                | Seller.balance vs PAID ledger SUM                                  |
+| `outbox.dispatch`                                                        | Claim and publish transactional outbox rows                        |
+| `paypal.webhook.verify`                                                  | Webhook signature verification                                     |
+| `paypal.webhook.handle`                                                  | Event claim, ignore, confirm or fail                               |
+| `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP                                                        |
+| `db.prisma`                                                              | Prisma operation (`db.operation` + `db.collection` only)           |
 
 `app.outcome` distinguishes expected business results from operational failures:
 
-| Outcome | Typical cause | Span status |
-|---|---|---|
-| `created` / `confirmed` | Success | UNSET |
-| `idempotency_replay` | Same key and listing set | UNSET |
-| `idempotency_conflict` | Same key, different request or in-progress | UNSET |
-| `reservation_conflict` | Listing already held | UNSET |
-| `reservation_expired` | Payment after expiry | UNSET |
-| `webhook_duplicate` / `webhook_ignored` | Duplicate or unsupported event | UNSET |
-| `timeout` / `provider_error` / `error` | PayPal/DB/unexpected | ERROR |
+| Outcome                                 | Typical cause                              | Span status |
+| --------------------------------------- | ------------------------------------------ | ----------- |
+| `created` / `confirmed`                 | Success                                    | UNSET       |
+| `idempotency_replay`                    | Same key and listing set                   | UNSET       |
+| `idempotency_conflict`                  | Same key, different request or in-progress | UNSET       |
+| `reservation_conflict`                  | Listing already held                       | UNSET       |
+| `reservation_expired`                   | Payment after expiry                       | UNSET       |
+| `webhook_duplicate` / `webhook_ignored` | Duplicate or unsupported event             | UNSET       |
+| `timeout` / `provider_error` / `error`  | PayPal/DB/unexpected                       | ERROR       |
 
 ## Metrics
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,14 +8,14 @@ Storefront funnel events (`page_view` → PayPal → `order_viewed`) live in the
 
 Telemetry is **off** unless `OTEL_ENABLED=true`.
 
-| Variable                              | Default            | Purpose                      |
-| ------------------------------------- | ------------------ | ---------------------------- |
-| `OTEL_ENABLED`                        | unset/false        | Start the SDK                |
-| `OTEL_EXPORTER`                       | `none`             | `none`, `console`, or `otlp` |
-| `OTEL_SERVICE_NAME`                   | `neon-arsenal-api` | Resource service name        |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`         | unset              | Base OTLP HTTP endpoint      |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | unset              | Overrides the traces URL     |
-| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset              | Overrides the metrics URL    |
+| Variable | Default | Purpose |
+|---|---|---|
+| `OTEL_ENABLED` | unset/false | Start the SDK |
+| `OTEL_EXPORTER` | `none` | `none`, `console`, or `otlp` |
+| `OTEL_SERVICE_NAME` | `neon-arsenal-api` | Resource service name |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | unset | Base OTLP HTTP endpoint |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Overrides the traces URL |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | unset | Overrides the metrics URL |
 
 `npm run dev` does not need Docker extras, Jaeger, Grafana, Prometheus or a collector. If the chosen exporter is unreachable, request handling continues.
 
@@ -33,34 +33,34 @@ Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second
 
 ## Spans
 
-| Span                                                                     | Meaning                                                            |
-| ------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| `http.server.request`                                                    | Inbound HTTP, except `/health` and `/ready`                        |
-| `orders.create`                                                          | Order creation, including idempotency outcomes                     |
-| `orders.create.transaction`                                              | PostgreSQL transaction that reserves listings and writes the order |
-| `listings.reserve`                                                       | Reservation attempt (order path or standalone reserve)             |
-| `listings.expire`                                                        | Expired-reservation sweep                                          |
-| `payments.confirm`                                                       | Payment confirmation                                               |
-| `payments.confirm.transaction`                                           | Claim order, sell listings, write seller transactions              |
-| `payments.reconcile`                                                     | PayPal GET reconciliation batch                                    |
-| `seller.ledger.reconcile`                                                | Seller.balance vs PAID ledger SUM                                  |
-| `outbox.dispatch`                                                        | Claim and publish transactional outbox rows                        |
-| `paypal.webhook.verify`                                                  | Webhook signature verification                                     |
-| `paypal.webhook.handle`                                                  | Event claim, ignore, confirm or fail                               |
-| `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP                                                        |
-| `db.prisma`                                                              | Prisma operation (`db.operation` + `db.collection` only)           |
+| Span | Meaning |
+|---|---|
+| `http.server.request` | Inbound HTTP, except `/health` and `/ready` |
+| `orders.create` | Order creation, including idempotency outcomes |
+| `orders.create.transaction` | PostgreSQL transaction that reserves listings and writes the order |
+| `listings.reserve` | Reservation attempt (order path or standalone reserve) |
+| `listings.expire` | Expired-reservation sweep |
+| `payments.confirm` | Payment confirmation |
+| `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
+| `payments.reconcile` | PayPal GET reconciliation batch |
+| `seller.ledger.reconcile` | Seller.balance vs PAID ledger SUM |
+| `outbox.dispatch` | Claim and publish transactional outbox rows |
+| `paypal.webhook.verify` | Webhook signature verification |
+| `paypal.webhook.handle` | Event claim, ignore, confirm or fail |
+| `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP |
+| `db.prisma` | Prisma operation (`db.operation` + `db.collection` only) |
 
 `app.outcome` distinguishes expected business results from operational failures:
 
-| Outcome                                 | Typical cause                              | Span status |
-| --------------------------------------- | ------------------------------------------ | ----------- |
-| `created` / `confirmed`                 | Success                                    | UNSET       |
-| `idempotency_replay`                    | Same key and listing set                   | UNSET       |
-| `idempotency_conflict`                  | Same key, different request or in-progress | UNSET       |
-| `reservation_conflict`                  | Listing already held                       | UNSET       |
-| `reservation_expired`                   | Payment after expiry                       | UNSET       |
-| `webhook_duplicate` / `webhook_ignored` | Duplicate or unsupported event             | UNSET       |
-| `timeout` / `provider_error` / `error`  | PayPal/DB/unexpected                       | ERROR       |
+| Outcome | Typical cause | Span status |
+|---|---|---|
+| `created` / `confirmed` | Success | UNSET |
+| `idempotency_replay` | Same key and listing set | UNSET |
+| `idempotency_conflict` | Same key, different request or in-progress | UNSET |
+| `reservation_conflict` | Listing already held | UNSET |
+| `reservation_expired` | Payment after expiry | UNSET |
+| `webhook_duplicate` / `webhook_ignored` | Duplicate or unsupported event | UNSET |
+| `timeout` / `provider_error` / `error` | PayPal/DB/unexpected | ERROR |
 
 ## Metrics
 

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -1,0 +1,52 @@
+# Product analytics
+
+Frontend funnel telemetry for Neon Arsenal. This is **not** backend OpenTelemetry (`docs/observability.md`). There is no required vendor and **no new env var**.
+
+## Sink
+
+`track(event, props)` in `src/lib/analytics.ts`:
+
+- **No collector registered (default):** no-op. The app works with the sink off.
+- **Development:** events also go to `console.info("[analytics]", event, props)`.
+- **Production:** stays no-op until a collector is registered. Consent is not implemented; do not add a cookie banner or a vendor SDK here.
+- Optional hook: `setAnalyticsCollector(fn)` for tests or a future consented sink. Failures in `track` never throw.
+
+Do not send email, JWT, password, names, or PayPal tokens.
+
+## Funnel
+
+```text
+page_view
+  → category_view (Home chip / Market exterior)
+  → search (Market productId or applied filters)
+  → search_result_click (Market card)
+  → product_view (PDP)
+  → cart_add / cart_remove
+  → checkout_started
+  → payment_started (PayPal redirect)
+  → payment_return | payment_cancel
+  → order_viewed
+seller_listing_created (seller CRUD, not the buyer path)
+```
+
+## Events
+
+| Event                    | When                                      | Props                                                      |
+| ------------------------ | ----------------------------------------- | ---------------------------------------------------------- |
+| `page_view`              | Route change after auth is resolved       | `path`, `role` (`CUSTOMER` / `SELLER` / `ADMIN` / `guest`) |
+| `search`                 | Market has `productId` or filters         | `query`, `productId`, `source=market`, `resultCount`       |
+| `search_result_click`    | Click a Market listing card               | `listingId`, `productId`, `price`, `source=market`         |
+| `category_view`          | Home catalog chip or Market exterior chip | `productId` or `category`, `source`                        |
+| `product_view`           | Listing detail loaded                     | `listingId`, `productId`, `price`, `source`                |
+| `cart_add`               | Listing added to the local cart           | `listingId`, `productId`, `price`, `source`                |
+| `cart_remove`            | Buyer removes a cart line                 | `listingId`, `productId`, `price`                          |
+| `checkout_started`       | Customer checkout form shown              | `itemCount`                                                |
+| `payment_started`        | PayPal link created / retry               | `orderId`                                                  |
+| `payment_return`         | `/orders/:id/return`                      | `orderId`                                                  |
+| `payment_cancel`         | `/orders/:id/cancel`                      | `orderId`                                                  |
+| `order_viewed`           | Order status loaded                       | `orderId`                                                  |
+| `seller_listing_created` | Seller creates a listing                  | `listingId`, `productId`, `price`, `source=seller`         |
+
+`price` is a string (API decimal), never a JS `number` calculation. `source` is `home` \| `market` \| `related` \| `seller`.
+
+The Market has no free-text search box. `search` is the current discovery query (`productId` from Home shortcuts, exterior / StatTrak / price filters).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { CartProvider } from "@/contexts/CartContext";
 import MainLayout from "@/layouts/MainLayout";
 import DashboardLayout from "@/layouts/DashboardLayout";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { PageViewTracker } from "@/components/PageViewTracker";
 import Index from "./pages/Index";
 import Products from "./pages/Products";
 import ListingDetail from "./pages/ListingDetail";
@@ -42,6 +43,7 @@ const App = () => (
           <TooltipProvider>
             <Toaster />
             <BrowserRouter>
+              <PageViewTracker />
               <Routes>
                 <Route element={<MainLayout />}>
                   <Route path="/" element={<Index />} />

--- a/src/components/ListingCartCta.tsx
+++ b/src/components/ListingCartCta.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { ShoppingCart } from "lucide-react";
 import type { Listing } from "@/types/api";
 import { useCart } from "@/contexts/CartContext";
+import type { AnalyticsSource } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import {
   CART_ADDED_MESSAGE,
@@ -17,9 +18,11 @@ import { cn } from "@/lib/utils";
 export function ListingCartCta({
   listing,
   variant,
+  source,
 }: {
   listing: Listing;
   variant: "detail" | "card";
+  source?: AnalyticsSource;
 }) {
   const { addItem, items } = useCart();
   const [liveMessage, setLiveMessage] = useState("");
@@ -27,7 +30,7 @@ export function ListingCartCta({
   const cta = resolveListingCartCta(listing, inCart);
 
   const onAdd = () => {
-    const result = addItem(listing);
+    const result = addItem(listing, source ? { source } : undefined);
     if (result === "added") {
       setLiveMessage(CART_ADDED_MESSAGE);
     }

--- a/src/components/PageViewTracker.tsx
+++ b/src/components/PageViewTracker.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
+import { track, type AnalyticsRole } from "@/lib/analytics";
+
+export function PageViewTracker() {
+  const location = useLocation();
+  const { user, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isLoading) return;
+    const role: AnalyticsRole = user?.role ?? "guest";
+    track("page_view", { path: location.pathname, role });
+  }, [location.pathname, isLoading, user?.role]);
+
+  return null;
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import type { Listing, Product } from "@/types/api";
 import { ListingCartCta } from "@/components/ListingCartCta";
+import { analyticsPrice, track, type AnalyticsSource } from "@/lib/analytics";
 
 export function productDisplayName(
   product: Pick<Product, "weapon" | "skinName" | "exterior">,
@@ -76,17 +77,36 @@ export function SkinThumb({
   );
 }
 
-export function ListingCard({ listing }: { listing: Listing }) {
+export function ListingCard({
+  listing,
+  source,
+}: {
+  listing: Listing;
+  source?: AnalyticsSource;
+}) {
   const price =
     typeof listing.price === "number" ? listing.price : Number(listing.price);
   const sellerName =
     listing.seller?.user?.name ?? listing.seller?.storeName ?? "";
   const productName = productDisplayName(listing.product);
+  const listingState = source ? { source } : undefined;
+
+  const onListingNavigate = () => {
+    if (source !== "market") return;
+    track("search_result_click", {
+      listingId: listing.id,
+      productId: listing.productId,
+      price: analyticsPrice(listing.price),
+      source,
+    });
+  };
 
   return (
     <article className="group flex flex-col overflow-hidden rounded-md border border-border bg-card">
       <Link
         to={`/listing/${listing.id}`}
+        state={listingState}
+        onClick={onListingNavigate}
         className="relative block aspect-[4/3] bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <div className="flex h-full items-center justify-center">
@@ -102,6 +122,8 @@ export function ListingCard({ listing }: { listing: Listing }) {
       <div className="flex flex-1 flex-col gap-2 p-3">
         <Link
           to={`/listing/${listing.id}`}
+          state={listingState}
+          onClick={onListingNavigate}
           className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <h3 className="line-clamp-2 text-sm font-medium leading-snug text-foreground transition-colors hover:text-primary">
@@ -123,7 +145,7 @@ export function ListingCard({ listing }: { listing: Listing }) {
           <span className="tabular-nums text-base font-semibold text-foreground">
             ${price.toFixed(2)}
           </span>
-          <ListingCartCta listing={listing} variant="card" />
+          <ListingCartCta listing={listing} variant="card" source={source} />
         </div>
       </div>
     </article>

--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ListingCard, SkinThumb } from "../ProductCard";
@@ -12,6 +12,11 @@ import {
   CART_CTA_VIEW_CART,
 } from "@/lib/listingCartCta";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 
 const toast = vi.fn();
 
@@ -61,11 +66,14 @@ function CartProbe() {
   return <span data-testid="cart-count">{totalItems}</span>;
 }
 
-function renderCard(listing: Listing) {
+function renderCard(
+  listing: Listing,
+  source?: "home" | "market" | "related" | "seller",
+) {
   return render(
     <MemoryRouter>
       <CartProvider>
-        <ListingCard listing={listing} />
+        <ListingCard listing={listing} source={source} />
         <CartProbe />
       </CartProvider>
     </MemoryRouter>,
@@ -78,10 +86,21 @@ function addButton() {
   });
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("ListingCard", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     toast.mockReset();
     localStorage.removeItem(CART_STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    setAnalyticsCollector(null);
   });
   it("renders weapon | skin (exterior) as the display name", () => {
     renderCard(makeListing());
@@ -279,6 +298,24 @@ describe("ListingCard", () => {
     renderCard(makeListing());
     expect(screen.queryByText(/SKINMARKET/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/CS2 Skin Marketplace/i)).not.toBeInTheDocument();
+  });
+
+  it("tracks search_result_click only from the market source", () => {
+    renderCard(makeListing(), "market");
+    fireEvent.click(
+      screen.getAllByRole("link", {
+        name: "AK-47 | Redline (Field-Tested)",
+      })[0],
+    );
+    expect(analyticsEvents).toContainEqual({
+      event: "search_result_click",
+      props: {
+        listingId: "listing-1",
+        productId: "prod-1",
+        price: "299.5",
+        source: "market",
+      },
+    });
   });
 });
 

--- a/src/components/__tests__/PageViewTracker.test.tsx
+++ b/src/components/__tests__/PageViewTracker.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PageViewTracker } from "../PageViewTracker";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
+import type { Role, User } from "@/types/api";
+
+const authState = {
+  user: null as User | null,
+  isLoading: false,
+};
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+function collect() {
+  const events: { event: AnalyticsEventName; props: AnalyticsProps }[] = [];
+  setAnalyticsCollector((event, props) => {
+    events.push({ event, props });
+  });
+  return events;
+}
+
+afterEach(() => {
+  setAnalyticsCollector(null);
+  authState.user = null;
+  authState.isLoading = false;
+});
+
+function renderTracker(path = "/") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <PageViewTracker />
+    </MemoryRouter>,
+  );
+}
+
+describe("PageViewTracker", () => {
+  it("records page_view with role only after auth resolves", async () => {
+    const events = collect();
+    authState.user = {
+      id: "u1",
+      name: "Buyer",
+      email: "buyer@test.com",
+      role: "CUSTOMER" as Role,
+    };
+
+    renderTracker("/products");
+
+    await waitFor(() => {
+      expect(events).toEqual([
+        {
+          event: "page_view",
+          props: { path: "/products", role: "CUSTOMER" },
+        },
+      ]);
+    });
+    expect(JSON.stringify(events)).not.toMatch(/buyer@test.com|Buyer/);
+  });
+
+  it("uses guest when the visitor is anonymous", async () => {
+    const events = collect();
+    renderTracker("/");
+
+    await waitFor(() => {
+      expect(events[0]).toEqual({
+        event: "page_view",
+        props: { path: "/", role: "guest" },
+      });
+    });
+  });
+
+  it("does not emit while auth is still loading", () => {
+    const events = collect();
+    authState.isLoading = true;
+    renderTracker("/cart");
+    expect(events).toEqual([]);
+  });
+});

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -15,6 +15,7 @@ import {
   CART_REMOVED_MESSAGE,
 } from "@/lib/listingCartCta";
 import { useToast } from "@/hooks/use-toast";
+import { analyticsPrice, track, type AnalyticsSource } from "@/lib/analytics";
 
 export type AddItemResult = "added" | "duplicate" | "unavailable";
 
@@ -25,7 +26,10 @@ export interface CartItem {
 
 interface CartContextType {
   items: CartItem[];
-  addItem: (listing: Listing) => AddItemResult;
+  addItem: (
+    listing: Listing,
+    meta?: { source?: AnalyticsSource },
+  ) => AddItemResult;
   updateListing: (listing: Listing) => void;
   removeItem: (listingId: string) => void;
   removeItems: (listingIds: string[]) => void;
@@ -49,7 +53,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
     saveCartToStorage(items);
   }, [items]);
 
-  const addItem = (listing: Listing): AddItemResult => {
+  const addItem = (
+    listing: Listing,
+    meta?: { source?: AnalyticsSource },
+  ): AddItemResult => {
     if (listing.status !== "ACTIVE") {
       return "unavailable";
     }
@@ -62,6 +69,12 @@ export function CartProvider({ children }: { children: ReactNode }) {
         return prev;
       }
       return [...prev, { listing, priceWhenAdded: listing.price }];
+    });
+    track("cart_add", {
+      listingId: listing.id,
+      productId: listing.productId,
+      price: analyticsPrice(listing.price),
+      source: meta?.source,
     });
     toast({ title: CART_ADDED_MESSAGE });
     return "added";
@@ -80,10 +93,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const removeItem = (listingId: string) => {
-    if (!items.some((item) => item.listing.id === listingId)) {
+    const existing = items.find((item) => item.listing.id === listingId);
+    if (!existing) {
       return;
     }
     setItems((prev) => prev.filter((item) => item.listing.id !== listingId));
+    track("cart_remove", {
+      listingId: existing.listing.id,
+      productId: existing.listing.productId,
+      price: analyticsPrice(existing.priceWhenAdded ?? existing.listing.price),
+    });
     toast({ title: CART_REMOVED_MESSAGE });
   };
 

--- a/src/contexts/__tests__/CartContext.test.tsx
+++ b/src/contexts/__tests__/CartContext.test.tsx
@@ -1,4 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CartProvider, useCart } from "../CartContext";
 import type { Listing } from "@/types/api";
@@ -183,13 +188,21 @@ function renderCart() {
   );
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("CartContext", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     toast.mockReset();
     localStorage.removeItem(CART_STORAGE_KEY);
   });
 
   afterEach(() => {
+    setAnalyticsCollector(null);
     vi.restoreAllMocks();
     localStorage.removeItem(CART_STORAGE_KEY);
   });
@@ -209,6 +222,14 @@ describe("CartContext", () => {
 
       expect(screen.getByTestId("count").textContent).toBe("1");
       expect(screen.getByTestId("item-listing-ak")).toBeTruthy();
+      expect(analyticsEvents).toContainEqual({
+        event: "cart_add",
+        props: {
+          listingId: "listing-ak",
+          productId: "prod-1",
+          price: "150",
+        },
+      });
     });
 
     it("does not add duplicate items (same listing ID)", () => {
@@ -264,6 +285,14 @@ describe("CartContext", () => {
       expect(screen.getByTestId("count").textContent).toBe("0");
       expect(screen.queryByTestId("item-listing-ak")).toBeNull();
       expect(toast).toHaveBeenCalledWith({ title: CART_REMOVED_MESSAGE });
+      expect(analyticsEvents).toContainEqual({
+        event: "cart_remove",
+        props: {
+          listingId: "listing-ak",
+          productId: "prod-1",
+          price: "150",
+        },
+      });
     });
 
     it("does nothing when removing non-existent item", () => {

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ANALYTICS_EVENTS,
+  analyticsPrice,
+  isAnalyticsSource,
+  marketSearchQuery,
+  readAnalyticsSource,
+  setAnalyticsCollector,
+  track,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "../analytics";
+
+const PII_PROPS = {
+  email: "buyer@test.com",
+  password: "secret-pass",
+  token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.aaa.bbb",
+  jwt: "header.payload.sig",
+  name: "Ana Buyer",
+  accessToken: "access-secret",
+  refreshToken: "refresh-secret",
+};
+
+function collect() {
+  const events: { event: AnalyticsEventName; props: AnalyticsProps }[] = [];
+  setAnalyticsCollector((event, props) => {
+    events.push({ event, props });
+  });
+  return events;
+}
+
+afterEach(() => {
+  setAnalyticsCollector(null);
+  vi.restoreAllMocks();
+});
+
+describe("analytics wrapper", () => {
+  it("exposes every funnel event name", () => {
+    expect([...ANALYTICS_EVENTS]).toEqual([
+      "page_view",
+      "search",
+      "search_result_click",
+      "category_view",
+      "product_view",
+      "cart_add",
+      "cart_remove",
+      "checkout_started",
+      "payment_started",
+      "payment_return",
+      "payment_cancel",
+      "order_viewed",
+      "seller_listing_created",
+    ]);
+  });
+
+  it("no-ops when no collector is registered", () => {
+    expect(() =>
+      track("page_view", { path: "/", role: "guest" }),
+    ).not.toThrow();
+  });
+
+  it("forwards each funnel event to an optional collector", () => {
+    const events = collect();
+    const samples: [AnalyticsEventName, AnalyticsProps][] = [
+      ["page_view", { path: "/", role: "CUSTOMER" }],
+      [
+        "search",
+        { productId: "prod-1", query: "productId=prod-1", source: "market" },
+      ],
+      [
+        "search_result_click",
+        {
+          listingId: "l1",
+          productId: "prod-1",
+          price: "12.50",
+          source: "market",
+        },
+      ],
+      ["category_view", { productId: "prod-1", source: "home" }],
+      [
+        "product_view",
+        {
+          listingId: "l1",
+          productId: "prod-1",
+          price: "12.50",
+          source: "home",
+        },
+      ],
+      [
+        "cart_add",
+        {
+          listingId: "l1",
+          productId: "prod-1",
+          price: "12.50",
+          source: "market",
+        },
+      ],
+      ["cart_remove", { listingId: "l1", productId: "prod-1", price: "12.50" }],
+      ["checkout_started", { itemCount: 1 }],
+      ["payment_started", { orderId: "order-1" }],
+      ["payment_return", { orderId: "order-1" }],
+      ["payment_cancel", { orderId: "order-1" }],
+      ["order_viewed", { orderId: "order-1" }],
+      [
+        "seller_listing_created",
+        {
+          listingId: "l1",
+          productId: "prod-1",
+          price: "18.5",
+          source: "seller",
+        },
+      ],
+    ];
+
+    for (const [event, props] of samples) {
+      track(event, props);
+    }
+
+    expect(events.map((row) => row.event)).toEqual(ANALYTICS_EVENTS);
+    expect(events[0].props).toEqual({ path: "/", role: "CUSTOMER" });
+    expect(events[5].props.price).toBe("12.50");
+  });
+
+  it("strips email, JWT, password and names from event props", () => {
+    const events = collect();
+    track("page_view", {
+      path: "/checkout",
+      role: "CUSTOMER",
+      listingId: "l1",
+      ...(PII_PROPS as unknown as AnalyticsProps),
+    });
+
+    const props = events[0]?.props ?? {};
+    expect(props).toEqual({
+      path: "/checkout",
+      role: "CUSTOMER",
+      listingId: "l1",
+    });
+    expect(JSON.stringify(props)).not.toMatch(
+      /buyer@test.com|secret-pass|eyJhbGci|Ana Buyer|access-secret|refresh-secret/i,
+    );
+  });
+
+  it("keeps price as a string and drops unknown sources", () => {
+    const events = collect();
+    track("cart_add", {
+      listingId: "l1",
+      price: 22 as unknown as string,
+      source: "newsletter" as AnalyticsProps["source"],
+    });
+    expect(events[0].props.price).toBe("22");
+    expect(events[0].props.source).toBeUndefined();
+  });
+
+  it("does not throw when the collector fails", () => {
+    setAnalyticsCollector(() => {
+      throw new Error("sink down");
+    });
+    expect(() => track("checkout_started", { itemCount: 1 })).not.toThrow();
+  });
+});
+
+describe("analytics helpers", () => {
+  it("stringifies prices without using floating-point math", () => {
+    expect(analyticsPrice("10.25")).toBe("10.25");
+    expect(analyticsPrice(18.5)).toBe("18.5");
+    expect(analyticsPrice(undefined)).toBeUndefined();
+  });
+
+  it("reads an allowlisted navigation source", () => {
+    expect(isAnalyticsSource("home")).toBe(true);
+    expect(isAnalyticsSource("email")).toBe(false);
+    expect(readAnalyticsSource({ source: "related" })).toBe("related");
+    expect(readAnalyticsSource({ source: "email" })).toBeUndefined();
+  });
+
+  it("serializes market filters without PII", () => {
+    expect(
+      marketSearchQuery({
+        productId: "ak-redline-ft",
+        exterior: "Factory New",
+        isStattrak: true,
+        minPrice: "10",
+        maxPrice: "40",
+      }),
+    ).toBe(
+      "productId=ak-redline-ft&exterior=Factory+New&isStattrak=true&minPrice=10&maxPrice=40",
+    );
+    expect(marketSearchQuery({})).toBeUndefined();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,178 @@
+/**
+ * Product-analytics wrapper for the storefront funnel.
+ *
+ * No vendor SDK and no required env var. Production is a no-op until a
+ * collector is registered (consent / sink is a later decision).
+ * Track failures never throw.
+ */
+
+export const ANALYTICS_EVENTS = [
+  "page_view",
+  "search",
+  "search_result_click",
+  "category_view",
+  "product_view",
+  "cart_add",
+  "cart_remove",
+  "checkout_started",
+  "payment_started",
+  "payment_return",
+  "payment_cancel",
+  "order_viewed",
+  "seller_listing_created",
+] as const;
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[number];
+
+export const ANALYTICS_SOURCES = [
+  "home",
+  "market",
+  "related",
+  "seller",
+] as const;
+
+export type AnalyticsSource = (typeof ANALYTICS_SOURCES)[number];
+
+export type AnalyticsRole = "ADMIN" | "SELLER" | "CUSTOMER" | "guest";
+
+/** Allowlisted props only. Never email, JWT, password, or names. */
+export interface AnalyticsProps {
+  listingId?: string;
+  productId?: string;
+  price?: string;
+  source?: AnalyticsSource;
+  path?: string;
+  role?: AnalyticsRole;
+  query?: string;
+  category?: string;
+  resultCount?: number;
+  itemCount?: number;
+  orderId?: string;
+}
+
+export type AnalyticsCollector = (
+  event: AnalyticsEventName,
+  props: AnalyticsProps,
+) => void;
+
+const ALLOWED_PROP_KEYS = [
+  "listingId",
+  "productId",
+  "price",
+  "source",
+  "path",
+  "role",
+  "query",
+  "category",
+  "resultCount",
+  "itemCount",
+  "orderId",
+] as const satisfies readonly (keyof AnalyticsProps)[];
+
+const SOURCE_SET = new Set<string>(ANALYTICS_SOURCES);
+const ROLE_SET = new Set<string>(["ADMIN", "SELLER", "CUSTOMER", "guest"]);
+
+let collector: AnalyticsCollector | null = null;
+
+export function setAnalyticsCollector(next: AnalyticsCollector | null): void {
+  collector = next;
+}
+
+export function analyticsPrice(price: unknown): string | undefined {
+  if (price == null || price === "") return undefined;
+  return String(price);
+}
+
+export function isAnalyticsSource(value: unknown): value is AnalyticsSource {
+  return typeof value === "string" && SOURCE_SET.has(value);
+}
+
+export function readAnalyticsSource(
+  state: unknown,
+): AnalyticsSource | undefined {
+  if (!state || typeof state !== "object") return undefined;
+  return isAnalyticsSource((state as { source?: unknown }).source)
+    ? (state as { source: AnalyticsSource }).source
+    : undefined;
+}
+
+export function marketSearchQuery(input: {
+  productId?: string;
+  exterior?: string;
+  isStattrak?: boolean;
+  minPrice?: string;
+  maxPrice?: string;
+}): string | undefined {
+  const params = new URLSearchParams();
+  if (input.productId) params.set("productId", input.productId);
+  if (input.exterior) params.set("exterior", input.exterior);
+  if (input.isStattrak !== undefined) {
+    params.set("isStattrak", String(input.isStattrak));
+  }
+  if (input.minPrice) params.set("minPrice", input.minPrice);
+  if (input.maxPrice) params.set("maxPrice", input.maxPrice);
+  const query = params.toString();
+  return query || undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return value;
+}
+
+function sanitizeProps(props: Record<string, unknown>): AnalyticsProps {
+  const safe: AnalyticsProps = {};
+
+  for (const key of ALLOWED_PROP_KEYS) {
+    const value = props[key];
+    if (value == null || value === "") continue;
+
+    if (key === "source") {
+      if (isAnalyticsSource(value)) safe.source = value;
+      continue;
+    }
+    if (key === "role") {
+      if (typeof value === "string" && ROLE_SET.has(value)) {
+        safe.role = value as AnalyticsRole;
+      }
+      continue;
+    }
+    if (key === "price") {
+      const price = analyticsPrice(value);
+      if (price) safe.price = price;
+      continue;
+    }
+    if (key === "resultCount" || key === "itemCount") {
+      const n = asFiniteNumber(value);
+      if (n !== undefined) safe[key] = n;
+      continue;
+    }
+    if (typeof value === "string") {
+      safe[key] = value;
+    }
+  }
+
+  return safe;
+}
+
+function emitDevConsole(
+  event: AnalyticsEventName,
+  props: AnalyticsProps,
+): void {
+  if (!import.meta.env.DEV) return;
+  if (import.meta.env.MODE === "test") return;
+  console.info("[analytics]", event, props);
+}
+
+export function track(
+  event: AnalyticsEventName,
+  props: AnalyticsProps = {},
+): void {
+  try {
+    const safe = sanitizeProps({ ...(props as Record<string, unknown>) });
+    emitDevConsole(event, safe);
+    collector?.(event, safe);
+  } catch {
+    // Product analytics must never break the UI.
+  }
+}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -27,6 +27,7 @@ import {
   logTechnicalError,
   userFacingApiError,
 } from "@/lib/userFacingApiError";
+import { track } from "@/lib/analytics";
 import type { Order } from "@/types/api";
 
 export default function Checkout() {
@@ -43,6 +44,7 @@ export default function Checkout() {
   const [createdOrder, setCreatedOrder] = useState<Order | null>(null);
   const [now, setNow] = useState(() => Date.now());
   const inFlightRef = useRef(false);
+  const checkoutStartedRef = useRef(false);
   const idempotencyRef = useRef<CheckoutIdempotencyState | null>(null);
   const serviceFee = totalPrice * 0.05;
   const total = totalPrice * 1.05;
@@ -58,6 +60,19 @@ export default function Checkout() {
     const timer = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(timer);
   }, [expiresAt]);
+
+  const canShowCheckout =
+    (items.length > 0 || Boolean(createdOrder)) &&
+    isAuthenticated &&
+    user?.role === "CUSTOMER";
+
+  useEffect(() => {
+    if (!canShowCheckout || items.length === 0 || checkoutStartedRef.current) {
+      return;
+    }
+    checkoutStartedRef.current = true;
+    track("checkout_started", { itemCount: items.length });
+  }, [canShowCheckout, items.length]);
 
   if (items.length === 0 && !loading && !createdOrder) {
     return (
@@ -119,6 +134,7 @@ export default function Checkout() {
       createdOrderId = order.id;
       setCreatedOrder(order);
       removeItems(listingIds);
+      track("payment_started", { orderId: order.id });
       const payment = await createPaymentLink({
         orderId: order.id,
         ...paypalCheckoutUrls(order.id),

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,7 @@ import { listSellers } from "@/api/sellers";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MARKET_VIEW_CTA } from "@/lib/listingCartCta";
+import { track } from "@/lib/analytics";
 import {
   HOME_EMPTY_DESCRIPTION,
   HOME_EMPTY_TITLE,
@@ -108,7 +109,17 @@ export default function IndexPage() {
                 variant="outline"
                 size="sm"
               >
-                <Link to={shortcut.href}>{shortcut.label}</Link>
+                <Link
+                  to={shortcut.href}
+                  onClick={() =>
+                    track("category_view", {
+                      productId: shortcut.productId,
+                      source: "home",
+                    })
+                  }
+                >
+                  {shortcut.label}
+                </Link>
               </Button>
             ))}
           </div>
@@ -173,7 +184,7 @@ export default function IndexPage() {
         listings.length > 0 ? (
           <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {listings.map((listing) => (
-              <ListingCard key={listing.id} listing={listing} />
+              <ListingCard key={listing.id} listing={listing} source="home" />
             ))}
           </div>
         ) : null}

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1,4 +1,5 @@
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { ListingCard, SkinVisual } from "@/components/ProductCard";
@@ -9,6 +10,7 @@ import { getListing, listListings } from "@/api/listings";
 import { getPriceHistory } from "@/api/price-history";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { analyticsPrice, readAnalyticsSource, track } from "@/lib/analytics";
 import {
   isNotFoundApiError,
   isRetryableReadError,
@@ -18,6 +20,8 @@ import {
 export default function ListingDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
+  const source = readAnalyticsSource(location.state);
 
   const {
     data: listing,
@@ -51,6 +55,16 @@ export default function ListingDetail() {
   const related = (relatedData?.items ?? [])
     .filter((item) => item.id !== id)
     .slice(0, 4);
+
+  useEffect(() => {
+    if (!listing) return;
+    track("product_view", {
+      listingId: listing.id,
+      productId: listing.productId,
+      price: analyticsPrice(listing.price),
+      source,
+    });
+  }, [listing, source]);
   const productName = listing
     ? `${listing.product.weapon} | ${listing.product.skinName} (${listing.product.exterior})`
     : "";
@@ -204,7 +218,11 @@ export default function ListingDetail() {
                 Última alteração: ${Number(latestHistory.newPrice).toFixed(2)}
               </p>
             ) : null}
-            <ListingCartCta listing={listing} variant="detail" />
+            <ListingCartCta
+              listing={listing}
+              variant="detail"
+              source={source}
+            />
           </div>
 
           {priceHistory && priceHistory.length > 0 ? (
@@ -239,7 +257,7 @@ export default function ListingDetail() {
           </h2>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {related.map((item) => (
-              <ListingCard key={item.id} listing={item} />
+              <ListingCard key={item.id} listing={item} source="related" />
             ))}
           </div>
         </section>

--- a/src/pages/OrderStatus.tsx
+++ b/src/pages/OrderStatus.tsx
@@ -30,6 +30,7 @@ import {
   paymentStatusLabel,
   userFacingApiError,
 } from "@/lib/userFacingApiError";
+import { track } from "@/lib/analytics";
 import type { Order } from "@/types/api";
 
 function OrderHeadline({
@@ -105,6 +106,7 @@ export default function OrderStatusPage() {
   const [retrying, setRetrying] = useState(false);
   const [retryError, setRetryError] = useState<string | null>(null);
   const captureAttemptedRef = useRef<string | null>(null);
+  const analyticsKeyRef = useRef<string | null>(null);
 
   const {
     data: order,
@@ -127,6 +129,20 @@ export default function OrderStatusPage() {
     const timer = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(timer);
   }, [expiresAt]);
+
+  useEffect(() => {
+    if (!order) return;
+    const key = `${order.id}:${intent}`;
+    if (analyticsKeyRef.current === key) return;
+    analyticsKeyRef.current = key;
+    track("order_viewed", { orderId: order.id });
+    if (intent === "return") {
+      track("payment_return", { orderId: order.id });
+    }
+    if (intent === "cancel") {
+      track("payment_cancel", { orderId: order.id });
+    }
+  }, [order, intent]);
 
   useEffect(() => {
     if (intent !== "return" || !order || !isCustomer) return;
@@ -217,6 +233,7 @@ export default function OrderStatusPage() {
     setRetrying(true);
     setRetryError(null);
     try {
+      track("payment_started", { orderId: order.id });
       const payment = await createPaymentLink({
         orderId: order.id,
         ...paypalCheckoutUrls(order.id),

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Filter } from "lucide-react";
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { marketSearchQuery, track } from "@/lib/analytics";
 
 const EXTERIORS = [
   "",
@@ -86,6 +87,23 @@ export default function Products() {
 
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
+  const searchQuery = marketSearchQuery({
+    productId,
+    exterior,
+    isStattrak,
+    minPrice,
+    maxPrice,
+  });
+
+  useEffect(() => {
+    if (!searchQuery || isLoading || isError) return;
+    track("search", {
+      query: searchQuery,
+      productId,
+      source: "market",
+      resultCount: total,
+    });
+  }, [searchQuery, productId, isLoading, isError, total]);
 
   const sortedItems =
     sort === "price-asc"
@@ -131,6 +149,12 @@ export default function Products() {
                 onClick={() => {
                   setExterior(ext);
                   setPage(1);
+                  if (ext) {
+                    track("category_view", {
+                      category: ext,
+                      source: "market",
+                    });
+                  }
                 }}
               >
                 {ext || "Todos"}
@@ -264,7 +288,7 @@ export default function Products() {
         <>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {sortedItems.map((listing) => (
-              <ListingCard key={listing.id} listing={listing} />
+              <ListingCard key={listing.id} listing={listing} source="market" />
             ))}
           </div>
           {total > PAGE_SIZE && (

--- a/src/pages/__tests__/Checkout.test.tsx
+++ b/src/pages/__tests__/Checkout.test.tsx
@@ -9,6 +9,11 @@ import {
   PAYPAL_SANDBOX_LOGIN_COPY,
 } from "@/lib/orderPaymentView";
 import { USER_FACING_NETWORK } from "@/lib/userFacingApiError";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 
 const createOrder = vi.fn();
 const createPaymentLink = vi.fn();
@@ -169,6 +174,9 @@ function idempotencyKeyOf(call: unknown[]): string {
   return options.idempotencyKey;
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("Checkout", () => {
   const uuidKeys = [
     "11111111-1111-4111-8111-111111111111",
@@ -177,6 +185,10 @@ describe("Checkout", () => {
   ];
 
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -205,6 +217,7 @@ describe("Checkout", () => {
   });
 
   afterEach(() => {
+    setAnalyticsCollector(null);
     vi.restoreAllMocks();
   });
 
@@ -299,6 +312,17 @@ describe("Checkout", () => {
     expect(urls.cancelUrl.startsWith("http")).toBe(true);
     expect(cartState.removeItems).toHaveBeenCalledWith(["listing-ak"]);
     expect(cartState.clearCart).not.toHaveBeenCalled();
+    expect(analyticsEvents).toContainEqual({
+      event: "checkout_started",
+      props: { itemCount: 1 },
+    });
+    expect(analyticsEvents).toContainEqual({
+      event: "payment_started",
+      props: { orderId: "order-1" },
+    });
+    expect(JSON.stringify(analyticsEvents)).not.toMatch(
+      /buyer@|token=EC-1|paypal.com/i,
+    );
     expect(redirectToExternal).toHaveBeenCalledWith(
       "https://www.paypal.com/checkoutnow?token=EC-1",
     );

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -21,6 +21,11 @@ import {
   listingsCountLabel,
 } from "@/lib/homeDiscovery";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 
 const listListings = vi.fn();
 const listProducts = vi.fn();
@@ -115,8 +120,15 @@ function renderHome() {
   );
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("Index", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     localStorage.removeItem(CART_STORAGE_KEY);
     listListings.mockReset();
     listProducts.mockReset();
@@ -138,6 +150,10 @@ describe("Index", () => {
       makeSeller(),
       makeSeller({ id: "seller-2", userId: "user-2" }),
     ]);
+  });
+
+  afterEach(() => {
+    setAnalyticsCollector(null);
   });
 
   it("renders discovery home instead of only eight cards and one button", async () => {
@@ -265,6 +281,25 @@ describe("Index", () => {
 
     await waitFor(() => {
       expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    });
+  });
+
+  it("tracks category_view when a home catalog chip is used", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 8,
+    });
+
+    renderHome();
+    fireEvent.click(
+      await screen.findByRole("link", { name: "AK-47 | Redline" }),
+    );
+
+    expect(analyticsEvents).toContainEqual({
+      event: "category_view",
+      props: { productId: "ak-redline-ft", source: "home" },
     });
   });
 });

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -18,6 +18,11 @@ import {
   CART_CTA_VIEW_CART,
 } from "@/lib/listingCartCta";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 import {
   PRODUCT_REVIEWS_DELETE,
   PRODUCT_REVIEWS_EMPTY,
@@ -136,6 +141,9 @@ function CartProbe() {
   return <span data-testid="cart-count">{totalItems}</span>;
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 function renderDetail(id = "listing-1") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -156,6 +164,10 @@ function renderDetail(id = "listing-1") {
 
 describe("ListingDetail", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     getListing.mockReset();
     listListings.mockReset();
     getPriceHistory.mockReset();
@@ -172,6 +184,10 @@ describe("ListingDetail", () => {
     listListings.mockResolvedValue({ items: [], total: 0, page: 1, limit: 4 });
     getPriceHistory.mockResolvedValue([]);
     listProductReviews.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    setAnalyticsCollector(null);
   });
 
   it("keeps listing facts, history, related cards and add to cart", async () => {
@@ -410,5 +426,22 @@ describe("ListingDetail", () => {
     listProductReviews.mockResolvedValue([makeReview()]);
     fireEvent.click(screen.getByRole("button", { name: "Tentar novamente" }));
     expect(await screen.findByText("Ana")).toBeTruthy();
+  });
+
+  it("tracks product_view without PII when the listing loads", async () => {
+    getListing.mockResolvedValue(makeListing());
+    renderDetail();
+
+    await waitFor(() => {
+      expect(analyticsEvents).toContainEqual({
+        event: "product_view",
+        props: {
+          listingId: "listing-1",
+          productId: "ak-redline-ft",
+          price: "22",
+        },
+      });
+    });
+    expect(JSON.stringify(analyticsEvents)).not.toMatch(/NeonTrader|Ana|@/);
   });
 });

--- a/src/pages/__tests__/OrderStatus.test.tsx
+++ b/src/pages/__tests__/OrderStatus.test.tsx
@@ -14,6 +14,11 @@ import {
   USER_FACING_ORDER_CANCELLED,
 } from "@/lib/userFacingApiError";
 import type { Role, User } from "@/types/api";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 
 const getOrder = vi.fn();
 const createPaymentLink = vi.fn();
@@ -101,8 +106,15 @@ function renderPage(path: string) {
   );
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("OrderStatusPage", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     getOrder.mockReset();
     createPaymentLink.mockReset();
     capturePayment.mockReset();
@@ -122,6 +134,7 @@ describe("OrderStatusPage", () => {
   });
 
   afterEach(() => {
+    setAnalyticsCollector(null);
     vi.restoreAllMocks();
   });
 
@@ -391,5 +404,44 @@ describe("OrderStatusPage", () => {
     expect(
       screen.queryByRole("link", { name: "Voltar aos pedidos" }),
     ).toBeNull();
+  });
+
+  it("tracks order_viewed and payment_return on the PayPal return route", async () => {
+    getOrder.mockResolvedValue(pendingOrder());
+    renderPage("/orders/order-1/return");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Pedido criado. Aguardando confirmação do PayPal.",
+      }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(analyticsEvents).toContainEqual({
+        event: "order_viewed",
+        props: { orderId: "order-1" },
+      });
+      expect(analyticsEvents).toContainEqual({
+        event: "payment_return",
+        props: { orderId: "order-1" },
+      });
+    });
+    expect(JSON.stringify(analyticsEvents)).not.toMatch(/buyer@test.com|Buyer/);
+  });
+
+  it("tracks payment_cancel on the PayPal cancel route", async () => {
+    getOrder.mockResolvedValue(pendingOrder());
+    renderPage("/orders/order-1/cancel");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Você cancelou o pagamento.",
+      }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(analyticsEvents).toContainEqual({
+        event: "payment_cancel",
+        props: { orderId: "order-1" },
+      });
+    });
   });
 });

--- a/src/pages/__tests__/Products.test.tsx
+++ b/src/pages/__tests__/Products.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Products from "../Products";
@@ -11,6 +11,11 @@ import {
   MARKET_VIEW_CTA,
 } from "@/lib/listingCartCta";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 
 const listListings = vi.fn();
 
@@ -77,10 +82,21 @@ function renderMarket(path = "/products") {
   );
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("Products", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     listListings.mockReset();
     localStorage.removeItem(CART_STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    setAnalyticsCollector(null);
   });
 
   it("lists ACTIVE listings without a productId filter by default", async () => {
@@ -168,6 +184,66 @@ describe("Products", () => {
       page: 1,
       limit: 20,
       status: "ACTIVE",
+    });
+  });
+
+  it("tracks search and search_result_click on the market query", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?productId=ak-redline-ft");
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+
+    await waitFor(() => {
+      expect(analyticsEvents).toContainEqual({
+        event: "search",
+        props: {
+          query: "productId=ak-redline-ft",
+          productId: "ak-redline-ft",
+          source: "market",
+          resultCount: 1,
+        },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("link", { name: "AK-47 | Redline (Field-Tested)" }),
+    );
+    expect(analyticsEvents).toContainEqual({
+      event: "search_result_click",
+      props: {
+        listingId: "listing-1",
+        productId: "ak-redline-ft",
+        price: "22",
+        source: "market",
+      },
+    });
+  });
+
+  it("tracks category_view when an exterior chip is selected", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket();
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Factory New" }));
+    expect(analyticsEvents).toContainEqual({
+      event: "category_view",
+      props: { category: "Factory New", source: "market" },
     });
   });
 });

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -53,6 +53,7 @@ import {
   SkinThumb,
   SkinVisual,
 } from "@/components/ProductCard";
+import { analyticsPrice, track } from "@/lib/analytics";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -206,7 +207,7 @@ export default function SellerListings() {
         });
         toast({ title: "Listing atualizado" });
       } else {
-        await createListing({
+        const created = await createListing({
           productId: form.productId,
           floatValue,
           pattern,
@@ -214,6 +215,12 @@ export default function SellerListings() {
           currency: form.currency,
           tradeLockUntil: form.tradeLockUntil || undefined,
           steamAssetId: form.steamAssetId || undefined,
+        });
+        track("seller_listing_created", {
+          listingId: created.id,
+          productId: created.productId,
+          price: analyticsPrice(created.price),
+          source: "seller",
         });
         toast({ title: "Listing criado" });
       }

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -1,8 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import SellerListings from "../SellerListings";
+import { createListing } from "@/api";
 import type { Listing, Product, Seller, User } from "@/types/api";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
 
 const getSellerMe = vi.fn();
 const getSellerListings = vi.fn();
@@ -84,8 +90,15 @@ function listing(overrides: Partial<Listing> = {}): Listing {
   };
 }
 
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
 describe("SellerListings", () => {
   beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
     Element.prototype.scrollIntoView = vi.fn();
     getSellerMe.mockReset();
     getSellerListings.mockReset();
@@ -104,6 +117,10 @@ describe("SellerListings", () => {
       email: "seller@test.com",
       role: "SELLER",
     };
+  });
+
+  afterEach(() => {
+    setAnalyticsCollector(null);
   });
 
   it("keeps unique-item listing CRUD on /seller/listings", async () => {
@@ -261,5 +278,48 @@ describe("SellerListings", () => {
         screen.getByRole("img", { name: "AWP | Asiimov (Field-Tested)" }),
       ).toHaveAttribute("src", "https://cs2.sh/image/awp-asiimov.png");
     });
+  });
+
+  it("tracks seller_listing_created after a successful create", async () => {
+    const created = listing({ id: "listing-new", price: 18.5 });
+    vi.mocked(createListing).mockResolvedValue(created);
+
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Novo Listing" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("option", {
+        name: "AK-47 | Redline (Field-Tested)",
+      }),
+    );
+    fireEvent.change(screen.getByLabelText("Float (0-1)"), {
+      target: { value: "0.25" },
+    });
+    fireEvent.change(screen.getByLabelText("Preço"), {
+      target: { value: "18.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Criar" }));
+
+    await waitFor(() => {
+      expect(createListing).toHaveBeenCalled();
+      expect(analyticsEvents).toContainEqual({
+        event: "seller_listing_created",
+        props: {
+          listingId: "listing-new",
+          productId: "ak-redline-ft",
+          price: "18.5",
+          source: "seller",
+        },
+      });
+    });
+    expect(JSON.stringify(analyticsEvents)).not.toMatch(
+      /seller@test.com|Seller/,
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #102

Minimal storefront analytics: named funnel events, no vendor, no new env var, no PII.

## What changed

- `track(event, props)` wrapper: no-op without a sink, DEV console only, never throws
- Events: `page_view`, `search`, `search_result_click`, `category_view`, `product_view`, `cart_add`, `cart_remove`, `checkout_started`, `payment_started`, `payment_return`, `payment_cancel`, `order_viewed`, `seller_listing_created`
- Allowlisted props only (`listingId`, `productId`, price as string, `source`, `role`). No email, JWT, name, or password
- `docs/product-analytics.md` event catalog
- `server/` untouched

## Acceptance

- Each listed event is covered by wrapper tests and page call sites
- No event contains email, JWT, or password
- App works with the sink off (production stays no-op until consent/collector exists)

## Verification

- `npm run typecheck` → PASS
- `npm run lint` → PASS
- `npm test` → 305 passed
- Browser: DEV console shows `page_view` + `category_view`; no cookie banner; UI unchanged

[Home page unchanged; no cookie banner](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalytics-home.webp)
[Market filters used to fire category_view](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalytics-market.webp)

## Risks

- Production emits nothing until a collector is registered
- Market `search` is filter/productId discovery, not a free-text box

Do not merge from this agent. Do not close the issue from `gh`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

