### PR TITLE
#59 — P1 — Evoluir arquitetura para Modular Monolith explícito

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,13 +89,15 @@ Current domain modules include:
 - auth
 - users
 - sellers
-- products
+- products (Catalog)
 - listings
 - orders
 - payments
-- commissions
+- commissions (Ledger)
 - reviews
 - admin
+
+Allowed in-process imports and composition roots: `docs/architecture/modular-monolith.md` (ADR 0016, `SPEC-0006`).
 
 Do not introduce microservices unless a concrete requirement demonstrates that the modular monolith can no longer satisfy the requirement. Architectural complexity must have a measurable reason.
 

--- a/docs/adr/0016-modular-monolith-boundaries.md
+++ b/docs/adr/0016-modular-monolith-boundaries.md
@@ -1,0 +1,38 @@
+# ADR 0016 — Explicit modular monolith boundaries
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #59 / `SPEC-0006` asks for explicit boundaries for Auth, Users, Sellers, Catalog, Listings, Orders, Payments, Ledger, Reviews, and Admin, plus dependency rules that stop unconstrained cross-module access. It also asks to split large services — especially Payments — into application/domain/infrastructure *when complexity justifies it*.
+
+The backend is already a single Express deployable with domain folders under `server/src/modules/`. PostgreSQL is the source of truth (ADR 0007 keeps Render). Folder names do not match the issue vocabulary: Catalog is `products`, Ledger is `commissions`. Production cross-module imports today are Admin composing existing ADMIN use cases, and mutating modules writing Audit.
+
+`payments.service.ts` is large because it owns PaymentLink claims, webhook event identity, capture, reconciliation, and `confirmPayment`. PayPal HTTP already lives in `shared/utils`. `confirmPayment` sells listings, writes `SellerTransaction`, updates `Seller.balance`, and inserts outbox rows in one local transaction. Extracting collaborators into other modules or an extra layer would risk moving part of that write outside the transaction or creating a Payments → Orders/Listings/Ledger service cycle.
+
+## Decision
+
+1. **Stay a modular monolith.** One API process. No Redis, Kafka, RabbitMQ, SQS, or microservices.
+2. **Map logical names to existing folders.** Do not rename `products` or `commissions`. Catalog = `modules/products`. Ledger = `modules/commissions`. Audit is a supporting module.
+3. **Allowed production imports** are encoded in `server/src/shared/architecture/moduleBoundaries.ts` and described in `docs/architecture/modular-monolith.md`:
+   - every module → `shared/`
+   - Admin → Sellers, Orders, Catalog (`products`), Audit
+   - Payments, Orders, Listings, Sellers, Ledger (`commissions`) → Audit
+   - composition roots (`app.ts`, reservation expiry, PayPal reconcile, seller-ledger reconcile) → the services they already call
+4. **Forbidden:** a domain module importing another domain module's service, repository, DTO, or routes unless the edge is listed. `shared/` outside jobs must not import `modules/`.
+5. **Cross-table Prisma writes are not import violations** when they are a named workflow (order create + reserve; payment confirm + sell + ledger + outbox; payment-link claim). The owning service keeps the transaction.
+6. **Do not split Payments in this change.** Complexity is transactional coupling, not missing folders. An application/domain/infrastructure split is deferred until a later Specification shows it can preserve `confirmPayment` atomicity, webhook idempotency, and no-retry `OrdersCreate` / `OrdersCapture`.
+7. **Enforce with a unit test**, not a new linter dependency.
+
+## Rollback
+
+Delete the architecture contract, ADR, map doc, and unit test. Runtime behavior does not depend on them.
+
+## Consequences
+
+- A new cross-module production import fails CI unit tests unless the graph is updated in the same change.
+- Agents must not "fix" boundary violations by calling another module's service from inside a payment or reservation transaction.
+- Interviewers can point at a single map: logical name, folder, owner, allowed edges.
+- Payments remains one application service with the PayPal adapter already isolated in `shared/utils`.

--- a/docs/architecture/c4.md
+++ b/docs/architecture/c4.md
@@ -158,9 +158,9 @@ Some services still call Prisma directly; that is a known inconsistency, not a s
                          └─ /health  /ready  /docs
                                     │
         ┌──────────┬──────────┬─────┴──────┬──────────┐
-        │ auth     │ users    │ sellers    │ products │
-        │ listings │ orders   │ payments   │ …        │
-        │ reviews  │ admin    │ commissions│          │
+        │ auth     │ users    │ sellers    │ products (Catalog) │
+        │ listings │ orders   │ payments   │ commissions (Ledger)│
+        │ reviews  │ admin    │ audit      │                    │
         └──────────┴──────────┴────────────┴──────────┘
                                     │
                     shared: jwt, hash, paypal client,
@@ -179,7 +179,7 @@ C4Component
     Component(listings, "listings", "modules/listings", "Unique items; reserve/expire")
     Component(orders, "orders", "modules/orders", "Checkout + Idempotency-Key")
     Component(payments, "payments", "modules/payments", "PaymentLink, webhook, confirmPayment")
-    Component(other, "other domains", "users, sellers, products, commissions, reviews, admin")
+    Component(other, "other domains", "users, sellers, products/Catalog, commissions/Ledger, reviews, admin, audit")
     Component(jobs, "in-process jobs", "shared/jobs", "Expiry + PayPal GET + seller ledger reconcile + outbox")
     Component(paypalc, "PayPal adapter", "shared/utils", "Create/capture/GET; webhook RSA-SHA256")
     ComponentDb(db, "PostgreSQL", "Prisma")
@@ -207,7 +207,8 @@ C4Component
 | HTTP edge (`app.ts`) | Untrusted input. Captures `rawBody` for webhook signatures. Global in-memory rate limit. |
 | auth | bcrypt passwords; Bearer access JWT; refresh token families (`RefreshToken` allowlist, reuse revokes family); per-email login throttle. ADMIN is not a public register role. |
 | listings / orders | Unique listing: conditional `ACTIVE → RESERVED` in the same transaction as the order. |
-| payments | Client cannot mark paid. `PaymentLink` before `OrdersCreate`. Capture after approval (`POST /payments/capture`). Webhook unsigned until verified. Only PayPal `COMPLETED` sells. |
+| payments | Client cannot mark paid. `PaymentLink` before `OrdersCreate`. Capture after approval (`POST /payments/capture`). Webhook unsigned until verified. Only PayPal `COMPLETED` sells. Not split into extra layers (ADR 0016). |
+| Catalog / Ledger | Catalog = `modules/products`. Ledger = `modules/commissions`. Import rules: `docs/architecture/modular-monolith.md`. |
 | jobs | Same invariants as HTTP paths; they are not a second source of truth. |
 | Prisma / PostgreSQL | Constraints (idempotency key, webhook event id, seller txn per order) enforce what the process might retry. |
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -16,13 +16,14 @@ Express API
        +--> auth
        +--> users
        +--> sellers
-       +--> products
+       +--> products      (Catalog)
        +--> listings
        +--> orders
        +--> payments
-       +--> commissions
+       +--> commissions   (Ledger)
        +--> reviews
        +--> admin
+       +--> audit         (supporting)
        |
        v
 PostgreSQL via Prisma
@@ -52,6 +53,8 @@ Prisma / PostgreSQL
 ```
 
 Shared infrastructure belongs in `server/src/shared/`. Business behavior belongs in `server/src/modules/<domain>/`.
+
+Logical module names, allowed import edges, and composition-root exceptions are in `docs/architecture/modular-monolith.md`. The executable graph is `server/src/shared/architecture/moduleBoundaries.ts` (ADR 0016, `SPEC-0006`). Catalog is the `products` folder; Ledger is the `commissions` folder. Do not rename those folders. Payments stays one application service: PayPal HTTP is already in `shared/utils`, and `confirmPayment` remains a single local transaction. Do not add a module-to-module service call to look layered.
 
 ### Important current inconsistency
 
@@ -120,7 +123,7 @@ Agents must inspect the actual `.env.example` and configuration modules before i
 
 ## Architectural rules
 
-- Keep the backend modular-monolith unless a concrete scaling or isolation requirement proves otherwise.
+- Keep the backend modular-monolith unless a concrete scaling or isolation requirement proves otherwise. Module names, allowed imports, and Payments layering: `docs/architecture/modular-monolith.md`.
 - Keep PostgreSQL authoritative for transactional state.
 - Keep transaction boundaries explicit.
 - Prefer atomic database operations for invariants.

--- a/docs/architecture/modular-monolith.md
+++ b/docs/architecture/modular-monolith.md
@@ -1,0 +1,95 @@
+# Modular monolith — module boundaries
+
+Authoritative import graph: `server/src/shared/architecture/moduleBoundaries.ts`.
+Decision: `docs/adr/0016-modular-monolith-boundaries.md`.
+Contract: `SPEC-0006`.
+
+This is one Express API process and one PostgreSQL database. Modules are folders, not services.
+
+## Logical modules
+
+| Logical name | Folder | Owns |
+|---|---|---|
+| Auth | `modules/auth` | Register, email verify, login, refresh families, logout, login throttle |
+| Users | `modules/users` | Authenticated profile (`/users/me`) |
+| Sellers | `modules/sellers` | Seller records and approval writes |
+| Catalog | `modules/products` | Product catalog and cs2.sh import |
+| Listings | `modules/listings` | Unique items, reservation/expiry, price history |
+| Orders | `modules/orders` | Checkout, idempotency key, fulfillment status |
+| Payments | `modules/payments` | PaymentLink, webhook claim, capture, `confirmPayment`, PayPal GET reconcile |
+| Ledger | `modules/commissions` | `Seller.balance` projection reads and projection-only reconcile |
+| Reviews | `modules/reviews` | Product reviews |
+| Admin | `modules/admin` | ADMIN composition: users, orders, seller approval, audit read, catalog import |
+| Audit | `modules/audit` | Append-only `AuditLog` (supporting; not a marketplace domain) |
+
+HTTP mounts stay `/products` and `/commissions`. Do not rename folders to match logical names.
+
+## Layering inside a module
+
+```text
+Routes / Controllers
+      ↓
+Application / Domain services
+      ↓
+Repositories (when present)
+      ↓
+Prisma / PostgreSQL
+```
+
+Some services still call Prisma directly. That is a known inconsistency (`docs/architecture/current-state.md`). Do not start a repository rewrite from this document.
+
+Shared infrastructure (`jwt`, PayPal client, money helpers, outbox, observability, middleware) lives in `server/src/shared/`. Business rules live in the owning module.
+
+## Allowed production imports
+
+```text
+*            → shared/
+admin        → sellers, orders, products (Catalog), audit
+payments     → audit
+orders       → audit
+listings     → audit
+sellers      → audit
+commissions  → audit   (Ledger)
+```
+
+All other module → module production imports are forbidden.
+
+### Composition roots (not modules)
+
+| Root | May import |
+|---|---|
+| `server/src/app.ts` | Any module route barrel already mounted |
+| `shared/jobs/reservationExpiryJob.ts` | `listings` |
+| `shared/jobs/paypalReconciliationJob.ts` | `payments` |
+| `shared/jobs/sellerLedgerReconciliationJob.ts` | `commissions` (Ledger) |
+| `shared/jobs/outboxDispatcherJob.ts` | `shared/outbox` only |
+
+Other production files under `shared/` must not import `modules/`. Tests and scripts may import any module.
+
+## Cross-table writes (allowed without importing the other service)
+
+PostgreSQL transactions may touch tables owned by more than one module for these workflows only:
+
+1. **Order create** — `Order`, `OrderItem`, `OrderIdempotencyKey`, listing `ACTIVE → RESERVED` in one transaction (`INV-ORDER-ATOMIC-CREATE`).
+2. **Payment confirm** — claim order, listing `RESERVED → SOLD`, `SellerTransaction`, `Seller.balance` increment, outbox insert (`INV-PAYMENT-TRUSTED-CONFIRM`, `INV-SELLER-LEDGER-SOURCE`).
+3. **Payment link claim** — `PaymentLink` plus `Order.paypalOrderId` after `OrdersCreate` (`INV-PAYMENT-LINK-IDEMPOTENT`).
+
+Ledger *writes* on confirm belong to Payments. Ledger *projection reconcile* belongs to `commissions`. Do not invert that by having Payments import `commissionsService` or Listings import `ordersService`.
+
+## Payments layering
+
+Payments is **not** split into application/domain/infrastructure here.
+
+- PayPal HTTP and webhook crypto already sit in `shared/utils`.
+- `confirmPayment` must remain one local transaction.
+- `OrdersCreate` and `OrdersCapture` are not retried.
+
+A later change may split the file only with a Specification that preserves those rules.
+
+## How to add a dependency
+
+1. Justify the edge in the same PR (composition vs a new domain leak).
+2. Update `moduleBoundaries.ts` and this document together.
+3. Keep transactional writes in the owning service.
+
+Do not add a module import to "look layered" when a Prisma write inside the existing transaction is the correct modular-monolith move.

--- a/docs/plans/PLAN-0003-modular-monolith-boundaries.md
+++ b/docs/plans/PLAN-0003-modular-monolith-boundaries.md
@@ -1,0 +1,143 @@
+---
+id: PLAN-0003
+status: Ready
+version: 1
+source_spec: SPEC-0006
+source_spec_version: 1
+baseline_revision: 191d5c80a884e950bb4516f9afc2cc926c33c268
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [PLAN-0003] — Explicit modular monolith boundaries
+
+## Status
+
+`Ready`
+
+## Source
+
+- Specification: `SPEC-0006` v1
+- Issue: `#59`
+- Planning task: issue #59 Backend + Reliability + Security + Test + Verification
+- Baseline: `191d5c80a884e950bb4516f9afc2cc926c33c268`
+
+The Plan derives implementation work from the Specification. It may narrow implementation choices but must not add, remove, or reinterpret acceptance criteria.
+
+## Current State
+
+Inspected at the baseline:
+
+- Domain folders exist under `server/src/modules/`: auth, users, sellers, products, listings, orders, payments, commissions, reviews, admin, audit.
+- Issue #59 names Catalog and Ledger; folders are `products` and `commissions`.
+- Production cross-module imports are Admin composing sellers/orders/products/audit, and mutating modules writing Audit.
+- `app.ts` mounts routes. In-process jobs import listings, payments, and commissions services.
+- `payments.service.ts` owns PaymentLink, webhook claim, capture, reconcile, and `confirmPayment`. PayPal HTTP is in `shared/utils`.
+- No machine-readable import graph. No eslint/dependency-cruiser.
+- `SPEC-0005` is already the API security-hardening Specification (#58). This Plan uses `SPEC-0006`.
+
+## Goal
+
+Document the module map and allowed edges, encode them in TypeScript, and fail unit tests on forbidden production imports. Do not rename folders, split Payments, or change runtime behavior.
+
+## Affected Areas
+
+- `docs/specs/SPEC-0006-modular-monolith-boundaries.md`
+- `docs/plans/PLAN-0003-modular-monolith-boundaries.md`
+- `docs/tasks/TASK-0006-enforce-module-boundaries.md`
+- `docs/adr/0016-modular-monolith-boundaries.md`
+- `docs/architecture/modular-monolith.md`
+- `docs/architecture/current-state.md`
+- `docs/architecture/c4.md`
+- `AGENTS.md` (module list pointer only)
+- `server/src/shared/architecture/moduleBoundaries.ts`
+- `server/src/shared/architecture/__tests__/moduleBoundaries.test.ts`
+
+No Prisma schema, route, or `src/` client changes.
+
+## Architecture
+
+Keep the modular monolith. Composition roots (`app.ts`, documented jobs) wire modules. Domain modules do not call each other's services except Admin → {Sellers, Orders, Catalog, Audit} and mutating modules → Audit. Cross-table writes stay inside existing transactions. ADR 0016 records the Payments non-split.
+
+## Database
+
+None. No schema, migration, lock, or constraint change. Existing reservation, payment-confirm, and ledger transactions are unchanged.
+
+## Implementation Sequence
+
+1. Accept `SPEC-0006` and mark this Plan Ready against baseline `191d5c80a884e950bb4516f9afc2cc926c33c268`.
+2. Write ADR 0016 and the architecture map.
+3. Encode the graph in `moduleBoundaries.ts` with a production-source scanner.
+4. Add unit tests for the live tree and a synthetic forbidden edge.
+5. Point `current-state.md`, `c4.md`, and `AGENTS.md` at the map.
+6. Run factory validation, unit, and integration suites.
+
+## Task Graph
+
+```text
+TASK-0006
+```
+
+Single sequential task: docs and the scanner share the same graph.
+
+## Testing Strategy
+
+| Criterion | Test |
+|---|---|
+| AC-01 | Unit: logical names map, Catalog=`products`, Ledger=`commissions` |
+| AC-02 | Unit: `ALLOWED_MODULE_EDGES` matches Admin + Audit edges |
+| AC-03 | Unit: `isModuleEdgeAllowed("payments", "orders")` is false |
+| AC-04 | Unit: `findImportViolations(srcRoot)` is empty |
+| AC-05 | Manual review of the diff + ADR 0016 |
+| AC-06 | Existing integration suite (reservation, payment, ledger) |
+
+## Verification Strategy
+
+Independent verifier runs:
+
+1. `python3 scripts/ai-factory/validate.py`
+2. `cd server && npm run test:unit`
+3. `cd server && npm run test:integration`
+
+PostgreSQL is required for step 3. No PayPal credentials. No browser. Inspect the diff: no `src/` edits, no Payments layering, no auth/CORS/rate-limit weakening.
+
+## Risks
+
+- Over-strict graph would force a Payments/Orders/Listings service rewrite and risk transactional invariants. Mitigation: encode the current legal edges only; allow named cross-table SQL. Detection: AC-04 empty-violation test.
+- Speculative Payments split could hide `confirmPayment` atomicity. Mitigation: `SPEC-0006` BR-08 rejects the split. Residual: the file stays large.
+- SPEC ID collision with #58 (`SPEC-0005`). Mitigation: this work is `SPEC-0006`.
+
+## Dependencies
+
+- `SPEC-0006` v1 Accepted
+- ADR 0007 Render; ADR 0011 seller ledger; ADR 0016 written in the same change
+
+## Stop Conditions
+
+- Request to rename folders, add microservices, or split Payments into application/domain/infrastructure
+- Evidence that current production imports already violate the intended graph in a way that requires a payment-path rewrite
+- Source Specification version change
+
+## Definition of Done
+
+Logical modules are mapped, the graph is documented and tested, current production imports pass, Payments is not split, factory validation passes, and unit plus integration suites pass.
+
+## Traceability
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+- Issue: `#59`
+- Specification: `SPEC-0006` v1
+- Plan: `PLAN-0003` v1
+- Tasks: `TASK-0006`
+- PR: pending
+- Verification/Convergence: pending
+- Evaluation: pending
+- Memory: pending
+
+## Change History
+
+- `v1` — Ready plan for SPEC-0006 — 2026-09-06

--- a/docs/specs/SPEC-0006-modular-monolith-boundaries.md
+++ b/docs/specs/SPEC-0006-modular-monolith-boundaries.md
@@ -1,0 +1,178 @@
+---
+id: SPEC-0006
+status: Accepted
+version: 1
+source_issue: "#59"
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [SPEC-0006] — Explicit modular monolith boundaries
+
+## Status
+
+`Accepted`
+
+This Specification authorizes documenting and enforcing in-process module boundaries. It does not change marketplace business behavior, public HTTP contracts, payment semantics, or the PostgreSQL schema.
+
+## Problem
+
+The backend already lives under `server/src/modules/*`, but the logical modules named by issue #59 (Auth, Users, Sellers, Catalog, Listings, Orders, Payments, Ledger, Reviews, Admin) are not mapped, dependency rules are not written down, and nothing fails when one module imports another module's internals. That makes the modular monolith implicit and easy to erode.
+
+## Goal
+
+Make the modular monolith explicit: every named domain module has a folder, owner, and allowed dependency set. Production source must not import another module except on a documented edge. Enforcement is a unit test over the existing folder tree, not a new runtime or microservice split.
+
+## Actors
+
+- Backend agent implementing or reviewing `server/` changes
+- Verification agent running unit and integration suites
+- Express composition root (`app.ts`) and in-process jobs
+- PostgreSQL as the transactional source of truth
+
+## Scope
+
+- Map logical module names to existing folders (`products` = Catalog, `commissions` = Ledger).
+- Document allowed module-to-module imports and composition-root exceptions.
+- Document that cross-table Prisma writes remain allowed only for named transactional workflows.
+- Enforce the import graph with a machine-readable contract and a unit test.
+- Record why Payments is not split into application/domain/infrastructure in this change.
+
+## Non-goals
+
+- Renaming `products` or `commissions` folders.
+- Introducing microservices, Redis, Kafka, RabbitMQ, SQS, or extra processes.
+- Changing PayPal contracts, refunds, retries of `OrdersCreate` / `OrdersCapture`, or environment variables.
+- Changing authentication, authorization, CORS, rate limits, or public API shapes.
+- Schema or migration changes.
+- Splitting `payments.service.ts` unless a later Specification proves that layering reduces risk without breaking `confirmPayment` atomicity.
+- Moving Prisma access out of services as a repository rewrite.
+
+## Business Rules
+
+- `BR-01`: The deployable remains one Express process plus PostgreSQL. Module boundaries are in-process.
+- `BR-02`: Logical modules are Auth, Users, Sellers, Catalog, Listings, Orders, Payments, Ledger, Reviews, and Admin. Catalog is implemented as `modules/products`. Ledger is implemented as `modules/commissions`. Audit is a supporting module, not a marketplace domain.
+- `BR-03`: Production files under `server/src/modules/<name>/` may import their own module and `server/src/shared/`. They may import another module only when that edge is listed in the allowed graph.
+- `BR-04`: Admin is a composition module. It may import Sellers, Orders, Catalog (`products`), and Audit for ADMIN HTTP use cases already implemented.
+- `BR-05`: Mutating domain modules that already write `AuditLog` may import Audit. New domain-to-domain service imports are forbidden.
+- `BR-06`: `app.ts` and documented in-process jobs are composition roots. They may import the module services or routes they already orchestrate. Other `shared/` production files must not import `modules/`.
+- `BR-07`: A single PostgreSQL transaction may write tables owned by more than one module when the write is a named workflow (order create + reserve; payment confirm + sell + ledger + outbox; payment-link claim). That is not permission to import the other module's service.
+- `BR-08`: Payments stays one application service. PayPal HTTP already lives in `shared/utils`. `confirmPayment` remains one local transaction. An application/domain/infrastructure split is out of scope until complexity is shown to justify it without weakening payment invariants.
+- `BR-09`: Tests and scripts may import any module. Enforcement applies to production source.
+
+## Invariants
+
+This Specification does not add or redefine domain invariants. The import graph must not weaken:
+
+- `INV-LISTING-EXCLUSIVE-RESERVE`
+- `INV-LISTING-SOLD-IRREVERSIBLE`
+- `INV-LISTING-RESERVATION-TTL`
+- `INV-ORDER-ATOMIC-CREATE`
+- `INV-ORDER-IDEMPOTENCY`
+- `INV-PAYMENT-TRUSTED-CONFIRM`
+- `INV-PAYMENT-WEBHOOK-IDEMPOTENT`
+- `INV-PAYMENT-LINK-IDEMPOTENT`
+- `INV-SELLER-LEDGER-SOURCE`
+- `INV-SELLER-TXN-UNIQUE`
+- `INV-AUTH-OWNERSHIP`
+- `INV-AUDIT-APPEND-ONLY`
+
+## State Transitions
+
+No listing, order, payment, or seller-ledger transition changes.
+
+Module membership is static. Adding a new domain folder requires updating the machine-readable graph in the same change.
+
+## API / Data Contract
+
+No public HTTP, webhook, or Prisma schema change.
+
+The internal contract is `server/src/shared/architecture/moduleBoundaries.ts`:
+
+- folder ↔ logical name
+- allowed module edges
+- composition-root exceptions
+
+Documentation in `docs/architecture/modular-monolith.md` must match that file.
+
+## Concurrency Model
+
+Import enforcement is a static unit test. It does not participate in request concurrency.
+
+Named cross-table transactions stay the concurrency boundary for reservation, payment confirmation, and ledger writes. This Specification must not move those writes behind service calls that run outside the existing transaction.
+
+## Failure Modes
+
+- A forbidden production import is added: the module-boundary unit test fails.
+- The documented graph and the TypeScript contract disagree: the unit test or review fails; the TypeScript file wins until docs are updated.
+- A future Payments split that extracts `confirmPayment` collaborators incorrectly: payment confirmation could lose atomicity. That split is rejected here.
+- Process crash, webhook duplicate, and PayPal timeout behavior are unchanged and remain owned by existing payment/reliability ADRs.
+
+## Security
+
+- Authentication, authorization, CORS, rate limits, and webhook signature verification stay in their current modules and shared middleware.
+- The graph must not let a customer-facing module import Admin internals.
+- Audit remains append-only and ADMIN-readable. Importing Audit is not permission to read the trail from non-Admin modules.
+
+## Observability
+
+No new metrics or spans. Existing payment, reservation, ledger, and outbox signals stay in their current services.
+
+## Backward Compatibility
+
+Additive documentation and a failing-closed unit test. Existing clients, migrations, and Render topology are unchanged. Folder names stay `products` and `commissions` so HTTP mounts (`/products`, `/commissions`) do not move.
+
+## Acceptance Criteria
+
+- [ ] `AC-01` — Auth, Users, Sellers, Catalog, Listings, Orders, Payments, Ledger, Reviews, and Admin are mapped to existing `server/src/modules/*` folders, including Catalog=`products` and Ledger=`commissions`. **Evidence:** test
+- [ ] `AC-02` — Allowed production module-to-module imports are documented and encoded in `moduleBoundaries.ts`. **Evidence:** test
+- [ ] `AC-03` — A production import that is not an allowed edge fails the unit test. **Evidence:** test
+- [ ] `AC-04` — Current production source on this branch satisfies the allowed graph (no drive-by import rewrites required). **Evidence:** test
+- [ ] `AC-05` — Payments is not split into application/domain/infrastructure in this change; the decision is recorded in the ADR. **Evidence:** manual review
+- [ ] `AC-06` — Public API, authz, CORS, rate limits, PayPal contracts, and schema are unchanged. **Evidence:** integration
+
+## Verification Strategy
+
+- Required commands: `cd server && npm run test:unit`; `cd server && npm run test:integration`; `python3 scripts/ai-factory/validate.py`
+- Unit tests: module-boundary graph + negative forbidden-import case
+- Integration tests: existing reservation/payment/ledger suites prove behavior did not change
+- Security/contract checks: no auth, CORS, rate-limit, or OpenAPI edits
+- Runtime/manual checks: inspect the diff for `src/` edits and Payments layering
+- Required external evidence: none (no provider contract change)
+
+The final implementation must be traceable from each material acceptance criterion to evidence.
+
+## Decisions / References
+
+- Issue `#59`
+- `docs/architecture/current-state.md`
+- `docs/architecture/c4.md`
+- `docs/architecture/domain-invariants.md`
+- `docs/adr/0016-modular-monolith-boundaries.md`
+- `docs/adr/0007-cloud-target-render.md`
+- `docs/adr/0011-seller-ledger.md`
+- `docs/architecture/ai-engineering-authority.md`
+
+## Traceability
+
+Material changes must preserve this chain:
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+### Traceability metadata
+
+- Issue: `#59`
+- Spec: `SPEC-0006`
+- Plan: `PLAN-0003`
+- Tasks: `TASK-0006`
+- PR: pending
+- Verification/Convergence: pending
+- Evaluation: pending F5
+- Memory: pending F6
+
+## Change History
+
+- `v1` — Initial accepted modular-monolith boundary contract — 2026-09-06

--- a/docs/tasks/TASK-0006-enforce-module-boundaries.md
+++ b/docs/tasks/TASK-0006-enforce-module-boundaries.md
@@ -1,0 +1,49 @@
+# [TASK-0006] — Enforce modular monolith import boundaries
+
+## Source
+
+- Specification: `SPEC-0006`
+- Plan: `PLAN-0003`
+- Issue: #59
+
+## Objective
+
+Land the module map, ADR, machine-readable allowed-import graph, and unit-test enforcement without changing runtime behavior or splitting Payments.
+
+## Scope
+
+Architecture docs, ADR 0016, `server/src/shared/architecture/*`, and factory artifacts for #59. Unrelated cleanup is out of scope. Do not edit `src/`.
+
+## Preconditions
+
+- Isolated worktree from `origin/main` at PLAN-0003 `baseline_revision`
+- `SPEC-0006` accepted
+- Current production cross-module imports are Admin composition and Audit writes only
+
+## Acceptance Criteria
+
+- [ ] AC-01: Logical module names map to folders, including Catalog=`products` and Ledger=`commissions`
+- [ ] AC-02: Allowed edges live in `moduleBoundaries.ts` and `docs/architecture/modular-monolith.md`
+- [ ] AC-03: Unit test fails a forbidden production import and passes the current tree
+- [ ] AC-04: Payments service is not re-layered
+- [ ] AC-05: `npm run test:unit` and `npm run test:integration` pass
+
+## Dependencies
+
+`PLAN-0003` Ready.
+
+## Risks
+
+Encoding a stricter graph than the current tree would require importing refactors inside payment/order transactions.
+
+## Verification Command
+
+```bash
+python3 scripts/ai-factory/validate.py
+cd server && npm run test:unit
+cd server && npm run test:integration
+```
+
+## Expected Evidence
+
+Validator PASS. Unit suite PASS including `moduleBoundaries.test.ts`. Integration suite PASS with no payment/reservation failures. Diff contains no `src/` and no Payments split.

--- a/server/src/shared/architecture/__tests__/moduleBoundaries.test.ts
+++ b/server/src/shared/architecture/__tests__/moduleBoundaries.test.ts
@@ -1,0 +1,106 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ALLOWED_MODULE_EDGES,
+  DOMAIN_MODULE_FOLDERS,
+  LOGICAL_MODULE_NAMES,
+  extractImportSpecifiers,
+  findImportViolations,
+  isModuleEdgeAllowed,
+  requiredLogicalModulesAreMapped,
+  resolveImportTarget,
+} from "../moduleBoundaries.js";
+
+const srcRoot = resolveSrcRoot();
+
+function resolveSrcRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "..", "..");
+}
+
+describe("SPEC-0006 modular monolith map", () => {
+  it("maps Auth, Users, Sellers, Catalog, Listings, Orders, Payments, Ledger, Reviews, and Admin", () => {
+    expect(requiredLogicalModulesAreMapped()).toBe(true);
+    expect(LOGICAL_MODULE_NAMES.products).toBe("Catalog");
+    expect(LOGICAL_MODULE_NAMES.commissions).toBe("Ledger");
+    expect(DOMAIN_MODULE_FOLDERS).toContain("products");
+    expect(DOMAIN_MODULE_FOLDERS).toContain("commissions");
+    expect(DOMAIN_MODULE_FOLDERS).toContain("audit");
+  });
+
+  it("encodes Admin composition and Audit write edges only", () => {
+    expect(ALLOWED_MODULE_EDGES.admin).toEqual(["sellers", "orders", "products", "audit"]);
+    expect(ALLOWED_MODULE_EDGES.payments).toEqual(["audit"]);
+    expect(ALLOWED_MODULE_EDGES.orders).toEqual(["audit"]);
+    expect(ALLOWED_MODULE_EDGES.listings).toEqual(["audit"]);
+    expect(ALLOWED_MODULE_EDGES.sellers).toEqual(["audit"]);
+    expect(ALLOWED_MODULE_EDGES.commissions).toEqual(["audit"]);
+    expect(ALLOWED_MODULE_EDGES.auth).toEqual([]);
+    expect(ALLOWED_MODULE_EDGES.reviews).toEqual([]);
+    expect(isModuleEdgeAllowed("payments", "orders")).toBe(false);
+    expect(isModuleEdgeAllowed("orders", "listings")).toBe(false);
+    expect(isModuleEdgeAllowed("reviews", "products")).toBe(false);
+    expect(isModuleEdgeAllowed("admin", "sellers")).toBe(true);
+    expect(isModuleEdgeAllowed("payments", "audit")).toBe(true);
+  });
+});
+
+describe("import specifier parsing", () => {
+  it("reads static, type, multiline, and dynamic imports", () => {
+    const source = `
+      import { auditRepository } from "../audit/audit.repository.js";
+      import type { AuditActor } from "../audit/audit.types.js";
+      import {
+        listingsService,
+      } from "../../modules/listings/listings.service.js";
+      export { ordersRepository } from "../orders/orders.repository.js";
+      const loaded = await import("../payments/payments.service.js");
+      export const label = "from 'not-an-import'";
+    `;
+    expect(extractImportSpecifiers(source)).toEqual([
+      "../audit/audit.repository.js",
+      "../audit/audit.types.js",
+      "../../modules/listings/listings.service.js",
+      "../orders/orders.repository.js",
+      "../payments/payments.service.js",
+    ]);
+  });
+
+  it("resolves relative module and shared targets", () => {
+    const fromPayments = join(srcRoot, "modules", "payments", "payments.service.ts");
+    expect(resolveImportTarget(fromPayments, "../audit/audit.repository.js", srcRoot)).toEqual({
+      specifier: "../audit/audit.repository.js",
+      kind: "module",
+      targetModule: "audit",
+    });
+    expect(resolveImportTarget(fromPayments, "../../shared/utils/paypal.js", srcRoot)).toEqual({
+      specifier: "../../shared/utils/paypal.js",
+      kind: "shared",
+      targetModule: null,
+    });
+    expect(resolveImportTarget(fromPayments, "@prisma/client", srcRoot)).toEqual({
+      specifier: "@prisma/client",
+      kind: "package",
+      targetModule: null,
+    });
+  });
+});
+
+describe("production source graph", () => {
+  it("has no forbidden production module imports", () => {
+    const violations = findImportViolations(srcRoot);
+    expect(violations).toEqual([]);
+  });
+
+  it("rejects a synthetic Payments → Orders service import", () => {
+    const paymentsFile = join(srcRoot, "modules", "payments", "payments.service.ts");
+    const resolved = resolveImportTarget(
+      paymentsFile,
+      "../orders/orders.service.js",
+      srcRoot
+    );
+    expect(resolved.targetModule).toBe("orders");
+    expect(isModuleEdgeAllowed("payments", "orders")).toBe(false);
+  });
+});

--- a/server/src/shared/architecture/moduleBoundaries.ts
+++ b/server/src/shared/architecture/moduleBoundaries.ts
@@ -1,0 +1,260 @@
+/**
+ * Explicit modular-monolith import graph (issue #59, SPEC-0006, ADR 0016).
+ *
+ * Folder names stay products (Catalog) and commissions (Ledger).
+ * This file is the executable contract; docs/architecture/modular-monolith.md
+ * must stay aligned with it.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+
+export const DOMAIN_MODULE_FOLDERS = [
+  "auth",
+  "users",
+  "sellers",
+  "products",
+  "listings",
+  "orders",
+  "payments",
+  "commissions",
+  "reviews",
+  "admin",
+  "audit",
+] as const;
+
+export type DomainModuleFolder = (typeof DOMAIN_MODULE_FOLDERS)[number];
+
+export const LOGICAL_MODULE_NAMES = {
+  auth: "Auth",
+  users: "Users",
+  sellers: "Sellers",
+  products: "Catalog",
+  listings: "Listings",
+  orders: "Orders",
+  payments: "Payments",
+  commissions: "Ledger",
+  reviews: "Reviews",
+  admin: "Admin",
+  audit: "Audit",
+} as const satisfies Record<DomainModuleFolder, string>;
+
+export const REQUIRED_LOGICAL_MODULES = [
+  "Auth",
+  "Users",
+  "Sellers",
+  "Catalog",
+  "Listings",
+  "Orders",
+  "Payments",
+  "Ledger",
+  "Reviews",
+  "Admin",
+] as const;
+
+/** Production module → module edges. Every module may also import shared/. */
+export const ALLOWED_MODULE_EDGES: Record<DomainModuleFolder, readonly DomainModuleFolder[]> = {
+  auth: [],
+  users: [],
+  sellers: ["audit"],
+  products: [],
+  listings: ["audit"],
+  orders: ["audit"],
+  payments: ["audit"],
+  commissions: ["audit"],
+  reviews: [],
+  admin: ["sellers", "orders", "products", "audit"],
+  audit: [],
+};
+
+export type ImportKind = "package" | "shared" | "module" | "unknown";
+
+export type ResolvedImport = {
+  specifier: string;
+  kind: ImportKind;
+  targetModule: DomainModuleFolder | null;
+};
+
+export type ImportViolation = {
+  file: string;
+  specifier: string;
+  fromModule: DomainModuleFolder | "shared" | "composition";
+  toModule: DomainModuleFolder | "shared" | "unknown";
+  reason: string;
+};
+
+const IMPORT_FROM_RE =
+  /\b(?:import|export)(?:\s+type)?\s+[\s\S]*?\sfrom\s+["']([^"']+)["']/g;
+const SIDE_EFFECT_IMPORT_RE = /\bimport\s+["']([^"']+)["']/g;
+const DYNAMIC_IMPORT_RE = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+const COMPOSITION_ROOTS: ReadonlyArray<{
+  relativeFromSrc: string;
+  allowedModules: readonly DomainModuleFolder[];
+}> = [
+  { relativeFromSrc: "app.ts", allowedModules: DOMAIN_MODULE_FOLDERS },
+  { relativeFromSrc: join("shared", "jobs", "reservationExpiryJob.ts"), allowedModules: ["listings"] },
+  {
+    relativeFromSrc: join("shared", "jobs", "paypalReconciliationJob.ts"),
+    allowedModules: ["payments"],
+  },
+  {
+    relativeFromSrc: join("shared", "jobs", "sellerLedgerReconciliationJob.ts"),
+    allowedModules: ["commissions"],
+  },
+  { relativeFromSrc: join("shared", "jobs", "outboxDispatcherJob.ts"), allowedModules: [] },
+];
+
+export function isDomainModuleFolder(value: string): value is DomainModuleFolder {
+  return (DOMAIN_MODULE_FOLDERS as readonly string[]).includes(value);
+}
+
+export function isModuleEdgeAllowed(
+  fromModule: DomainModuleFolder,
+  toModule: DomainModuleFolder
+): boolean {
+  if (fromModule === toModule) return true;
+  return ALLOWED_MODULE_EDGES[fromModule].includes(toModule);
+}
+
+export function extractImportSpecifiers(source: string): string[] {
+  const specifiers = new Set<string>();
+  const text = stripComments(source);
+  for (const re of [IMPORT_FROM_RE, SIDE_EFFECT_IMPORT_RE, DYNAMIC_IMPORT_RE]) {
+    re.lastIndex = 0;
+    let match: RegExpExecArray | null = re.exec(text);
+    while (match) {
+      specifiers.add(match[1]);
+      match = re.exec(text);
+    }
+  }
+  return [...specifiers];
+}
+
+export function resolveImportTarget(
+  fromFile: string,
+  specifier: string,
+  srcRoot: string
+): ResolvedImport {
+  if (!specifier.startsWith(".")) {
+    return { specifier, kind: "package", targetModule: null };
+  }
+
+  const fromDir = dirname(fromFile);
+  const resolved = resolve(fromDir, specifier);
+  const rel = relative(srcRoot, resolved).split(sep);
+
+  if (rel[0] === "shared" || rel[0] === "..") {
+    if (rel[0] === "shared") {
+      return { specifier, kind: "shared", targetModule: null };
+    }
+  }
+
+  if (rel[0] === "modules" && rel[1] && isDomainModuleFolder(rel[1])) {
+    return { specifier, kind: "module", targetModule: rel[1] };
+  }
+
+  return { specifier, kind: "unknown", targetModule: null };
+}
+
+export function scanProductionTypeScriptFiles(root: string): string[] {
+  const files: string[] = [];
+
+  function walk(dir: string): void {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir)) {
+      if (entry === "node_modules" || entry === "dist") continue;
+      const full = join(dir, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        if (entry === "__tests__") continue;
+        walk(full);
+        continue;
+      }
+      if (!entry.endsWith(".ts")) continue;
+      if (entry.endsWith(".test.ts") || entry.endsWith(".integration.test.ts")) continue;
+      files.push(full);
+    }
+  }
+
+  walk(root);
+  return files.sort();
+}
+
+function moduleOfProductionFile(file: string, srcRoot: string): DomainModuleFolder | null {
+  const rel = relative(srcRoot, file).split(sep);
+  if (rel[0] === "modules" && rel[1] && isDomainModuleFolder(rel[1])) {
+    return rel[1];
+  }
+  return null;
+}
+
+function compositionRootFor(file: string, srcRoot: string) {
+  const rel = relative(srcRoot, file);
+  return COMPOSITION_ROOTS.find((root) => root.relativeFromSrc === rel) ?? null;
+}
+
+export function findImportViolations(srcRoot: string): ImportViolation[] {
+  const violations: ImportViolation[] = [];
+  const moduleRoot = join(srcRoot, "modules");
+  const sharedRoot = join(srcRoot, "shared");
+
+  for (const file of scanProductionTypeScriptFiles(moduleRoot)) {
+    const fromModule = moduleOfProductionFile(file, srcRoot);
+    if (!fromModule) continue;
+    const source = readFileSync(file, "utf8");
+    for (const specifier of extractImportSpecifiers(source)) {
+      const resolved = resolveImportTarget(file, specifier, srcRoot);
+      if (resolved.kind === "package" || resolved.kind === "shared") continue;
+      if (resolved.kind === "module" && resolved.targetModule) {
+        if (isModuleEdgeAllowed(fromModule, resolved.targetModule)) continue;
+        violations.push({
+          file: relative(srcRoot, file),
+          specifier,
+          fromModule,
+          toModule: resolved.targetModule,
+          reason: `${fromModule} must not import ${resolved.targetModule}`,
+        });
+        continue;
+      }
+      violations.push({
+        file: relative(srcRoot, file),
+        specifier,
+        fromModule,
+        toModule: "unknown",
+        reason: "production module import must resolve to shared/ or an allowed module",
+      });
+    }
+  }
+
+  for (const file of scanProductionTypeScriptFiles(sharedRoot)) {
+    const source = readFileSync(file, "utf8");
+    const composition = compositionRootFor(file, srcRoot);
+    for (const specifier of extractImportSpecifiers(source)) {
+      const resolved = resolveImportTarget(file, specifier, srcRoot);
+      if (resolved.kind !== "module" || !resolved.targetModule) continue;
+      if (composition && composition.allowedModules.includes(resolved.targetModule)) {
+        continue;
+      }
+      violations.push({
+        file: relative(srcRoot, file),
+        specifier,
+        fromModule: composition ? "composition" : "shared",
+        toModule: resolved.targetModule,
+        reason: composition
+          ? `composition root may not import ${resolved.targetModule}`
+          : "shared/ production code outside documented jobs must not import modules/",
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function requiredLogicalModulesAreMapped(): boolean {
+  const mapped = new Set(Object.values(LOGICAL_MODULE_NAMES));
+  return REQUIRED_LOGICAL_MODULES.every((name) => mapped.has(name));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #59

Make in-process module boundaries explicit without splitting the monolith or changing runtime behavior.

## What changed

- SPEC-0006 / PLAN-0003 / TASK-0006 plus ADR 0016
- Documented logical modules: Auth, Users, Sellers, Catalog (`modules/products`), Listings, Orders, Payments, Ledger (`modules/commissions`), Reviews, Admin
- Allowed dependency edges and composition roots (`app.ts`, jobs)
- Executable import graph in `server/src/shared/architecture/moduleBoundaries.ts` with unit tests
- Payments stays one application service (`confirmPayment` remains one local transaction)

No `src/` edits. No Redis/Kafka/SQS. No PayPal or schema changes.

## Verification

- `python3 scripts/ai-factory/validate.py` → PASS
- `cd server && npm run test:unit` → 340 passed
- `cd server && npm run test:integration` → 111 passed

## Risks

- Import scanner is regex-based, not a TypeScript parser
- A new legitimate Admin/job import must update `moduleBoundaries.ts` in the same change
- Payments file remains large by design

Do not merge from this agent. Do not close the issue from `gh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

