### PR TITLE
#105 — [Product] Implementar recentemente visualizados e continue de onde parou sem inventar motor de recomendação

### DIFF
--- a/src/components/RecentlyViewedRail.tsx
+++ b/src/components/RecentlyViewedRail.tsx
@@ -1,0 +1,35 @@
+import { ListingCard } from "@/components/ProductCard";
+import {
+  RECENTLY_VIEWED_COPY,
+  RECENTLY_VIEWED_HEADING,
+} from "@/lib/recentlyViewed";
+import type { Listing } from "@/types/api";
+
+export function RecentlyViewedRail({
+  listings,
+  headingId = "recently-viewed-heading",
+}: {
+  listings: Listing[];
+  headingId?: string;
+}) {
+  if (listings.length === 0) return null;
+
+  return (
+    <section aria-labelledby={headingId}>
+      <h2
+        id={headingId}
+        className="text-xl font-semibold tracking-tight text-foreground"
+      >
+        {RECENTLY_VIEWED_HEADING}
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {RECENTLY_VIEWED_COPY}
+      </p>
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {listings.map((listing) => (
+          <ListingCard key={listing.id} listing={listing} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/__tests__/RecentlyViewedRail.test.tsx
+++ b/src/components/__tests__/RecentlyViewedRail.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RecentlyViewedRail } from "../RecentlyViewedRail";
+import { CartProvider } from "@/contexts/CartContext";
+import type { Listing } from "@/types/api";
+import {
+  RECENTLY_VIEWED_COPY,
+  RECENTLY_VIEWED_HEADING,
+} from "@/lib/recentlyViewed";
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: "listing-2",
+    productId: "awp-asiimov-ft",
+    sellerId: "seller-1",
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    floatValue: 0.21,
+    pattern: 12,
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    product: {
+      id: "awp-asiimov-ft",
+      game: "CS2",
+      weapon: "AWP",
+      skinName: "Asiimov",
+      rarity: "Covert",
+      collection: "The Operation Phoenix Collection",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      imageUrl: null,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
+    seller: {
+      id: "seller-1",
+      storeName: "Neon Store",
+      user: { id: "user-1", name: "Alice" },
+    },
+    ...overrides,
+  };
+}
+
+describe("RecentlyViewedRail", () => {
+  it("renders nothing when there are no fetchable listings", () => {
+    const { container } = render(<RecentlyViewedRail listings={[]} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(RECENTLY_VIEWED_HEADING)).toBeNull();
+    expect(screen.queryByText(/nenhum visto/i)).toBeNull();
+  });
+
+  it("uses history copy instead of a personalization engine", () => {
+    render(
+      <MemoryRouter>
+        <CartProvider>
+          <RecentlyViewedRail listings={[makeListing()]} />
+        </CartProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(RECENTLY_VIEWED_HEADING)).toBeTruthy();
+    expect(screen.getByText(RECENTLY_VIEWED_COPY)).toBeTruthy();
+    expect(screen.getByText("AWP | Asiimov (Field-Tested)")).toBeTruthy();
+    expect(screen.queryByText(/recomendado para você/i)).toBeNull();
+    expect(screen.queryByText(/outros compradores/i)).toBeNull();
+    expect(screen.queryByText(/personaliz/i)).toBeNull();
+  });
+});

--- a/src/hooks/useRecentlyViewedListings.ts
+++ b/src/hooks/useRecentlyViewedListings.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { getListing } from "@/api/listings";
+import {
+  loadRecentlyViewedIds,
+  normalizeRecentlyViewedId,
+  selectRecentlyViewedListings,
+  type RecentlyViewedFetchResult,
+} from "@/lib/recentlyViewed";
+import type { Listing } from "@/types/api";
+
+export function useRecentlyViewedListings(excludeId?: string): Listing[] {
+  const excluded = normalizeRecentlyViewedId(excludeId);
+  const storedIds = useMemo(() => loadRecentlyViewedIds(), []);
+  const fetchIds = useMemo(
+    () => storedIds.filter((id) => id !== excluded),
+    [storedIds, excluded],
+  );
+
+  const queries = useQueries({
+    queries: fetchIds.map((id) => ({
+      queryKey: ["listing", id] as const,
+      queryFn: () => getListing(id),
+      retry: false,
+    })),
+  });
+
+  return useMemo(() => {
+    const byId = new Map<string, RecentlyViewedFetchResult>();
+    for (let index = 0; index < fetchIds.length; index += 1) {
+      const id = fetchIds[index];
+      const query = queries[index];
+      if (!id || !query) continue;
+      if (query.isError) {
+        byId.set(id, "error");
+        continue;
+      }
+      byId.set(id, query.data);
+    }
+    return selectRecentlyViewedListings(storedIds, byId, excluded ?? undefined);
+  }, [excluded, fetchIds, queries, storedIds]);
+}

--- a/src/hooks/useRecentlyViewedListings.ts
+++ b/src/hooks/useRecentlyViewedListings.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { getListing } from "@/api/listings";
 import {
@@ -11,7 +11,12 @@ import type { Listing } from "@/types/api";
 
 export function useRecentlyViewedListings(excludeId?: string): Listing[] {
   const excluded = normalizeRecentlyViewedId(excludeId);
-  const storedIds = useMemo(() => loadRecentlyViewedIds(), []);
+  const [storedIds, setStoredIds] = useState(loadRecentlyViewedIds);
+
+  useEffect(() => {
+    setStoredIds(loadRecentlyViewedIds());
+  }, [excluded]);
+
   const fetchIds = useMemo(
     () => storedIds.filter((id) => id !== excluded),
     [storedIds, excluded],

--- a/src/lib/__tests__/recentlyViewed.test.ts
+++ b/src/lib/__tests__/recentlyViewed.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type { Listing } from "@/types/api";
+import {
+  RECENTLY_VIEWED_LIMIT,
+  RECENTLY_VIEWED_STORAGE_KEY,
+  RECENTLY_VIEWED_STORAGE_VERSION,
+  isRecentlyViewedBuyable,
+  loadRecentlyViewedIds,
+  parseRecentlyViewedIds,
+  pushRecentlyViewedId,
+  recordRecentlyViewedId,
+  saveRecentlyViewedIds,
+  selectRecentlyViewedListings,
+  serializeRecentlyViewedIds,
+} from "../recentlyViewed";
+
+function listing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: "listing-1",
+    productId: "prod-1",
+    sellerId: "seller-1",
+    price: 22,
+    currency: "USD",
+    status: "ACTIVE",
+    floatValue: 0.15,
+    pattern: null,
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      imageUrl: null,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
+    seller: { id: "seller-1", storeName: "Store Alpha" },
+    ...overrides,
+  };
+}
+
+function memoryStorage(initial?: string) {
+  const memory = new Map<string, string>();
+  if (initial !== undefined) {
+    memory.set(RECENTLY_VIEWED_STORAGE_KEY, initial);
+  }
+  return {
+    getItem: (key: string) => memory.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      memory.set(key, value);
+    },
+    memory,
+  };
+}
+
+describe("parseRecentlyViewedIds", () => {
+  it("returns empty when JSON is invalid or the version does not match", () => {
+    expect(parseRecentlyViewedIds("{not-json")).toEqual([]);
+    expect(parseRecentlyViewedIds("null")).toEqual([]);
+    expect(parseRecentlyViewedIds("[]")).toEqual([]);
+    expect(
+      parseRecentlyViewedIds(
+        JSON.stringify({ version: 99, ids: ["listing-1"] }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps most-recent-first unique ids and drops blanks", () => {
+    expect(
+      parseRecentlyViewedIds(
+        JSON.stringify({
+          version: RECENTLY_VIEWED_STORAGE_VERSION,
+          ids: [" listing-2 ", "listing-1", "listing-2", "", "   ", 4],
+        }),
+      ),
+    ).toEqual(["listing-2", "listing-1"]);
+  });
+
+  it("caps the stack at 12 ids", () => {
+    const ids = Array.from({ length: 20 }, (_, index) => `listing-${index}`);
+    expect(
+      parseRecentlyViewedIds(
+        JSON.stringify({
+          version: RECENTLY_VIEWED_STORAGE_VERSION,
+          ids,
+        }),
+      ),
+    ).toEqual(ids.slice(0, RECENTLY_VIEWED_LIMIT));
+  });
+});
+
+describe("pushRecentlyViewedId", () => {
+  it("moves a repeat view to the front without duplicating", () => {
+    expect(
+      pushRecentlyViewedId(["listing-2", "listing-1"], "listing-1"),
+    ).toEqual(["listing-1", "listing-2"]);
+  });
+
+  it("drops the oldest id after 12 views", () => {
+    const ids = Array.from({ length: 12 }, (_, index) => `listing-${index}`);
+    expect(pushRecentlyViewedId(ids, "listing-new")).toEqual([
+      "listing-new",
+      ...ids.slice(0, 11),
+    ]);
+  });
+});
+
+describe("selectRecentlyViewedListings", () => {
+  it("skips failed ids, the current listing, and non-ACTIVE rows", () => {
+    const active = listing({ id: "listing-2", product: listing().product });
+    const sold = listing({
+      id: "listing-sold",
+      status: "SOLD",
+      product: { ...listing().product, skinName: "Asiimov" },
+    });
+    const reserved = listing({ id: "listing-reserved", status: "RESERVED" });
+    const selected = selectRecentlyViewedListings(
+      [
+        "listing-current",
+        "listing-dead",
+        "listing-sold",
+        "listing-reserved",
+        "listing-2",
+        "listing-pending",
+      ],
+      new Map([
+        ["listing-current", listing({ id: "listing-current" })],
+        ["listing-dead", "error"],
+        ["listing-sold", sold],
+        ["listing-reserved", reserved],
+        ["listing-2", active],
+        ["listing-pending", undefined],
+      ]),
+      "listing-current",
+    );
+
+    expect(selected.map((item) => item.id)).toEqual(["listing-2"]);
+    expect(selected.every((item) => item.status === "ACTIVE")).toBe(true);
+  });
+
+  it("does not treat SOLD as buyable", () => {
+    expect(isRecentlyViewedBuyable(listing({ status: "SOLD" }))).toBe(false);
+    expect(isRecentlyViewedBuyable(listing({ status: "ACTIVE" }))).toBe(true);
+  });
+});
+
+describe("storage helpers", () => {
+  it("round-trips ids through a mock Storage so a reload can restore them", () => {
+    const storage = memoryStorage();
+    expect(recordRecentlyViewedId("listing-a", storage)).toEqual(["listing-a"]);
+    expect(recordRecentlyViewedId("listing-b", storage)).toEqual([
+      "listing-b",
+      "listing-a",
+    ]);
+    expect(storage.memory.has(RECENTLY_VIEWED_STORAGE_KEY)).toBe(true);
+    expect(loadRecentlyViewedIds(storage)).toEqual(["listing-b", "listing-a"]);
+  });
+
+  it("keeps writes from breaking when setItem throws", () => {
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+    expect(saveRecentlyViewedIds(["listing-1"], storage)).toBe(false);
+    expect(recordRecentlyViewedId("listing-1", storage)).toEqual(["listing-1"]);
+  });
+
+  it("loads empty when getItem throws", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => undefined,
+    };
+    expect(loadRecentlyViewedIds(storage)).toEqual([]);
+  });
+
+  it("serializes a versioned payload", () => {
+    const payload = JSON.parse(
+      serializeRecentlyViewedIds(["listing-1", ""]),
+    ) as {
+      version: number;
+      ids: string[];
+    };
+    expect(payload).toEqual({
+      version: RECENTLY_VIEWED_STORAGE_VERSION,
+      ids: ["listing-1"],
+    });
+  });
+});

--- a/src/lib/recentlyViewed.ts
+++ b/src/lib/recentlyViewed.ts
@@ -1,0 +1,165 @@
+import type { Listing } from "@/types/api";
+
+/**
+ * Device-local recently viewed listing IDs (issue #105).
+ *
+ * This is not an account history, not multi-device, and not a
+ * recommendation engine. The stack lives in `localStorage` on this
+ * browser only. Display still fetches live listings and keeps only
+ * ACTIVE rows so SOLD/RESERVED/CANCELED are not shown as buyable.
+ */
+export const RECENTLY_VIEWED_STORAGE_KEY = "neon-arsenal.recently-viewed";
+export const RECENTLY_VIEWED_STORAGE_VERSION = 1;
+export const RECENTLY_VIEWED_LIMIT = 12;
+
+export const RECENTLY_VIEWED_HEADING = "Vistos recentemente";
+export const RECENTLY_VIEWED_COPY = "Listings que você abriu neste navegador.";
+
+export interface PersistedRecentlyViewedV1 {
+  version: typeof RECENTLY_VIEWED_STORAGE_VERSION;
+  ids: string[];
+}
+
+type RecentlyViewedStorage = Pick<Storage, "getItem" | "setItem">;
+
+function getBrowserStorage(): RecentlyViewedStorage | null {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeRecentlyViewedId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function pushRecentlyViewedId(
+  ids: string[],
+  listingId: string,
+  limit = RECENTLY_VIEWED_LIMIT,
+): string[] {
+  const nextId = normalizeRecentlyViewedId(listingId);
+  if (!nextId) return ids.slice(0, limit);
+  return [nextId, ...ids.filter((id) => id !== nextId)].slice(0, limit);
+}
+
+export function parseRecentlyViewedIds(raw: string | null): string[] {
+  if (!raw) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return [];
+    if (parsed.version !== RECENTLY_VIEWED_STORAGE_VERSION) return [];
+    if (!Array.isArray(parsed.ids)) return [];
+
+    const ids: string[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of parsed.ids) {
+      const id = normalizeRecentlyViewedId(entry);
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+      if (ids.length >= RECENTLY_VIEWED_LIMIT) break;
+    }
+
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
+export function serializeRecentlyViewedIds(ids: string[]): string {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of ids) {
+    const id = normalizeRecentlyViewedId(entry);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    unique.push(id);
+    if (unique.length >= RECENTLY_VIEWED_LIMIT) break;
+  }
+  const payload: PersistedRecentlyViewedV1 = {
+    version: RECENTLY_VIEWED_STORAGE_VERSION,
+    ids: unique,
+  };
+  return JSON.stringify(payload);
+}
+
+export function loadRecentlyViewedIds(
+  storage: RecentlyViewedStorage | null = getBrowserStorage(),
+): string[] {
+  if (!storage) return [];
+  try {
+    return parseRecentlyViewedIds(storage.getItem(RECENTLY_VIEWED_STORAGE_KEY));
+  } catch {
+    return [];
+  }
+}
+
+export function saveRecentlyViewedIds(
+  ids: string[],
+  storage: RecentlyViewedStorage | null = getBrowserStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(
+      RECENTLY_VIEWED_STORAGE_KEY,
+      serializeRecentlyViewedIds(ids),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function recordRecentlyViewedId(
+  listingId: string,
+  storage: RecentlyViewedStorage | null = getBrowserStorage(),
+): string[] {
+  const next = pushRecentlyViewedId(loadRecentlyViewedIds(storage), listingId);
+  saveRecentlyViewedIds(next, storage);
+  return next;
+}
+
+export function isRecentlyViewedBuyable(
+  listing: Pick<Listing, "status">,
+): boolean {
+  return listing.status === "ACTIVE";
+}
+
+export type RecentlyViewedFetchResult = Listing | "error" | undefined;
+
+/**
+ * Keep storage order (most recent first). Skip failed IDs, the current
+ * PDP listing, and rows that are not ACTIVE so SOLD is never shown as
+ * a buyable card.
+ */
+export function selectRecentlyViewedListings(
+  orderedIds: string[],
+  byId: ReadonlyMap<string, RecentlyViewedFetchResult>,
+  excludeId?: string,
+): Listing[] {
+  const excluded = normalizeRecentlyViewedId(excludeId);
+  const items: Listing[] = [];
+
+  for (const id of orderedIds) {
+    if (excluded && id === excluded) continue;
+    const entry = byId.get(id);
+    if (entry === undefined || entry === "error") continue;
+    if (!isRecentlyViewedBuyable(entry)) continue;
+    items.push(entry);
+  }
+
+  return items;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ListingCard } from "@/components/ProductCard";
+import { RecentlyViewedRail } from "@/components/RecentlyViewedRail";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { listListings } from "@/api/listings";
 import { listProducts } from "@/api/products";
@@ -9,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MARKET_VIEW_CTA } from "@/lib/listingCartCta";
 import { track } from "@/lib/analytics";
+import { useRecentlyViewedListings } from "@/hooks/useRecentlyViewedListings";
 import {
   HOME_EMPTY_DESCRIPTION,
   HOME_EMPTY_TITLE,
@@ -48,6 +50,7 @@ export default function IndexPage() {
   const listingsTotal = listingsQuery.data?.total;
   const approvedSellerCount = sellersQuery.data?.length;
   const shortcuts = catalogDiscoveryLinks(productsQuery.data?.items ?? []);
+  const recentlyViewed = useRecentlyViewedListings();
 
   return (
     <div className="container space-y-12 py-10">
@@ -125,6 +128,8 @@ export default function IndexPage() {
           </div>
         )}
       </section>
+
+      <RecentlyViewedRail listings={recentlyViewed} />
 
       <section aria-labelledby="home-new-heading">
         <h2

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -5,11 +5,14 @@ import { ArrowLeft } from "lucide-react";
 import { ListingCard, SkinVisual } from "@/components/ProductCard";
 import { ListingCartCta } from "@/components/ListingCartCta";
 import { ProductReviews } from "@/components/ProductReviews";
+import { RecentlyViewedRail } from "@/components/RecentlyViewedRail";
 import { ErrorState } from "@/components/page-state";
 import { getListing, listListings } from "@/api/listings";
 import { getPriceHistory } from "@/api/price-history";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useRecentlyViewedListings } from "@/hooks/useRecentlyViewedListings";
+import { recordRecentlyViewedId } from "@/lib/recentlyViewed";
 import { analyticsPrice, readAnalyticsSource, track } from "@/lib/analytics";
 import {
   isNotFoundApiError,
@@ -55,9 +58,11 @@ export default function ListingDetail() {
   const related = (relatedData?.items ?? [])
     .filter((item) => item.id !== id)
     .slice(0, 4);
+  const recentlyViewed = useRecentlyViewedListings(id);
 
   useEffect(() => {
     if (!listing) return;
+    recordRecentlyViewedId(listing.id);
     track("product_view", {
       listingId: listing.id,
       productId: listing.productId,
@@ -261,6 +266,15 @@ export default function ListingDetail() {
             ))}
           </div>
         </section>
+      ) : null}
+
+      {recentlyViewed.length > 0 ? (
+        <div className="mt-12 border-t border-border pt-10">
+          <RecentlyViewedRail
+            listings={recentlyViewed}
+            headingId="pdp-recently-viewed-heading"
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -22,17 +22,24 @@ import {
 } from "@/lib/homeDiscovery";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
 import {
+  RECENTLY_VIEWED_HEADING,
+  RECENTLY_VIEWED_STORAGE_KEY,
+  saveRecentlyViewedIds,
+} from "@/lib/recentlyViewed";
+import {
   setAnalyticsCollector,
   type AnalyticsEventName,
   type AnalyticsProps,
 } from "@/lib/analytics";
 
 const listListings = vi.fn();
+const getListing = vi.fn();
 const listProducts = vi.fn();
 const listSellers = vi.fn();
 
 vi.mock("@/api/listings", () => ({
   listListings: (...args: unknown[]) => listListings(...args),
+  getListing: (...args: unknown[]) => getListing(...args),
 }));
 
 vi.mock("@/api/products", () => ({
@@ -130,9 +137,12 @@ describe("Index", () => {
       analyticsEvents.push({ event, props });
     });
     localStorage.removeItem(CART_STORAGE_KEY);
+    localStorage.removeItem(RECENTLY_VIEWED_STORAGE_KEY);
     listListings.mockReset();
+    getListing.mockReset();
     listProducts.mockReset();
     listSellers.mockReset();
+    getListing.mockRejectedValue(new Error("unused recently viewed id"));
     listProducts.mockResolvedValue({
       items: [
         makeProduct(),
@@ -198,6 +208,9 @@ describe("Index", () => {
 
     expect(screen.queryByText("Em destaque")).toBeNull();
     expect(screen.queryByText("Continue de onde parou")).toBeNull();
+    expect(screen.queryByText(RECENTLY_VIEWED_HEADING)).toBeNull();
+    expect(screen.queryByText(/recomendado para você/i)).toBeNull();
+    expect(getListing).not.toHaveBeenCalled();
     expect(screen.queryByText(/Oito em destaque/i)).toBeNull();
     expect(document.querySelector(".scan-lines")).toBeNull();
     expect(document.querySelector(".neon-text")).toBeNull();
@@ -301,5 +314,73 @@ describe("Index", () => {
       event: "category_view",
       props: { productId: "ak-redline-ft", source: "home" },
     });
+  });
+
+  it("shows a recently viewed rail after reload when stored ids are still ACTIVE", async () => {
+    saveRecentlyViewedIds(["listing-seen", "listing-dead", "listing-sold"]);
+    getListing.mockImplementation(async (id: unknown) => {
+      if (id === "listing-seen") {
+        return makeListing({
+          id: "listing-seen",
+          product: makeProduct({
+            id: "awp-asiimov-ft",
+            weapon: "AWP",
+            skinName: "Asiimov",
+          }),
+        });
+      }
+      if (id === "listing-sold") {
+        return makeListing({
+          id: "listing-sold",
+          status: "SOLD",
+          product: makeProduct({
+            id: "m4-howl",
+            weapon: "M4A4",
+            skinName: "Howl",
+          }),
+        });
+      }
+      throw new Error("gone");
+    });
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 8,
+    });
+
+    renderHome();
+
+    expect(await screen.findByText(RECENTLY_VIEWED_HEADING)).toBeTruthy();
+    expect(screen.getByText("AWP | Asiimov (Field-Tested)")).toBeTruthy();
+    expect(screen.queryByText("M4A4 | Howl (Field-Tested)")).toBeNull();
+    expect(screen.queryByText(/nenhum visto/i)).toBeNull();
+    expect(screen.queryByText(/recomendado para você/i)).toBeNull();
+    expect(screen.queryByText(/outros compradores/i)).toBeNull();
+    expect(getListing).toHaveBeenCalledWith("listing-seen");
+    expect(getListing).toHaveBeenCalledWith("listing-dead");
+    expect(getListing).toHaveBeenCalledWith("listing-sold");
+  });
+
+  it("keeps Home without history identical for this rail after a failed stored id", async () => {
+    saveRecentlyViewedIds(["listing-dead"]);
+    getListing.mockRejectedValue(new Error("gone"));
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 8,
+    });
+
+    renderHome();
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(getListing).toHaveBeenCalledWith("listing-dead");
+    });
+    expect(screen.queryByText(RECENTLY_VIEWED_HEADING)).toBeNull();
+    expect(screen.queryByText(/nenhum visto/i)).toBeNull();
   });
 });

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -19,6 +19,12 @@ import {
 } from "@/lib/listingCartCta";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
 import {
+  RECENTLY_VIEWED_HEADING,
+  RECENTLY_VIEWED_STORAGE_KEY,
+  loadRecentlyViewedIds,
+  saveRecentlyViewedIds,
+} from "@/lib/recentlyViewed";
+import {
   setAnalyticsCollector,
   type AnalyticsEventName,
   type AnalyticsProps,
@@ -181,6 +187,7 @@ describe("ListingDetail", () => {
     authState.isAuthenticated = false;
     authState.isLoading = false;
     localStorage.removeItem(CART_STORAGE_KEY);
+    localStorage.removeItem(RECENTLY_VIEWED_STORAGE_KEY);
     listListings.mockResolvedValue({ items: [], total: 0, page: 1, limit: 4 });
     getPriceHistory.mockResolvedValue([]);
     listProductReviews.mockResolvedValue([]);
@@ -443,5 +450,73 @@ describe("ListingDetail", () => {
       });
     });
     expect(JSON.stringify(analyticsEvents)).not.toMatch(/NeonTrader|Ana|@/);
+  });
+
+  it("records the current listing and shows earlier ACTIVE views only", async () => {
+    saveRecentlyViewedIds(["listing-seen", "listing-1", "listing-sold"]);
+    getListing.mockImplementation(async (id: unknown) => {
+      if (id === "listing-1") return makeListing();
+      if (id === "listing-seen") {
+        return makeListing({
+          id: "listing-seen",
+          productId: "awp-asiimov-ft",
+          product: {
+            ...makeListing().product,
+            id: "awp-asiimov-ft",
+            weapon: "AWP",
+            skinName: "Asiimov",
+          },
+        });
+      }
+      if (id === "listing-sold") {
+        return makeListing({
+          id: "listing-sold",
+          status: "SOLD",
+          productId: "m4-howl",
+          product: {
+            ...makeListing().product,
+            id: "m4-howl",
+            weapon: "M4A4",
+            skinName: "Howl",
+          },
+        });
+      }
+      throw new Error("gone");
+    });
+
+    renderDetail();
+
+    expect(
+      await screen.findByRole("heading", { name: /AK-47 \| Redline/ }),
+    ).toBeTruthy();
+    expect(await screen.findByText(RECENTLY_VIEWED_HEADING)).toBeTruthy();
+    expect(screen.getByText("AWP | Asiimov (Field-Tested)")).toBeTruthy();
+    expect(screen.queryByText("M4A4 | Howl (Field-Tested)")).toBeNull();
+    expect(
+      screen.getAllByRole("heading", { name: /AK-47 \| Redline/ }),
+    ).toHaveLength(1);
+    expect(screen.queryByText(/recomendado para você/i)).toBeNull();
+    expect(screen.queryByText(/outros compradores/i)).toBeNull();
+    expect(loadRecentlyViewedIds()).toEqual([
+      "listing-1",
+      "listing-seen",
+      "listing-sold",
+    ]);
+    expect(getListing).toHaveBeenCalledWith("listing-seen");
+    expect(getListing).toHaveBeenCalledWith("listing-sold");
+  });
+
+  it("omits the recently viewed block when only the current listing is stored", async () => {
+    getListing.mockResolvedValue(makeListing());
+    renderDetail();
+
+    expect(
+      await screen.findByRole("heading", { name: /AK-47 \| Redline/ }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(loadRecentlyViewedIds()).toEqual(["listing-1"]);
+    });
+    expect(screen.queryByText(RECENTLY_VIEWED_HEADING)).toBeNull();
+    expect(screen.queryByText(/nenhum visto/i)).toBeNull();
   });
 });

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  within,
+} from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ListingDetail from "../ListingDetail";
@@ -518,5 +524,57 @@ describe("ListingDetail", () => {
     });
     expect(screen.queryByText(RECENTLY_VIEWED_HEADING)).toBeNull();
     expect(screen.queryByText(/nenhum visto/i)).toBeNull();
+  });
+
+  it("shows earlier ACTIVE views after navigating to another listing", async () => {
+    const first = makeListing();
+    const second = makeListing({
+      id: "listing-2",
+      productId: "awp-asiimov-ft",
+      product: {
+        ...makeListing().product,
+        id: "awp-asiimov-ft",
+        weapon: "AWP",
+        skinName: "Asiimov",
+      },
+    });
+    getListing.mockImplementation(async (id: unknown) => {
+      if (id === "listing-1") return first;
+      if (id === "listing-2") return second;
+      throw new Error("gone");
+    });
+    listListings.mockResolvedValue({
+      items: [first, second],
+      total: 2,
+      page: 1,
+      limit: 4,
+    });
+
+    renderDetail();
+
+    expect(
+      await screen.findByRole("heading", { name: /AK-47 \| Redline/ }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(loadRecentlyViewedIds()).toEqual(["listing-1"]);
+    });
+    expect(screen.queryByText(RECENTLY_VIEWED_HEADING)).toBeNull();
+
+    fireEvent.click(screen.getByText("AWP | Asiimov (Field-Tested)"));
+
+    expect(
+      await screen.findByRole("heading", { name: /AWP \| Asiimov/ }),
+    ).toBeTruthy();
+    expect(await screen.findByText(RECENTLY_VIEWED_HEADING)).toBeTruthy();
+    const rail = screen
+      .getByRole("heading", { name: RECENTLY_VIEWED_HEADING })
+      .closest("section");
+    expect(rail).toBeTruthy();
+    expect(
+      within(rail as HTMLElement).getByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(
+      within(rail as HTMLElement).queryByText("AWP | Asiimov (Field-Tested)"),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #105

Client-only recently viewed listings. No recommendation engine, no new backend API.

## What changed

- Versioned `localStorage` stack of up to 12 listing IDs (most recent first, no duplicates)
- Home rail and PDP block titled **Vistos recentemente**, only when ≥1 stored ID is still `ACTIVE`
- PDP records a view on successful load and excludes the current listing
- Failed IDs and `SOLD`/`RESERVED`/`CANCELED` are skipped, never shown as buyable
- Empty history: rail is absent (same as a new visitor)

## Verification

- `npm run typecheck` → PASS
- `npm run lint` → PASS
- `npm test` → 323 passed
- Browser: empty Home has no rail; dead stored IDs omit the rail; `localStorage` persists after reload
- Live three-PDP → Home rail was not screenshot-proven here (local listings API 500/CORS). Covered by unit/UI tests.

[Home without history: no Vistos recentemente rail](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_105_home_without_history.png)
[Home after dead stored IDs: rail still omitted](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_105_home_failed_ids_omits_rail.png)

## Risks

- History is browser-local, not account-bound
- Dead IDs stay in the stack until the 12-cap evicts them

Do not merge from this agent. Do not close the issue from `gh`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

