### PR TITLE
#121 #122 #111 — Auth resend, server logout, and account footer

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,8 +1,69 @@
+import { Link } from "react-router-dom";
+import { HOME_SELLER_CTA, HOME_TRUST_HEADING } from "@/lib/homeDiscovery";
+
+const FOOTER_TRUST_COPY =
+  "Cada listing é um item único. O pagamento é pelo PayPal.";
+
+const footerLinkClass =
+  "inline-flex min-h-11 items-center text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
 export function SiteFooter() {
+  const year = new Date().getFullYear();
+
   return (
     <footer className="border-t border-border">
-      <div className="container py-6 text-sm text-muted-foreground">
-        Neon Arsenal
+      <div className="container grid gap-8 py-10 md:grid-cols-3">
+        <div>
+          <p className="text-sm font-semibold tracking-tight text-foreground">
+            Neon Arsenal
+          </p>
+          <p className="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
+            {FOOTER_TRUST_COPY}
+          </p>
+        </div>
+
+        <nav aria-label="Market">
+          <p className="text-sm font-medium text-foreground">Market</p>
+          <ul className="mt-3 flex flex-col">
+            <li>
+              <Link to="/products" className={footerLinkClass}>
+                Market
+              </Link>
+            </li>
+            <li>
+              <Link to="/#home-trust-heading" className={footerLinkClass}>
+                {HOME_TRUST_HEADING}
+              </Link>
+            </li>
+            <li>
+              <Link to="/register" className={footerLinkClass}>
+                {HOME_SELLER_CTA}
+              </Link>
+            </li>
+          </ul>
+        </nav>
+
+        <nav aria-label="Conta">
+          <p className="text-sm font-medium text-foreground">Conta</p>
+          <ul className="mt-3 flex flex-col">
+            <li>
+              <Link to="/login" className={footerLinkClass}>
+                Entrar
+              </Link>
+            </li>
+            <li>
+              <Link to="/register" className={footerLinkClass}>
+                Criar conta
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+
+      <div className="border-t border-border">
+        <div className="container py-4 text-xs text-muted-foreground">
+          © {year} Neon Arsenal
+        </div>
       </div>
     </footer>
   );

--- a/src/components/__tests__/SiteFooter.test.tsx
+++ b/src/components/__tests__/SiteFooter.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SiteFooter } from "../SiteFooter";
+import { HOME_SELLER_CTA, HOME_TRUST_HEADING } from "@/lib/homeDiscovery";
+
+function renderFooter() {
+  return render(
+    <MemoryRouter>
+      <SiteFooter />
+    </MemoryRouter>,
+  );
+}
+
+describe("SiteFooter", () => {
+  it("exposes at least three real storefront links and no invented legal routes", () => {
+    renderFooter();
+
+    expect(screen.getByText("Neon Arsenal")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Cada listing é um item único. O pagamento é pelo PayPal.",
+      ),
+    ).toBeTruthy();
+
+    const market = screen.getByRole("link", { name: "Market" });
+    expect(market).toHaveAttribute("href", "/products");
+
+    const howItWorks = screen.getByRole("link", { name: HOME_TRUST_HEADING });
+    expect(howItWorks).toHaveAttribute("href", "/#home-trust-heading");
+
+    expect(screen.getByRole("link", { name: "Entrar" })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+    expect(screen.getByRole("link", { name: "Criar conta" })).toHaveAttribute(
+      "href",
+      "/register",
+    );
+    expect(screen.getByRole("link", { name: HOME_SELLER_CTA })).toHaveAttribute(
+      "href",
+      "/register",
+    );
+
+    const realHrefs = screen
+      .getAllByRole("link")
+      .map((link) => link.getAttribute("href") ?? "")
+      .filter(
+        (href) =>
+          href === "/products" || href === "/login" || href === "/register",
+      );
+    expect(new Set(realHrefs).size).toBeGreaterThanOrEqual(3);
+
+    expect(screen.queryByRole("link", { name: /termos/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /privacidade/i })).toBeNull();
+    expect(screen.queryByText("SKINMARKET")).toBeNull();
+    expect(document.querySelector(".scan-lines")).toBeNull();
+    expect(document.querySelector(".neon-text")).toBeNull();
+  });
+});

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -129,9 +129,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const logout = useCallback(async () => {
-    await authApi.logout();
-    setUser(null);
-    setError(null);
+    try {
+      await authApi.logout();
+    } catch {
+      // Revoke is best-effort; the UI must still return to guest.
+    } finally {
+      setUser(null);
+      setError(null);
+    }
   }, []);
 
   const clearError = useCallback(() => setError(null), []);

--- a/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/contexts/__tests__/AuthContext.test.tsx
@@ -83,6 +83,24 @@ describe("AuthContext profile and logout", () => {
     });
   });
 
+  it("still returns to guest when revoke fails", async () => {
+    logoutApi.mockRejectedValueOnce(new Error("network"));
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+
+    expect(await screen.findByTestId("name")).toHaveTextContent("Buyer");
+    fireEvent.click(screen.getByRole("button", { name: "sair" }));
+
+    await waitFor(() => {
+      expect(logoutApi).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("name")).toHaveTextContent("anon");
+    });
+  });
+
   it("logout calls the revoke helper then drops the user", async () => {
     render(
       <AuthProvider>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,13 +1,20 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { homePathForRole } from "@/lib/postLoginPath";
+import { userFacingApiError } from "@/lib/userFacingApiError";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 type Role = "CUSTOMER" | "SELLER";
+
+/** Cooldown after each startRegistration call (30–60s, issue #121). */
+export const REGISTER_RESEND_COOLDOWN_SECONDS = 45;
+
+export const REGISTER_RESEND_SUCCESS =
+  "Enviamos um novo código. O código anterior pode expirar.";
 
 export default function Register() {
   const { startRegistration, confirmRegistration, error, clearError } =
@@ -15,6 +22,10 @@ export default function Register() {
   const navigate = useNavigate();
   const [step, setStep] = useState<1 | 2>(1);
   const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [resendSeconds, setResendSeconds] = useState(0);
+  const [resendNotice, setResendNotice] = useState<string | null>(null);
+  const [resendError, setResendError] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -24,19 +35,33 @@ export default function Register() {
   const [code, setCode] = useState("");
   const [devCode, setDevCode] = useState<string | null>(null);
 
+  const cooldownActive = resendSeconds > 0;
+  useEffect(() => {
+    if (!cooldownActive) return;
+    const timer = window.setInterval(() => {
+      setResendSeconds((seconds) => (seconds <= 1 ? 0 : seconds - 1));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [cooldownActive]);
+
+  const registrationPayload = {
+    name,
+    email,
+    password,
+    role,
+    ...(role === "SELLER" ? { storeName: storeName || undefined } : {}),
+  };
+
   const handleStep1 = async (e: React.FormEvent) => {
     e.preventDefault();
     clearError();
     setLoading(true);
     try {
-      const result = await startRegistration({
-        name,
-        email,
-        password,
-        role,
-        ...(role === "SELLER" ? { storeName: storeName || undefined } : {}),
-      });
+      const result = await startRegistration(registrationPayload);
       setDevCode(result.code ?? null);
+      setResendNotice(null);
+      setResendError(null);
+      setResendSeconds(REGISTER_RESEND_COOLDOWN_SECONDS);
       setStep(2);
     } catch {
       // error shown via context
@@ -48,6 +73,7 @@ export default function Register() {
   const handleStep2 = async (e: React.FormEvent) => {
     e.preventDefault();
     clearError();
+    setResendError(null);
     setLoading(true);
     try {
       await confirmRegistration(email, code);
@@ -56,6 +82,29 @@ export default function Register() {
       setLoading(false);
     }
   };
+
+  const handleResend = async () => {
+    if (resending || resendSeconds > 0 || loading) return;
+    clearError();
+    setResendError(null);
+    setResendNotice(null);
+    setResending(true);
+    try {
+      const result = await startRegistration(registrationPayload);
+      if (result.code) {
+        setDevCode(result.code);
+      }
+      setResendNotice(REGISTER_RESEND_SUCCESS);
+      setResendSeconds(REGISTER_RESEND_COOLDOWN_SECONDS);
+    } catch (e) {
+      setResendError(userFacingApiError(e));
+    } finally {
+      setResending(false);
+    }
+  };
+
+  const step2Busy = loading || resending;
+  const step2Alert = error ?? resendError;
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -233,17 +282,32 @@ export default function Register() {
                   maxLength={6}
                   required
                   autoComplete="one-time-code"
-                  aria-invalid={error ? true : undefined}
-                  aria-describedby={error ? "register-code-error" : undefined}
+                  aria-invalid={step2Alert ? true : undefined}
+                  aria-describedby={
+                    step2Alert
+                      ? "register-code-error"
+                      : resendNotice
+                        ? "register-resend-notice"
+                        : undefined
+                  }
                 />
               </div>
-              {error ? (
+              {resendNotice ? (
+                <p
+                  id="register-resend-notice"
+                  className="text-sm text-muted-foreground"
+                  role="status"
+                >
+                  {resendNotice}
+                </p>
+              ) : null}
+              {step2Alert ? (
                 <p
                   id="register-code-error"
                   className="text-sm text-destructive"
                   role="alert"
                 >
-                  {error}
+                  {step2Alert}
                 </p>
               ) : null}
               <div className="flex gap-2">
@@ -254,20 +318,41 @@ export default function Register() {
                   onClick={() => {
                     setStep(1);
                     setCode("");
+                    setResendNotice(null);
+                    setResendError(null);
                     clearError();
                   }}
-                  disabled={loading}
+                  disabled={step2Busy}
                 >
                   Voltar
                 </Button>
                 <Button
                   type="submit"
                   className="flex-1"
-                  disabled={loading || code.length !== 6}
+                  disabled={step2Busy || code.length !== 6}
                 >
                   {loading ? "Confirmando..." : "Confirmar"}
                 </Button>
               </div>
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full"
+                onClick={() => {
+                  void handleResend();
+                }}
+                disabled={step2Busy || resendSeconds > 0}
+              >
+                {resending
+                  ? "Reenviando..."
+                  : resendSeconds > 0
+                    ? `Reenviar em ${resendSeconds}s`
+                    : "Reenviar código"}
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                Não chegou? Reenvie depois do intervalo. O código anterior pode
+                expirar.
+              </p>
             </form>
           )}
 

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -184,6 +184,7 @@ describe("Index", () => {
     expect(screen.getByText(HOME_NEW_SORT_COPY)).toBeTruthy();
     expect(screen.getByText(HOME_SHORTCUTS_HEADING)).toBeTruthy();
     expect(screen.getByText(HOME_TRUST_HEADING)).toBeTruthy();
+    expect(document.getElementById("home-trust-heading")).toBeTruthy();
     for (const item of HOME_TRUST_ITEMS) {
       expect(screen.getByText(item)).toBeTruthy();
     }

--- a/src/pages/__tests__/Register.test.tsx
+++ b/src/pages/__tests__/Register.test.tsx
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import Register from "../Register";
+import Register, {
+  REGISTER_RESEND_COOLDOWN_SECONDS,
+  REGISTER_RESEND_SUCCESS,
+} from "../Register";
+import {
+  ApiClientError,
+  USER_FACING_RATE_LIMIT,
+} from "@/lib/userFacingApiError";
 
 const startRegistration = vi.fn();
 const confirmRegistration = vi.fn();
@@ -28,12 +35,36 @@ function renderRegister() {
   );
 }
 
+async function goToStep2(values?: {
+  name?: string;
+  email?: string;
+  password?: string;
+}) {
+  fireEvent.change(screen.getByLabelText("Nome"), {
+    target: { value: values?.name ?? "Ana" },
+  });
+  fireEvent.change(screen.getByLabelText("E-mail"), {
+    target: { value: values?.email ?? "ana@test.com" },
+  });
+  fireEvent.change(screen.getByLabelText("Senha"), {
+    target: { value: values?.password ?? "secret1" },
+  });
+  fireEvent.click(
+    screen.getByRole("button", { name: "Enviar código por e-mail" }),
+  );
+  expect(await screen.findByLabelText("Código")).toBeTruthy();
+}
+
 describe("Register", () => {
   beforeEach(() => {
     startRegistration.mockReset();
     confirmRegistration.mockReset();
     startRegistration.mockResolvedValue({ message: "ok", code: "123456" });
     confirmRegistration.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("does not offer ADMIN as a public registration role", () => {
@@ -97,5 +128,111 @@ describe("Register", () => {
     expect(await screen.findByText("landed-seller")).toBeTruthy();
     expect(screen.queryByText("landed-home")).toBeNull();
     expect(screen.queryByText("landed-admin")).toBeNull();
+  });
+
+  it("keeps name and email from step 1 when going back from step 2", async () => {
+    renderRegister();
+    await goToStep2({ name: "Ana", email: "ana@test.com" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Voltar" }));
+
+    expect(screen.getByLabelText("Nome")).toHaveValue("Ana");
+    expect(screen.getByLabelText("E-mail")).toHaveValue("ana@test.com");
+  });
+
+  it("does not show a verification code when the API omits it", async () => {
+    startRegistration.mockResolvedValue({ message: "ok" });
+    renderRegister();
+    await goToStep2();
+
+    expect(screen.queryByText(/código =/i)).toBeNull();
+    expect(screen.queryByText("123456")).toBeNull();
+  });
+
+  async function submitStep1AndFlush() {
+    fireEvent.change(screen.getByLabelText("Nome"), {
+      target: { value: "Ana" },
+    });
+    fireEvent.change(screen.getByLabelText("E-mail"), {
+      target: { value: "ana@test.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "secret1" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enviar código por e-mail" }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByLabelText("Código")).toBeTruthy();
+  }
+
+  it("resends with the same step 1 fields after the cooldown", async () => {
+    vi.useFakeTimers();
+    renderRegister();
+    await submitStep1AndFlush();
+
+    expect(
+      screen.getByRole("button", {
+        name: `Reenviar em ${REGISTER_RESEND_COOLDOWN_SECONDS}s`,
+      }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        REGISTER_RESEND_COOLDOWN_SECONDS * 1000,
+      );
+    });
+
+    const resend = screen.getByRole("button", { name: "Reenviar código" });
+    expect(resend).toBeEnabled();
+    fireEvent.click(resend);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(startRegistration).toHaveBeenCalledTimes(2);
+    expect(startRegistration).toHaveBeenLastCalledWith({
+      name: "Ana",
+      email: "ana@test.com",
+      password: "secret1",
+      role: "CUSTOMER",
+    });
+    expect(screen.getByText(REGISTER_RESEND_SUCCESS)).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: `Reenviar em ${REGISTER_RESEND_COOLDOWN_SECONDS}s`,
+      }),
+    ).toBeDisabled();
+  });
+
+  it("maps 429 on resend to wait copy without leaving step 2", async () => {
+    startRegistration
+      .mockResolvedValueOnce({ message: "ok" })
+      .mockRejectedValueOnce(
+        new ApiClientError("Too many requests", { status: 429 }),
+      );
+
+    vi.useFakeTimers();
+    renderRegister();
+    await submitStep1AndFlush();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        REGISTER_RESEND_COOLDOWN_SECONDS * 1000,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reenviar código" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(USER_FACING_RATE_LIMIT);
+    expect(screen.getByLabelText("Código")).toBeTruthy();
+    expect(screen.getByText(/ana@test.com/)).toBeTruthy();
+    expect(startRegistration).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #121
Closes #122
Closes #111

Frontend account/session chrome against existing APIs. No `server/` edits. Favorites (#106) is not in this PR.

## #122 — Server logout

`src/api/auth.ts` already POSTed `/auth/logout` on `main`. This PR hardens AuthContext so a failed revoke still returns to guest and always clears local session.

## #121 — Resend verification code

Register step 2: **Reenviar código** via the same `startRegistration` payload. 45s cooldown. 429 → wait copy. Name/email from step 1 kept. Dev code leak not expanded.

## #111 — Footer

Market, Como comprar (`/#home-trust-heading`), Entrar, Criar conta, Vender. Unique-item + PayPal copy. No invented `/terms`.

## Verification

- `npm run typecheck` → PASS
- `npm run lint` → PASS
- `npm test` → 329 passed
- Browser: resend cooldown, `POST /auth/logout` + guest chrome, footer desktop/mobile

[auth_resend_logout_footer_walkthrough.mp4](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_resend_logout_footer_walkthrough.mp4)
[Desktop footer with real account links](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter_desktop.png)
[Register step 2 with Reenviar cooldown](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fregister_step2_resend_visible.png)
[After Sair, guest chrome](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogout_guest_cleared.png)

## Risks

- Footer still shows guest account links while signed in

Do not merge from this agent. Do not close issues from `gh`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

