### PR TITLE
#113 #115 — Seller pending onboarding and admin order filters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import SellerOrders from "./pages/seller/SellerOrders";
 import SellerTransactions from "./pages/seller/SellerTransactions";
 import AdminSellers from "./pages/admin/AdminSellers";
 import AdminOrders from "./pages/admin/AdminOrders";
+import AdminOrderDetail from "./pages/admin/AdminOrderDetail";
 import AdminUsers from "./pages/admin/AdminUsers";
 import AdminCatalog from "./pages/admin/AdminCatalog";
 import NotFound from "./pages/NotFound";
@@ -178,6 +179,14 @@ const App = () => (
                     element={
                       <ProtectedRoute allowedRoles={["ADMIN"]}>
                         <AdminOrders />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/orders/:id"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminOrderDetail />
                       </ProtectedRoute>
                     }
                   />

--- a/src/api/__tests__/admin.test.ts
+++ b/src/api/__tests__/admin.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listAdminOrders } from "../admin";
+
+const get = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    get: (...args: unknown[]) => get(...args),
+  },
+}));
+
+describe("listAdminOrders", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue([]);
+  });
+
+  it("GETs /admin/orders without query when called without filters", async () => {
+    await listAdminOrders();
+    expect(get).toHaveBeenCalledWith("/admin/orders");
+  });
+
+  it("sends status and paymentStatus query params the admin API already accepts", async () => {
+    await listAdminOrders({ status: "PENDING", paymentStatus: "PAID" });
+    expect(get).toHaveBeenCalledWith(
+      "/admin/orders?status=PENDING&paymentStatus=PAID",
+    );
+  });
+
+  it("omits unknown filter values instead of inventing query params", async () => {
+    await listAdminOrders({ status: "CANCELED", paymentStatus: "CAPTURED" });
+    expect(get).toHaveBeenCalledWith("/admin/orders");
+  });
+});

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,4 +1,5 @@
 import { api } from "./client";
+import { adminOrderListQuery } from "@/lib/adminOrderFilters";
 import type { User, Order, Seller } from "@/types/api";
 
 export type Cs2ShImportSummary = {
@@ -25,8 +26,16 @@ export function listAdminUsers(): Promise<User[]> {
 }
 
 // ─── Orders ───────────────────────────────────────────────────────────────────
-export function listAdminOrders(): Promise<Order[]> {
-  return api.get<Order[]>("/admin/orders");
+export function listAdminOrders(params?: {
+  status?: string;
+  paymentStatus?: string;
+}): Promise<Order[]> {
+  const filters = adminOrderListQuery(params);
+  const search = new URLSearchParams();
+  if (filters.status) search.set("status", filters.status);
+  if (filters.paymentStatus) search.set("paymentStatus", filters.paymentStatus);
+  const qs = search.toString();
+  return api.get<Order[]>(`/admin/orders${qs ? `?${qs}` : ""}`);
 }
 
 // ─── Sellers ──────────────────────────────────────────────────────────────────

--- a/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/src/components/__tests__/ProtectedRoute.test.tsx
@@ -104,3 +104,61 @@ describe("ProtectedRoute seller surface", () => {
     expect(screen.queryByText("seller-page")).toBeNull();
   });
 });
+
+const ADMIN_ORDER_ROUTES = [
+  "/admin/orders",
+  "/admin/orders/order-abcdef12",
+] as const;
+
+function renderAdminGate(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          element={
+            <ProtectedRoute>
+              <ProtectedRoute allowedRoles={["ADMIN"]}>
+                <div>admin-page</div>
+              </ProtectedRoute>
+            </ProtectedRoute>
+          }
+        >
+          <Route path="/admin/orders" element={null} />
+          <Route path="/admin/orders/:id" element={null} />
+        </Route>
+        <Route path="/login" element={<div>login</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ProtectedRoute admin orders", () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
+  });
+
+  it.each(ADMIN_ORDER_ROUTES)("keeps ADMIN on %s", (path) => {
+    authState.user = userFor("ADMIN");
+    authState.isAuthenticated = true;
+
+    renderAdminGate(path);
+
+    expect(screen.getByText("admin-page")).toBeTruthy();
+    expect(screen.queryByText("Acesso negado")).toBeNull();
+  });
+
+  it.each(["SELLER", "CUSTOMER"] as const)(
+    "denies %s on admin order list and detail",
+    (role) => {
+      authState.user = userFor(role);
+      authState.isAuthenticated = true;
+
+      renderAdminGate("/admin/orders/order-abcdef12");
+
+      expect(screen.getByText("Acesso negado")).toBeTruthy();
+      expect(screen.queryByText("admin-page")).toBeNull();
+    },
+  );
+});

--- a/src/components/seller/SellerPendingBanner.tsx
+++ b/src/components/seller/SellerPendingBanner.tsx
@@ -1,0 +1,19 @@
+export const SELLER_PENDING_BANNER_TITLE = "Sua loja aguarda aprovação";
+export const SELLER_PENDING_BANNER_BODY =
+  "Você poderá anunciar depois que um admin aprovar.";
+
+export function SellerPendingBanner() {
+  return (
+    <div
+      role="status"
+      className="mb-6 rounded-md border border-border bg-card p-4"
+    >
+      <p className="text-sm font-semibold tracking-tight">
+        {SELLER_PENDING_BANNER_TITLE}
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {SELLER_PENDING_BANNER_BODY}
+      </p>
+    </div>
+  );
+}

--- a/src/components/seller/__tests__/SellerPendingBanner.test.tsx
+++ b/src/components/seller/__tests__/SellerPendingBanner.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  SELLER_PENDING_BANNER_BODY,
+  SELLER_PENDING_BANNER_TITLE,
+  SellerPendingBanner,
+} from "../SellerPendingBanner";
+
+describe("SellerPendingBanner", () => {
+  it("explains admin approval without inventing an email", () => {
+    render(<SellerPendingBanner />);
+
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText(SELLER_PENDING_BANNER_TITLE)).toBeTruthy();
+    expect(screen.getByText(SELLER_PENDING_BANNER_BODY)).toBeTruthy();
+    expect(screen.queryByText(/e-?mail/i)).toBeNull();
+    expect(screen.queryByText(/aprovad[oa] por e-mail/i)).toBeNull();
+  });
+});

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Outlet, useLocation, Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import {
   BarChart3,
   Menu,
@@ -10,6 +11,8 @@ import {
   Shield,
   Tag,
 } from "lucide-react";
+import { getSellerMe } from "@/api/sellers";
+import { SellerPendingBanner } from "@/components/seller/SellerPendingBanner";
 import { Header } from "@/components/Header";
 import { SiteFooter } from "@/components/SiteFooter";
 import { Button } from "@/components/ui/button";
@@ -81,6 +84,12 @@ export default function DashboardLayout() {
   const isAdmin = location.pathname.startsWith("/admin");
   const items = isAdmin ? adminItems : sellerItems;
   const [open, setOpen] = useState(false);
+  const sellerMeQuery = useQuery({
+    queryKey: ["sellerMe"],
+    queryFn: () => getSellerMe(),
+    enabled: !isAdmin,
+  });
+  const showPendingBanner = sellerMeQuery.data?.isApproved === false;
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -117,6 +126,7 @@ export default function DashboardLayout() {
             </Sheet>
           </div>
           <main className="flex-1 p-6">
+            {showPendingBanner ? <SellerPendingBanner /> : null}
             <Outlet />
           </main>
         </div>

--- a/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import DashboardLayout from "../DashboardLayout";
+import { SELLER_PENDING_BANNER_TITLE } from "@/components/seller/SellerPendingBanner";
+import type { Seller } from "@/types/api";
+
+const getSellerMe = vi.fn();
 
 vi.mock("@/components/Header", () => ({
   Header: () => <div>header</div>,
@@ -11,36 +16,60 @@ vi.mock("@/components/SiteFooter", () => ({
   SiteFooter: () => null,
 }));
 
-function renderAdminNav(path: string) {
+vi.mock("@/api/sellers", () => ({
+  getSellerMe: (...args: unknown[]) => getSellerMe(...args),
+}));
+
+function sellerMe(overrides: Partial<Seller> = {}): Seller {
+  return {
+    id: "seller-1",
+    userId: "seller-user",
+    storeName: "NeonTrader Store",
+    balance: 0,
+    rating: 0,
+    isApproved: true,
+    ...overrides,
+  };
+}
+
+function renderLayout(path: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route element={<DashboardLayout />}>
-          <Route path="/admin" element={<div>overview</div>} />
-          <Route path="/admin/catalog" element={<div>catalog-page</div>} />
-        </Route>
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route element={<DashboardLayout />}>
+            <Route path="/admin" element={<div>overview</div>} />
+            <Route path="/admin/catalog" element={<div>catalog-page</div>} />
+            <Route path="/admin/orders" element={<div>admin-orders</div>} />
+            <Route path="/seller" element={<div>overview</div>} />
+            <Route
+              path="/seller/transactions"
+              element={<div>transactions-page</div>}
+            />
+            <Route path="/seller/listings" element={<div>listings-page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
+}
+
+function renderAdminNav(path: string) {
+  return renderLayout(path);
 }
 
 function renderSellerNav(path: string) {
-  return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route element={<DashboardLayout />}>
-          <Route path="/seller" element={<div>overview</div>} />
-          <Route
-            path="/seller/transactions"
-            element={<div>transactions-page</div>}
-          />
-        </Route>
-      </Routes>
-    </MemoryRouter>,
-  );
+  return renderLayout(path);
 }
 
 describe("DashboardLayout admin nav", () => {
+  beforeEach(() => {
+    getSellerMe.mockReset();
+  });
+
   it("exposes Catálogo next to Visão Geral", () => {
     renderAdminNav("/admin");
     const links = screen.getAllByRole("link", { name: "Catálogo" });
@@ -49,6 +78,7 @@ describe("DashboardLayout admin nav", () => {
     expect(
       screen.getAllByRole("link", { name: "Visão Geral" })[0],
     ).toHaveAttribute("href", "/admin");
+    expect(getSellerMe).not.toHaveBeenCalled();
   });
 
   it("marks Catálogo current on /admin/catalog", () => {
@@ -58,11 +88,17 @@ describe("DashboardLayout admin nav", () => {
       links.some((link) => link.getAttribute("aria-current") === "page"),
     ).toBe(true);
     expect(screen.getByText("catalog-page")).toBeTruthy();
+    expect(getSellerMe).not.toHaveBeenCalled();
   });
 });
 
 describe("DashboardLayout seller nav", () => {
-  it("exposes Transações next to Visão Geral", () => {
+  beforeEach(() => {
+    getSellerMe.mockReset();
+    getSellerMe.mockResolvedValue(sellerMe());
+  });
+
+  it("exposes Transações next to Visão Geral", async () => {
     renderSellerNav("/seller");
     const links = screen.getAllByRole("link", { name: "Transações" });
     expect(links.length).toBeGreaterThan(0);
@@ -70,6 +106,8 @@ describe("DashboardLayout seller nav", () => {
     expect(
       screen.getAllByRole("link", { name: "Visão Geral" })[0],
     ).toHaveAttribute("href", "/seller");
+    expect(await screen.findByText("overview")).toBeTruthy();
+    expect(screen.queryByText(SELLER_PENDING_BANNER_TITLE)).toBeNull();
   });
 
   it("marks Transações current on /seller/transactions", () => {
@@ -79,5 +117,28 @@ describe("DashboardLayout seller nav", () => {
       links.some((link) => link.getAttribute("aria-current") === "page"),
     ).toBe(true);
     expect(screen.getByText("transactions-page")).toBeTruthy();
+  });
+
+  it("shows a persistent pending banner from getSellerMe on /seller/*", async () => {
+    getSellerMe.mockResolvedValue(sellerMe({ isApproved: false }));
+
+    renderSellerNav("/seller/listings");
+
+    expect(await screen.findByText(SELLER_PENDING_BANNER_TITLE)).toBeTruthy();
+    expect(
+      screen.getByText("Você poderá anunciar depois que um admin aprovar."),
+    ).toBeTruthy();
+    expect(screen.getByText("listings-page")).toBeTruthy();
+    expect(getSellerMe).toHaveBeenCalled();
+    expect(screen.queryByText(/e-?mail/i)).toBeNull();
+  });
+
+  it("hides the pending banner after getSellerMe reports approval", async () => {
+    getSellerMe.mockResolvedValue(sellerMe({ isApproved: true }));
+
+    renderSellerNav("/seller");
+
+    expect(await screen.findByText("overview")).toBeTruthy();
+    expect(screen.queryByText(SELLER_PENDING_BANNER_TITLE)).toBeNull();
   });
 });

--- a/src/lib/__tests__/adminOrderFilters.test.ts
+++ b/src/lib/__tests__/adminOrderFilters.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  adminOrderListQuery,
+  hasAdminOrderFilters,
+  parseAdminOrderStatus,
+  parseAdminPaymentStatus,
+} from "../adminOrderFilters";
+
+describe("adminOrderFilters", () => {
+  it("accepts API status and paymentStatus values", () => {
+    expect(parseAdminOrderStatus("CONFIRMED")).toBe("CONFIRMED");
+    expect(parseAdminPaymentStatus("PENDING")).toBe("PENDING");
+    expect(
+      adminOrderListQuery({
+        status: "SHIPPED",
+        paymentStatus: "PAID",
+      }),
+    ).toEqual({ status: "SHIPPED", paymentStatus: "PAID" });
+  });
+
+  it("ignores empty or unknown query values instead of inventing filters", () => {
+    expect(parseAdminOrderStatus("")).toBeUndefined();
+    expect(parseAdminOrderStatus("CANCELED")).toBeUndefined();
+    expect(parseAdminPaymentStatus("CAPTURED")).toBeUndefined();
+    expect(adminOrderListQuery({ status: "nope", paymentStatus: " " })).toEqual(
+      {},
+    );
+    expect(hasAdminOrderFilters({})).toBe(false);
+    expect(hasAdminOrderFilters({ status: "PENDING" })).toBe(true);
+  });
+});

--- a/src/lib/adminOrderFilters.ts
+++ b/src/lib/adminOrderFilters.ts
@@ -1,0 +1,54 @@
+export const ADMIN_ORDER_STATUSES = [
+  "PENDING",
+  "CONFIRMED",
+  "SHIPPED",
+  "DELIVERED",
+  "CANCELLED",
+] as const;
+
+export const ADMIN_PAYMENT_STATUSES = ["PENDING", "PAID", "REFUNDED"] as const;
+
+export type AdminOrderStatus = (typeof ADMIN_ORDER_STATUSES)[number];
+export type AdminPaymentStatus = (typeof ADMIN_PAYMENT_STATUSES)[number];
+
+function isOneOf<T extends string>(
+  value: string,
+  allowed: readonly T[],
+): value is T {
+  return (allowed as readonly string[]).includes(value);
+}
+
+export function parseAdminOrderStatus(
+  value: string | null | undefined,
+): AdminOrderStatus | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return isOneOf(trimmed, ADMIN_ORDER_STATUSES) ? trimmed : undefined;
+}
+
+export function parseAdminPaymentStatus(
+  value: string | null | undefined,
+): AdminPaymentStatus | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return isOneOf(trimmed, ADMIN_PAYMENT_STATUSES) ? trimmed : undefined;
+}
+
+export function adminOrderListQuery(params?: {
+  status?: string;
+  paymentStatus?: string;
+}): { status?: AdminOrderStatus; paymentStatus?: AdminPaymentStatus } {
+  const status = parseAdminOrderStatus(params?.status);
+  const paymentStatus = parseAdminPaymentStatus(params?.paymentStatus);
+  return {
+    ...(status ? { status } : {}),
+    ...(paymentStatus ? { paymentStatus } : {}),
+  };
+}
+
+export function hasAdminOrderFilters(params: {
+  status?: string;
+  paymentStatus?: string;
+}): boolean {
+  return Boolean(params.status || params.paymentStatus);
+}

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -33,7 +33,7 @@ export default function AdminDashboard() {
 
   const ordersQuery = useQuery({
     queryKey: ["admin-orders"],
-    queryFn: listAdminOrders,
+    queryFn: () => listAdminOrders(),
   });
   const sellersQuery = useQuery({
     queryKey: ["admin-sellers"],

--- a/src/pages/admin/AdminOrderDetail.tsx
+++ b/src/pages/admin/AdminOrderDetail.tsx
@@ -1,0 +1,192 @@
+import { Link, useLocation, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getOrder } from "@/api/orders";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { isOrderAccessError, orderItemLabel } from "@/lib/orderPaymentView";
+import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
+
+function formatMoney(value: number): string {
+  return `$${Number(value).toFixed(2)}`;
+}
+
+export default function AdminOrderDetail() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+  const listHref = {
+    pathname: "/admin/orders",
+    search: location.search,
+  };
+
+  const {
+    data: order,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["admin-order", id],
+    queryFn: () => getOrder(id!),
+    enabled: Boolean(id),
+    retry: false,
+  });
+
+  if (!id) {
+    return (
+      <EmptyState
+        title="Pedido não encontrado"
+        description="O identificador do pedido é inválido."
+        action={
+          <Button asChild variant="outline">
+            <Link to={listHref}>Voltar aos pedidos</Link>
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-72 max-w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (isError || !order) {
+    const missing = isOrderAccessError(error);
+    return (
+      <ErrorState
+        title={missing ? "Pedido não encontrado" : "Erro ao carregar o pedido"}
+        error={error}
+        description={
+          missing ? "Este pedido não existe ou não está disponível." : undefined
+        }
+        action={
+          missing ? (
+            <Button asChild variant="outline">
+              <Link to={listHref}>Voltar aos pedidos</Link>
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void refetch()}
+            >
+              Tentar novamente
+            </Button>
+          )
+        }
+      />
+    );
+  }
+
+  const items = order.items ?? [];
+  const customerName = order.customer?.name?.trim();
+  const customerEmail = order.customer?.email?.trim();
+  const trackingCode = order.trackingCode?.trim();
+  const trackingCarrier = order.trackingCarrier?.trim();
+  const paypalOrderId = order.paypalOrderId?.trim();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Pedido #{order.id.slice(0, 8)}
+          </h1>
+          <p className="mt-1 font-mono text-xs text-muted-foreground">
+            {order.id}
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link to={listHref}>Voltar aos pedidos</Link>
+        </Button>
+      </div>
+
+      <dl className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-md border border-border bg-card p-4">
+          <dt className="text-xs text-muted-foreground">Status</dt>
+          <dd className="mt-2">
+            <Badge variant="secondary">{orderStatusLabel(order.status)}</Badge>
+          </dd>
+        </div>
+        <div className="rounded-md border border-border bg-card p-4">
+          <dt className="text-xs text-muted-foreground">Pagamento</dt>
+          <dd className="mt-2">
+            <Badge variant="outline">
+              {paymentStatusLabel(order.paymentStatus)}
+            </Badge>
+          </dd>
+        </div>
+        <div className="rounded-md border border-border bg-card p-4">
+          <dt className="text-xs text-muted-foreground">Total</dt>
+          <dd className="mt-2 tabular-nums text-lg font-semibold">
+            {formatMoney(order.totalAmount)}
+          </dd>
+        </div>
+        <div className="rounded-md border border-border bg-card p-4">
+          <dt className="text-xs text-muted-foreground">Cliente</dt>
+          <dd className="mt-2 text-sm">
+            {customerName || customerEmail || "—"}
+            {customerName && customerEmail ? (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {customerEmail}
+              </p>
+            ) : null}
+          </dd>
+        </div>
+        <div className="rounded-md border border-border bg-card p-4">
+          <dt className="text-xs text-muted-foreground">Rastreio</dt>
+          <dd className="mt-2 text-sm">
+            {trackingCode || trackingCarrier
+              ? [trackingCarrier, trackingCode].filter(Boolean).join(" · ")
+              : "Sem rastreio"}
+          </dd>
+        </div>
+        {paypalOrderId ? (
+          <div className="rounded-md border border-border bg-card p-4">
+            <dt className="text-xs text-muted-foreground">PayPal order ID</dt>
+            <dd className="mt-2 font-mono text-sm">{paypalOrderId}</dd>
+          </div>
+        ) : null}
+      </dl>
+
+      <section>
+        <h2 className="text-sm font-semibold tracking-tight">Itens</h2>
+        {items.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            Este pedido não tem itens.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center justify-between gap-4 rounded-md border border-border bg-card p-4"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {orderItemLabel(item)}
+                  </p>
+                  {item.seller?.storeName ? (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {item.seller.storeName}
+                    </p>
+                  ) : null}
+                </div>
+                <p className="tabular-nums text-sm font-semibold">
+                  {formatMoney(item.priceSnapshot)}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -1,9 +1,18 @@
+import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { listAdminOrders } from "@/api/admin";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ADMIN_ORDER_STATUSES,
+  ADMIN_PAYMENT_STATUSES,
+  hasAdminOrderFilters,
+  parseAdminOrderStatus,
+  parseAdminPaymentStatus,
+} from "@/lib/adminOrderFilters";
 import { orderStatusLabel, paymentStatusLabel } from "@/lib/userFacingApiError";
 import {
   Table,
@@ -19,6 +28,17 @@ function formatMoney(value: number): string {
 }
 
 export default function AdminOrders() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const status = parseAdminOrderStatus(searchParams.get("status"));
+  const paymentStatus = parseAdminPaymentStatus(
+    searchParams.get("paymentStatus"),
+  );
+  const filters = {
+    ...(status ? { status } : {}),
+    ...(paymentStatus ? { paymentStatus } : {}),
+  };
+  const filtered = hasAdminOrderFilters(filters);
+
   const {
     data: orders = [],
     isLoading,
@@ -26,36 +46,16 @@ export default function AdminOrders() {
     error,
     refetch,
   } = useQuery({
-    queryKey: ["admin-orders"],
-    queryFn: listAdminOrders,
+    queryKey: ["admin-orders", filters],
+    queryFn: () => listAdminOrders(filters),
   });
 
-  if (isLoading) {
-    return (
-      <div className="space-y-4" role="status" aria-label="Carregando">
-        <Skeleton className="h-8 w-40" />
-        <Skeleton className="h-48 w-full" />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <ErrorState
-        title="Erro ao carregar os pedidos"
-        error={error}
-        action={
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => void refetch()}
-          >
-            Tentar novamente
-          </Button>
-        }
-      />
-    );
-  }
+  const setFilter = (key: "status" | "paymentStatus", value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setSearchParams(next, { replace: true });
+  };
 
   return (
     <div className="space-y-6">
@@ -66,8 +66,66 @@ export default function AdminOrders() {
         </p>
       </div>
 
-      {orders.length === 0 ? (
-        <EmptyState title="Nenhum pedido encontrado" />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor="admin-order-status">Status</Label>
+          <select
+            id="admin-order-status"
+            className="flex h-11 min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={status ?? ""}
+            onChange={(event) => setFilter("status", event.target.value)}
+          >
+            <option value="">Todos</option>
+            {ADMIN_ORDER_STATUSES.map((value) => (
+              <option key={value} value={value}>
+                {orderStatusLabel(value)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="admin-order-payment-status">Pagamento</Label>
+          <select
+            id="admin-order-payment-status"
+            className="flex h-11 min-h-11 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={paymentStatus ?? ""}
+            onChange={(event) => setFilter("paymentStatus", event.target.value)}
+          >
+            <option value="">Todos</option>
+            {ADMIN_PAYMENT_STATUSES.map((value) => (
+              <option key={value} value={value}>
+                {paymentStatusLabel(value)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-4" role="status" aria-label="Carregando">
+          <Skeleton className="h-48 w-full" />
+        </div>
+      ) : isError ? (
+        <ErrorState
+          title="Erro ao carregar os pedidos"
+          error={error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void refetch()}
+            >
+              Tentar novamente
+            </Button>
+          }
+        />
+      ) : orders.length === 0 ? (
+        <EmptyState
+          title={
+            filtered ? "Nenhum pedido neste filtro" : "Nenhum pedido encontrado"
+          }
+          description={filtered ? "Tente ajustar os filtros" : undefined}
+        />
       ) : (
         <div className="overflow-hidden rounded-md border border-border">
           <Table>
@@ -84,7 +142,15 @@ export default function AdminOrders() {
               {orders.map((order) => (
                 <TableRow key={order.id}>
                   <TableCell className="font-mono text-xs">
-                    #{order.id.slice(0, 8)}
+                    <Link
+                      to={{
+                        pathname: `/admin/orders/${order.id}`,
+                        search: searchParams.toString(),
+                      }}
+                      className="underline-offset-4 hover:underline"
+                    >
+                      #{order.id.slice(0, 8)}
+                    </Link>
                   </TableCell>
                   <TableCell>{formatMoney(order.totalAmount)}</TableCell>
                   <TableCell>

--- a/src/pages/admin/__tests__/AdminOrderDetail.test.tsx
+++ b/src/pages/admin/__tests__/AdminOrderDetail.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiClientError } from "@/lib/userFacingApiError";
+import AdminOrderDetail from "../AdminOrderDetail";
+import type { Order } from "@/types/api";
+
+const getOrder = vi.fn();
+
+vi.mock("@/api/orders", () => ({
+  getOrder: (...args: unknown[]) => getOrder(...args),
+}));
+
+function order(overrides: Partial<Order> = {}): Order {
+  return {
+    id: "order-abcdef12",
+    totalAmount: 18.5,
+    status: "CONFIRMED",
+    paymentStatus: "PAID",
+    trackingCode: "BR123456",
+    trackingCarrier: "Correios",
+    paypalOrderId: "PAYPAL-ORDER-9",
+    createdAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+    updatedAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+    customer: {
+      id: "cust-1",
+      name: "Ana Buyer",
+      email: "ana@example.com",
+      role: "CUSTOMER",
+    },
+    items: [
+      {
+        id: "item-1",
+        listingId: "listing-1",
+        sellerId: "seller-1",
+        priceSnapshot: 18.5,
+        listing: {
+          id: "listing-1",
+          product: {
+            id: "prod-1",
+            weapon: "AK-47",
+            skinName: "Redline",
+            exterior: "Field-Tested",
+          },
+        },
+        seller: { id: "seller-1", storeName: "NeonTrader Store" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderDetail(path = "/admin/orders/order-abcdef12") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/admin/orders/:id" element={<AdminOrderDetail />} />
+          <Route path="/admin/orders" element={<div>orders-list</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminOrderDetail", () => {
+  beforeEach(() => {
+    getOrder.mockReset();
+  });
+
+  it("shows read-only items, customer, payment, tracking and paypalOrderId", async () => {
+    getOrder.mockResolvedValue(order());
+
+    renderDetail();
+
+    expect(await screen.findByText("Pedido #order-ab")).toBeTruthy();
+    expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    expect(screen.getByText("Ana Buyer")).toBeTruthy();
+    expect(screen.getByText("ana@example.com")).toBeTruthy();
+    expect(screen.getByText("Pago")).toBeTruthy();
+    expect(screen.getByText("Correios · BR123456")).toBeTruthy();
+    expect(screen.getByText("PAYPAL-ORDER-9")).toBeTruthy();
+    expect(getOrder).toHaveBeenCalledWith("order-abcdef12");
+    expect(screen.queryByRole("button", { name: /reembols/i })).toBeNull();
+    expect(screen.queryByText(/PAYPAL_SECRET/i)).toBeNull();
+    expect(screen.queryByText(/webhook/i)).toBeNull();
+    expect(screen.queryByText(/client secret/i)).toBeNull();
+  });
+
+  it("maps a missing order to Portuguese 404 copy", async () => {
+    getOrder.mockRejectedValue(
+      new ApiClientError("Order not found", { status: 404 }),
+    );
+
+    renderDetail("/admin/orders/missing-order");
+
+    expect(await screen.findByText("Pedido não encontrado")).toBeTruthy();
+    expect(
+      screen.getByText("Este pedido não existe ou não está disponível."),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Voltar aos pedidos" }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Order not found/i)).toBeNull();
+  });
+});

--- a/src/pages/admin/__tests__/AdminOrders.test.tsx
+++ b/src/pages/admin/__tests__/AdminOrders.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AdminOrders from "../AdminOrders";
 import type { Order } from "@/types/api";
@@ -11,7 +11,7 @@ vi.mock("@/api/admin", () => ({
   listAdminOrders: (...args: unknown[]) => listAdminOrders(...args),
 }));
 
-function order(): Order {
+function order(overrides: Partial<Order> = {}): Order {
   return {
     id: "order-abcdef12",
     totalAmount: 18.5,
@@ -19,17 +19,20 @@ function order(): Order {
     paymentStatus: "PAID",
     createdAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
     updatedAt: new Date("2026-01-15T12:00:00.000Z").toISOString(),
+    ...overrides,
   };
 }
 
-function renderOrders() {
+function renderOrders(path = "/admin/orders") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={client}>
-      <MemoryRouter>
-        <AdminOrders />
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/admin/orders" element={<AdminOrders />} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -49,7 +52,52 @@ describe("AdminOrders", () => {
     expect(screen.getByText("#order-ab")).toBeTruthy();
     expect(screen.getByText("$18.50")).toBeTruthy();
     expect(screen.getByText("Pago")).toBeTruthy();
-    expect(listAdminOrders).toHaveBeenCalled();
+    expect(listAdminOrders).toHaveBeenCalledWith({});
     expect(screen.queryByRole("button", { name: "Aprovar" })).toBeNull();
+    expect(screen.queryByText(/reembols/i)).toBeNull();
+    expect(screen.getByRole("link", { name: "#order-ab" })).toHaveAttribute(
+      "href",
+      "/admin/orders/order-abcdef12",
+    );
+  });
+
+  it("sends URL query filters to GET /admin/orders", async () => {
+    listAdminOrders.mockResolvedValue([]);
+
+    renderOrders("/admin/orders?status=PENDING&paymentStatus=PENDING");
+
+    expect(await screen.findByText("Nenhum pedido neste filtro")).toBeTruthy();
+    expect(screen.getByText("Tente ajustar os filtros")).toBeTruthy();
+    expect(listAdminOrders).toHaveBeenCalledWith({
+      status: "PENDING",
+      paymentStatus: "PENDING",
+    });
+    expect(screen.getByLabelText("Status")).toHaveValue("PENDING");
+    expect(screen.getByLabelText("Pagamento")).toHaveValue("PENDING");
+  });
+
+  it("distinguishes an empty platform from an empty filter", async () => {
+    listAdminOrders.mockResolvedValue([]);
+
+    renderOrders();
+
+    expect(await screen.findByText("Nenhum pedido encontrado")).toBeTruthy();
+    expect(screen.queryByText("Nenhum pedido neste filtro")).toBeNull();
+    expect(screen.queryByText("Tente ajustar os filtros")).toBeNull();
+  });
+
+  it("updates the URL when a payment filter is chosen", async () => {
+    listAdminOrders.mockResolvedValue([order()]);
+
+    renderOrders();
+    expect(await screen.findByText("#order-ab")).toBeTruthy();
+
+    listAdminOrders.mockResolvedValue([]);
+    fireEvent.change(screen.getByLabelText("Pagamento"), {
+      target: { value: "PENDING" },
+    });
+
+    expect(await screen.findByText("Nenhum pedido neste filtro")).toBeTruthy();
+    expect(listAdminOrders).toHaveBeenCalledWith({ paymentStatus: "PENDING" });
   });
 });

--- a/src/pages/admin/__tests__/AdminOrders.test.tsx
+++ b/src/pages/admin/__tests__/AdminOrders.test.tsx
@@ -51,10 +51,11 @@ describe("AdminOrders", () => {
     expect(await screen.findByText("Pedidos")).toBeTruthy();
     expect(screen.getByText("#order-ab")).toBeTruthy();
     expect(screen.getByText("$18.50")).toBeTruthy();
-    expect(screen.getByText("Pago")).toBeTruthy();
+    expect(screen.getAllByText("Pago").length).toBeGreaterThan(0);
     expect(listAdminOrders).toHaveBeenCalledWith({});
     expect(screen.queryByRole("button", { name: "Aprovar" })).toBeNull();
-    expect(screen.queryByText(/reembols/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /reembols/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /reembols/i })).toBeNull();
     expect(screen.getByRole("link", { name: "#order-ab" })).toHaveAttribute(
       "href",
       "/admin/orders/order-abcdef12",

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -146,7 +146,14 @@ export default function SellerListings() {
     return <Navigate to="/admin" replace />;
   }
 
+  const canCreateListing = seller?.isApproved === true;
+  const pendingApproval = seller?.isApproved === false;
+  const createListingLabel = pendingApproval
+    ? "Disponível após aprovação"
+    : "Novo Listing";
+
   const openCreate = () => {
+    if (!canCreateListing) return;
     setEditingListing(null);
     setSelectedProduct(undefined);
     setForm(emptyForm);
@@ -323,9 +330,13 @@ export default function SellerListings() {
             CRUD de itens únicos. O catálogo de produtos é somente leitura.
           </p>
         </div>
-        <Button onClick={openCreate} disabled={!seller}>
-          <Package className="mr-2 h-4 w-4" />
-          Novo Listing
+        <Button
+          onClick={openCreate}
+          disabled={!canCreateListing}
+          title={pendingApproval ? "Disponível após aprovação" : undefined}
+        >
+          {canCreateListing ? <Package className="mr-2 h-4 w-4" /> : null}
+          {createListingLabel}
         </Button>
       </div>
 
@@ -340,10 +351,18 @@ export default function SellerListings() {
       ) : listings.length === 0 ? (
         <EmptyState
           title="Nenhum listing"
-          description="Crie um item único a partir do catálogo de produtos."
+          description={
+            pendingApproval
+              ? "Você poderá anunciar depois que um admin aprovar."
+              : "Crie um item único a partir do catálogo de produtos."
+          }
           action={
-            <Button onClick={openCreate} disabled={!seller}>
-              Novo Listing
+            <Button
+              onClick={openCreate}
+              disabled={!canCreateListing}
+              title={pendingApproval ? "Disponível após aprovação" : undefined}
+            >
+              {createListingLabel}
             </Button>
           }
         />

--- a/src/pages/seller/SellerTransactions.tsx
+++ b/src/pages/seller/SellerTransactions.tsx
@@ -1,6 +1,7 @@
 import { Link, Navigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { listCommissionTransactions } from "@/api/commissions";
+import { getSellerMe } from "@/api/sellers";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
@@ -37,6 +38,12 @@ export default function SellerTransactionsPage() {
     queryFn: () => listCommissionTransactions(),
     enabled: user?.role === "SELLER",
   });
+  const sellerMeQuery = useQuery({
+    queryKey: ["sellerMe"],
+    queryFn: () => getSellerMe(),
+    enabled: user?.role === "SELLER",
+  });
+  const canCreateListing = sellerMeQuery.data?.isApproved === true;
 
   if (isAdmin) {
     return <Navigate to="/admin" replace />;
@@ -81,9 +88,11 @@ export default function SellerTransactionsPage() {
           title="Nenhuma transação"
           description="Quando um pedido for pago, o movimento aparece aqui."
           action={
-            <Button asChild>
-              <Link to="/seller/listings">Criar listing</Link>
-            </Button>
+            canCreateListing ? (
+              <Button asChild>
+                <Link to="/seller/listings">Criar listing</Link>
+              </Button>
+            ) : undefined
           }
         />
       ) : (

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -123,6 +123,24 @@ describe("SellerListings", () => {
     setAnalyticsCollector(null);
   });
 
+  it("disables Novo Listing when getSellerMe reports a pending store", async () => {
+    getSellerMe.mockResolvedValue(seller({ isApproved: false }));
+
+    render(
+      <MemoryRouter>
+        <SellerListings />
+      </MemoryRouter>,
+    );
+
+    const createButton = await screen.findByRole("button", {
+      name: "Disponível após aprovação",
+    });
+    expect(createButton).toBeDisabled();
+    expect(createButton).toHaveAttribute("title", "Disponível após aprovação");
+    expect(screen.queryByRole("button", { name: "Novo Listing" })).toBeNull();
+    expect(screen.queryByText("Novo listing")).toBeNull();
+  });
+
   it("keeps unique-item listing CRUD on /seller/listings", async () => {
     render(
       <MemoryRouter>

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -43,7 +43,7 @@ vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
 }));
 
-function seller(): Seller {
+function seller(overrides: Partial<Seller> = {}): Seller {
   return {
     id: "seller-1",
     userId: "user-1",
@@ -51,6 +51,7 @@ function seller(): Seller {
     balance: 0,
     rating: 0,
     isApproved: true,
+    ...overrides,
   };
 }
 

--- a/src/pages/seller/__tests__/SellerTransactions.test.tsx
+++ b/src/pages/seller/__tests__/SellerTransactions.test.tsx
@@ -6,6 +6,7 @@ import SellerTransactionsPage from "../SellerTransactions";
 import type { Role, SellerTransaction, User } from "@/types/api";
 
 const listCommissionTransactions = vi.fn();
+const getSellerMe = vi.fn();
 const authState = {
   user: {
     id: "seller-user",
@@ -18,6 +19,10 @@ const authState = {
 vi.mock("@/api/commissions", () => ({
   listCommissionTransactions: (...args: unknown[]) =>
     listCommissionTransactions(...args),
+}));
+
+vi.mock("@/api/sellers", () => ({
+  getSellerMe: (...args: unknown[]) => getSellerMe(...args),
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -73,6 +78,15 @@ function renderTransactions() {
 describe("SellerTransactions", () => {
   beforeEach(() => {
     listCommissionTransactions.mockReset();
+    getSellerMe.mockReset();
+    getSellerMe.mockResolvedValue({
+      id: "seller-1",
+      userId: "seller-user",
+      storeName: "NeonTrader Store",
+      balance: 0,
+      rating: 0,
+      isApproved: true,
+    });
     setRole("SELLER");
   });
 
@@ -103,6 +117,27 @@ describe("SellerTransactions", () => {
       "href",
       "/seller/listings",
     );
+  });
+
+  it("does not push a pending seller to create a listing", async () => {
+    listCommissionTransactions.mockResolvedValue([]);
+    getSellerMe.mockResolvedValue({
+      id: "seller-1",
+      userId: "seller-user",
+      storeName: "NeonTrader Store",
+      balance: 0,
+      rating: 0,
+      isApproved: false,
+    });
+
+    renderTransactions();
+
+    expect(
+      await screen.findByText(
+        "Quando um pedido for pago, o movimento aparece aqui.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Criar listing" })).toBeNull();
   });
 
   it("retries the transactions query from the error state", async () => {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -173,6 +173,8 @@ export interface Order {
   paymentStatus: string;
   trackingCode?: string | null;
   trackingCarrier?: string | null;
+  /** Present when the admin/order API already returns it. Not a PayPal secret. */
+  paypalOrderId?: string | null;
   createdAt: string;
   updatedAt: string;
   items?: OrderItem[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #113
Closes #115

Operator dashboards against existing APIs. No `server/` edits. #120 (SellerListings extract) and #106 (favorites) are not in this PR.

## #113 — Seller pending onboarding

- Persistent banner on `/seller/*` when `getSellerMe().isApproved === false`
- “Novo Listing” disabled as **Disponível após aprovação**
- Approved seller does not see the banner
- No invented approval email

## #115 — Admin order filters and detail

- URL filters use real `status` / `paymentStatus` query params
- Read-only `/admin/orders/:id` (items, customer, payment, tracking)
- Empty global vs empty filtered
- 404 **Pedido não encontrado**
- No refund UI; only `paypalOrderId` already returned by the API

## Verification

- `npm run typecheck` → PASS
- `npm run lint` → PASS
- `npm test` → 348 passed
- Browser: pending vs approved seller; admin filter + detail + PT 404

[Pending seller listings with banner and disabled create CTA](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_113_pending_seller_listings.png)
[Approved seller listings without banner](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_113_approved_seller_listings.png)
[Admin orders filtered by paymentStatus=PENDING](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_115_admin_orders_pending_filter.png)
[Read-only admin order detail](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_115_admin_order_detail.png)

## Risks

- UI does not invent a backend block if create is still allowed for pending sellers

Do not merge from this agent. Do not close issues from `gh`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

