### PR TITLE
#62 #63 — Operational dashboards and SLOs from existing telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The API keeps Pino and `X-Request-Id`. OpenTelemetry is **disabled by default**.
 OTEL_ENABLED=true npm run dev --prefix server
 ```
 
-Exporters: `none` (default), `console`, or `otlp`. A missing collector does not prevent the process from starting. See `docs/observability.md`.
+Exporters: `none` (default), `console`, or `otlp`. A missing collector does not prevent the process from starting. See `docs/observability.md`. Operator dashboard definitions and SLOs that cite those instruments: `docs/operations/dashboards.md`, `docs/operations/slos.md`.
 
 ## Engineering Notes
 
@@ -338,7 +338,7 @@ Potential next iterations include:
 - Improved monetary precision using database-native decimal operations
 - Asynchronous processing for non-critical workflows
 - Distributed rate limiting
-- Stronger production export of traces/metrics (collector, dashboards)
+- Optional production OTLP collector (dashboard/SLO definitions already live under `docs/operations/`)
 - Benchmarks and query plans for the hottest checkout paths
 
 ## Project Status

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -36,7 +36,7 @@ Express API --> cs2.sh (optional catalog import; ADR 0014)
 
 The backend entrypoint is `server/src/index.ts`, which optionally starts OpenTelemetry, then loads `server/src/app.ts` and `startApiProcess`. The app applies request IDs, security headers, HTTP server spans, CORS, JSON parsing (`100kb` limit + webhook `rawBody`), rate limiting, health/docs routes, domain routes at both unversioned paths and `/api/v1` (SPEC-0007 / ADR 0017), 404 handling and centralized error handling. `/health`, `/ready`, and `/docs` stay host-rooted. Policy: `docs/architecture/api-versioning.md`. `startApiProcess` refuses default JWT secrets when `NODE_ENV=production`, binds `0.0.0.0:$PORT`, starts the in-process reservation-expiry, PayPal-reconciliation, seller-ledger-reconciliation, and outbox-dispatcher jobs, and registers SIGTERM/SIGINT graceful shutdown (drain HTTP, stop jobs, disconnect Prisma, shut down telemetry). `GET /ready` returns 503 `shutting_down` after shutdown begins. Security checklist: `docs/security/api-hardening-checklist.md`.
 
-Observability is optional. `OTEL_ENABLED` defaults to off so `npm run dev` does not need a collector. See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
+Observability is optional. `OTEL_ENABLED` defaults to off so `npm run dev` does not need a collector. See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`. Operator dashboards, SLOs, and request/trace diagnosis reuse those instruments (`docs/operations/dashboards.md`, `docs/operations/slos.md`, `SPEC-0008`). They do not add Grafana, Prometheus, Redis, or AWS.
 
 ## Backend layering
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,6 +2,8 @@
 
 Neon Arsenal Market uses OpenTelemetry for traces and metrics, and Pino for logs. The goal is to diagnose latency, errors and business failures on the checkout path without running an observability platform locally.
 
+Operator dashboards, SLOs, and request/trace diagnosis (issues #62 / #63, `SPEC-0008`) live in [`docs/operations/dashboards.md`](./operations/dashboards.md) and [`docs/operations/slos.md`](./operations/slos.md). They reuse the meters and spans below. They do not add Grafana, Prometheus, Redis, or AWS.
+
 Storefront funnel events (`page_view` → PayPal → `order_viewed`) live in the frontend wrapper documented in [`docs/product-analytics.md`](./product-analytics.md). They are not OTel spans and do not use `OTEL_*`.
 
 ## Defaults
@@ -31,6 +33,8 @@ X-Request-Id → request.id on http.server.request → child spans → logs
 
 Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second correlation-ID scheme.
 
+Step-by-step incident walk: [`docs/operations/runbook.md`](./operations/runbook.md#diagnose-with-request-id-and-trace-id).
+
 ## Spans
 
 | Span | Meaning |
@@ -40,6 +44,8 @@ Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second
 | `orders.create.transaction` | PostgreSQL transaction that reserves listings and writes the order |
 | `listings.reserve` | Reservation attempt (order path or standalone reserve) |
 | `listings.expire` | Expired-reservation sweep |
+| `payments.create_link` | `POST /payments/create` (PayPal OrdersCreate + local `PaymentLink`) |
+| `payments.capture` | `POST /payments/capture` (OrdersCapture, then confirm) |
 | `payments.confirm` | Payment confirmation |
 | `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
 | `payments.reconcile` | PayPal GET reconciliation batch |
@@ -54,12 +60,13 @@ Inbound W3C `traceparent` / `tracestate` are accepted. Do not introduce a second
 
 | Outcome | Typical cause | Span status |
 |---|---|---|
-| `created` / `confirmed` | Success | UNSET |
+| `created` / `confirmed` / `already_confirmed` | Success or duplicate confirm | UNSET |
 | `idempotency_replay` | Same key and listing set | UNSET |
 | `idempotency_conflict` | Same key, different request or in-progress | UNSET |
 | `reservation_conflict` | Listing already held | UNSET |
 | `reservation_expired` | Payment after expiry | UNSET |
 | `webhook_duplicate` / `webhook_ignored` | Duplicate or unsupported event | UNSET |
+| `webhook_failed` | Verify/parse/handle failure (may include `reservation_expired` on the handle span as its own outcome) | UNSET unless classified operational |
 | `timeout` / `provider_error` / `error` | PayPal/DB/unexpected | ERROR |
 
 ## Metrics

--- a/docs/operations/dashboards.md
+++ b/docs/operations/dashboards.md
@@ -1,0 +1,155 @@
+# Operational dashboards
+
+These panels describe how to read telemetry the API already emits. They are **not** a Grafana, Prometheus, or hosted metrics product. Production compute is Render (ADR 0007). Export is optional (`OTEL_ENABLED`, ADR 0004).
+
+Importable definition: [`dashboards/neon-arsenal-api.json`](./dashboards/neon-arsenal-api.json). An operator can map those instrument names into whatever OTLP-backed UI they already run. This repository does not start a collector.
+
+Contract: `SPEC-0008`. SLOs that use these panels: [`slos.md`](./slos.md). Instrument source: `server/src/shared/observability/`.
+
+## How to use this file
+
+1. Enable `OTEL_ENABLED=true` and an exporter (`console` locally, `otlp` if you already have an endpoint).
+2. Filter series by the attributes listed here. Do not add user, order, listing, or email labels.
+3. `http.route` is the Express pattern plus mount prefix. Count **both** unversioned and `/api/v1` series (SPEC-0007).
+4. `/health` and `/ready` never appear in HTTP metrics or `http.server.request` spans.
+
+When OTEL is off, skip panels and use Render logs + the SQL in [`runbook.md`](./runbook.md).
+
+## Allowed metric attributes
+
+| Instrument family | Attributes | Cardinality note |
+|---|---|---|
+| HTTP | `http.request.method`, `http.route`, `http.response.status_code` | Route is a pattern (`/listings/:id`), never the raw URL |
+| Database | `db.system=postgresql`, `db.operation`, `db.collection` | Prisma model name, not SQL |
+| PayPal HTTP | `paypal.operation` (`orders_create`, `orders_get`, `orders_capture`, `oauth_token`); optional `http.response.status_code` on some points | Four operations only |
+| Business counters | *(none)* | Totals only |
+
+`safeAttributes()` drops secrets and bearer/JWT-looking values. Do not re-introduce them on a panel.
+
+## Critical traces
+
+Parent is usually `http.server.request` with `request.id` = `X-Request-Id`.
+
+| Span | When | Success `app.outcome` | Investigate |
+|---|---|---|---|
+| `http.server.request` | Every request except probes | status &lt; 500 | 5xx → `http.server.errors` |
+| `orders.create` | `POST /orders` | `created`, `idempotency_replay` | `idempotency_conflict`, `reservation_conflict`, `error` |
+| `orders.create.transaction` | Same, inside the PG transaction | (child) | Duration vs `db.prisma` |
+| `listings.reserve` | Order path or `POST /listings/:id/reserve` | `created` | `reservation_conflict` |
+| `listings.expire` | 30 s sweep | — | Sweep errors in logs |
+| `payments.create_link` | `POST /payments/create` | `created`, `idempotency_replay` | `paypal.orders_create` timeout |
+| `payments.capture` | `POST /payments/capture` | `confirmed`, `already_confirmed` | `paypal.orders_capture` + `payments.confirm` |
+| `payments.confirm` | Trusted confirm only | `confirmed`, `already_confirmed` | `reservation_expired`, `error` |
+| `payments.confirm.transaction` | Claim order, sell listings, ledger | (child) | Must stay in PostgreSQL |
+| `paypal.webhook.verify` | `POST /payments/webhook` | `confirmed` | `webhook_failed` (bad signature / missing id) |
+| `paypal.webhook.handle` | After verify | `confirmed`, `webhook_duplicate`, `webhook_ignored` | `reservation_expired`, `webhook_failed` |
+| `payments.reconcile` | 60 s GET sweep | attributes `app.reconcile_scanned`, `app.reconcile_confirmed` | PayPal GET errors; no lag metric |
+| `seller.ledger.reconcile` | 60 s projection check | `app.reconcile_corrected` | `seller.ledger.drift_detected` |
+| `outbox.dispatch` | In-process dispatcher | — | `outbox.failed` |
+| `paypal.{operation}` | Client HTTP | `confirmed` | `timeout`, `provider_error` |
+| `db.prisma` | Prisma query | — | `db.client.errors`; no SQL text |
+
+`app.outcome` values `timeout`, `provider_error`, and `error` set span status ERROR. Expected 4xx business outcomes stay UNSET.
+
+## Dashboard 1 — API
+
+**Purpose:** Is the process answering, and how slow are user routes?
+
+| Panel | Instrument | How to read |
+|---|---|---|
+| Request rate | `http.server.request.count` | Rate by `http.request.method` + `http.route` |
+| Latency | `http.server.request.duration` (unit `s`) | p50 / p95 / p99. Catalog and checkout SLOs use this histogram |
+| 5xx | `http.server.errors` | Availability SLI numerator |
+| 5xx ratio | `http.server.errors / http.server.request.count` | See SLO-AVAIL-01 |
+| Status mix | `http.server.request.count` by `http.response.status_code` | 401/404/409 are usually business, not outages |
+
+**Catalog routes** (both prefixes): `GET /listings`, `GET /listings/:id`, `GET /products`, `GET /products/:id`, and the same paths under `/api/v1`.
+
+**Checkout routes** (both prefixes): `POST /orders`, `POST /payments/create`, `POST /payments/capture`, `POST /payments/webhook`.
+
+Render `GET /ready` is the instance probe. It is **not** on this dashboard.
+
+## Dashboard 2 — Orders and reservations
+
+**Purpose:** Did exclusive reserve work, and are buyers colliding?
+
+| Panel | Instrument | How to read |
+|---|---|---|
+| Orders created | `orders.created` | Successful new orders |
+| Creation failed | `orders.creation_failed` | Validation / unexpected create failures |
+| Idempotent replay | `orders.idempotency_replay` | Expected retry; not an error |
+| Idempotency conflict | `orders.idempotency_conflict` | Same key, different body or in-progress |
+| Reservations created | `reservations.created` | `ACTIVE → RESERVED` wins |
+| Reservation conflicts | `reservations.conflict` | Other buyer or not ACTIVE |
+| Reservations expired | `reservations.expired` | Sweep released the hold |
+| Order create trace | span `orders.create` | `app.outcome` + child `orders.create.transaction` / `listings.reserve` |
+
+There is **no** `orders.pending` gauge. Count unpaid work in PostgreSQL:
+
+```sql
+SELECT COUNT(*) FROM "Order" WHERE "paymentStatus" = 'PENDING' AND status = 'PENDING';
+```
+
+## Dashboard 3 — Payments
+
+**Purpose:** PayPal HTTP and local confirm, without treating expiry as an outage.
+
+| Panel | Instrument | How to read |
+|---|---|---|
+| PayPal calls | `paypal.client.request.count` by `paypal.operation` | `orders_create`, `orders_get`, `orders_capture`, `oauth_token` |
+| PayPal latency | `paypal.client.request.duration` (unit `s`) | Dominates `POST /payments/create` and capture |
+| PayPal errors | `paypal.client.errors` | Provider/HTTP failures |
+| PayPal timeouts | `paypal.client.timeouts` | 504 / `PAYPAL_API_TIMEOUT_MS` (default 10 s) |
+| Confirmed | `payments.confirmed` | Local `PAID` after trusted COMPLETED |
+| Confirm failed | `payments.failed` | Mixed: includes `reservation_expired` 409. Filter traces by `app.outcome` |
+| Create-link / capture traces | `payments.create_link`, `payments.capture` | Child `paypal.*` then `payments.confirm` |
+
+Buyer time from “Pay with PayPal” to `PAID` is **not** a metric. Proxies: PayPal client duration + local `payments.confirm` span duration when traces are exported.
+
+## Dashboard 4 — Webhooks
+
+**Purpose:** Delivery, duplicates, ignores, and real handle failures.
+
+| Panel | Instrument | How to read |
+|---|---|---|
+| Received | `paypal.webhooks.received` | Every parsed or unparsed delivery attempt that reached the handler |
+| Duplicate | `paypal.webhooks.duplicate` | Unique `(provider, externalEventId)` claim; expected |
+| Ignored | `paypal.webhooks.ignored` | `CHECKOUT.ORDER.APPROVED` and unknown types |
+| Failed | `paypal.webhooks.failed` | Mixed: bad payload, verify fail, 503 order-not-ready, **and** `reservation_expired` |
+| Verify / handle traces | `paypal.webhook.verify`, `paypal.webhook.handle` | `paypal.event_type`; `app.outcome` |
+
+HTTP 200 after `reservation_expired` is intentional so PayPal stops retrying. Confirm money in the PayPal dashboard; do not sell the listing. See runbook **Capture after reservation expiry**.
+
+## Dashboard 5 — Reconciliation and ledger
+
+**Purpose:** In-process recovery jobs, not a queue lag gauge.
+
+| Panel | Instrument | How to read |
+|---|---|---|
+| Reconcile batch | span `payments.reconcile` | Duration = batch work, **not** how late a capture is |
+| Scanned / confirmed | span attributes `app.reconcile_scanned`, `app.reconcile_confirmed` | Requires traces |
+| PayPal GET | `paypal.client.request.duration` where `paypal.operation=orders_get` | Sweep lookup cost |
+| Ledger drift | `seller.ledger.drift_detected` | Projection disagreed with PAID SUM |
+| Ledger corrected | `seller.ledger.corrected` | Projection written back to SUM |
+| Ledger span | `seller.ledger.reconcile` | `app.reconcile_scanned`, `app.reconcile_drift_candidates`, `app.reconcile_corrected` |
+| Outbox | `outbox.published`, `outbox.retry`, `outbox.failed` | First handler is log+metric only |
+
+**Reconciliation lag is not instrumented.** Config floor: ignore orders younger than 2 minutes (`PAYPAL_RECONCILE_MIN_AGE_MS`), then wait up to 60 s for the next sweep (`PAYPAL_RECONCILE_INTERVAL_MS`), batch 20. A sleeping free Render instance cannot sweep until the next request wakes it.
+
+Pending-but-old orders: SQL in [`runbook.md`](./runbook.md) (Inspect payments and reservations).
+
+## Dashboard 6 — Database
+
+**Purpose:** Prisma/PostgreSQL operation time and errors. No SQL text.
+
+| Panel | Instrument | How to read |
+|---|---|---|
+| Operation duration | `db.client.operation.duration` (unit `s`) | p95 by `db.operation` + `db.collection` |
+| Errors | `db.client.errors` | Unexpected Prisma failures |
+| Traces | `db.prisma` | Same attributes; never bind parameters |
+
+Checkout lock waits show up as longer `db.prisma` / `orders.create.transaction` spans, not as a lock gauge.
+
+## Alert thresholds (runbook, not a pager)
+
+See [`runbook.md`](./runbook.md#alert-thresholds-no-pager). Thresholds are investigation triggers for a human reading Render logs or an optional OTLP UI.

--- a/docs/operations/dashboards/neon-arsenal-api.json
+++ b/docs/operations/dashboards/neon-arsenal-api.json
@@ -1,0 +1,185 @@
+{
+  "version": 1,
+  "id": "neon-arsenal-api",
+  "title": "Neon Arsenal API operational definition",
+  "service": "neon-arsenal-api",
+  "meter": "neon-arsenal-api",
+  "spec": "SPEC-0008",
+  "note": "Vendor-neutral OTLP instrument catalog. Import names into an operator-owned backend later. This file is not a Grafana Cloud, Prometheus, or AWS dashboard and does not require those products.",
+  "security": {
+    "forbiddenMetricLabels": [
+      "user.id",
+      "order.id",
+      "listing.id",
+      "customer.id",
+      "email",
+      "authorization",
+      "access_token",
+      "paypal-transmission-sig"
+    ]
+  },
+  "routePrefixes": ["", "/api/v1"],
+  "instruments": [
+    {
+      "name": "http.server.request.duration",
+      "type": "histogram",
+      "unit": "s",
+      "attributes": ["http.request.method", "http.route", "http.response.status_code"]
+    },
+    {
+      "name": "http.server.request.count",
+      "type": "counter",
+      "unit": "1",
+      "attributes": ["http.request.method", "http.route", "http.response.status_code"]
+    },
+    {
+      "name": "http.server.errors",
+      "type": "counter",
+      "unit": "1",
+      "attributes": ["http.request.method", "http.route", "http.response.status_code"]
+    },
+    {
+      "name": "db.client.operation.duration",
+      "type": "histogram",
+      "unit": "s",
+      "attributes": ["db.system", "db.operation", "db.collection"]
+    },
+    {
+      "name": "db.client.errors",
+      "type": "counter",
+      "unit": "1",
+      "attributes": ["db.system", "db.operation", "db.collection"]
+    },
+    {
+      "name": "paypal.client.request.count",
+      "type": "counter",
+      "unit": "1",
+      "attributes": ["paypal.operation"]
+    },
+    {
+      "name": "paypal.client.errors",
+      "type": "counter",
+      "unit": "1",
+      "attributes": ["paypal.operation"]
+    },
+    {
+      "name": "paypal.client.timeouts",
+      "type": "counter",
+      "unit": "1",
+      "attributes": ["paypal.operation"]
+    },
+    {
+      "name": "paypal.client.request.duration",
+      "type": "histogram",
+      "unit": "s",
+      "attributes": ["paypal.operation"]
+    },
+    { "name": "orders.created", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "orders.creation_failed", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "orders.idempotency_replay", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "orders.idempotency_conflict", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "reservations.created", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "reservations.conflict", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "reservations.expired", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "payments.confirmed", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "payments.failed", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "paypal.webhooks.received", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "paypal.webhooks.duplicate", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "paypal.webhooks.ignored", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "paypal.webhooks.failed", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "seller.ledger.drift_detected", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "seller.ledger.corrected", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "outbox.published", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "outbox.retry", "type": "counter", "unit": "1", "attributes": [] },
+    { "name": "outbox.failed", "type": "counter", "unit": "1", "attributes": [] }
+  ],
+  "spans": [
+    { "name": "http.server.request", "file": "server/src/shared/observability/http.ts" },
+    { "name": "orders.create", "file": "server/src/modules/orders/orders.service.ts" },
+    { "name": "orders.create.transaction", "file": "server/src/modules/orders/orders.service.ts" },
+    { "name": "listings.reserve", "file": "server/src/modules/listings/listings.service.ts" },
+    { "name": "listings.expire", "file": "server/src/modules/listings/listings.service.ts" },
+    { "name": "payments.create_link", "file": "server/src/modules/payments/payments.service.ts" },
+    { "name": "payments.capture", "file": "server/src/modules/payments/payments.service.ts" },
+    { "name": "payments.confirm", "file": "server/src/modules/payments/payments.service.ts" },
+    { "name": "payments.confirm.transaction", "file": "server/src/modules/payments/payments.service.ts" },
+    { "name": "payments.reconcile", "file": "server/src/modules/payments/payments.service.ts" },
+    { "name": "paypal.webhook.verify", "file": "server/src/modules/payments/payments.controller.ts" },
+    { "name": "paypal.webhook.handle", "file": "server/src/modules/payments/payments.service.ts" },
+    { "name": "seller.ledger.reconcile", "file": "server/src/modules/commissions/commissions.service.ts" },
+    { "name": "outbox.dispatch", "file": "server/src/shared/outbox/outbox.dispatcher.ts" },
+    { "name": "db.prisma", "file": "server/src/shared/observability/prisma.ts" },
+    { "name": "paypal.", "file": "server/src/shared/observability/paypal.ts", "note": "Name is paypal.${operation}" }
+  ],
+  "dashboards": [
+    {
+      "id": "api",
+      "title": "API",
+      "sloRefs": ["SLO-AVAIL-01", "SLO-LAT-CATALOG", "SLO-LAT-CHECKOUT-RESERVE"],
+      "panels": [
+        { "title": "Request rate", "instrument": "http.server.request.count" },
+        { "title": "Request duration", "instrument": "http.server.request.duration" },
+        { "title": "5xx", "instrument": "http.server.errors" }
+      ]
+    },
+    {
+      "id": "orders",
+      "title": "Orders and reservations",
+      "sloRefs": ["SLO-LAT-CHECKOUT-RESERVE"],
+      "panels": [
+        { "title": "Orders created", "instrument": "orders.created" },
+        { "title": "Creation failed", "instrument": "orders.creation_failed" },
+        { "title": "Idempotency replay", "instrument": "orders.idempotency_replay" },
+        { "title": "Idempotency conflict", "instrument": "orders.idempotency_conflict" },
+        { "title": "Reservations created", "instrument": "reservations.created" },
+        { "title": "Reservation conflicts", "instrument": "reservations.conflict" },
+        { "title": "Reservations expired", "instrument": "reservations.expired" }
+      ]
+    },
+    {
+      "id": "payments",
+      "title": "Payments",
+      "sloRefs": ["SLO-LAT-PAYPAL-HTTP", "SLO-ERR-PAYPAL"],
+      "panels": [
+        { "title": "PayPal requests", "instrument": "paypal.client.request.count" },
+        { "title": "PayPal duration", "instrument": "paypal.client.request.duration" },
+        { "title": "PayPal errors", "instrument": "paypal.client.errors" },
+        { "title": "PayPal timeouts", "instrument": "paypal.client.timeouts" },
+        { "title": "Payments confirmed", "instrument": "payments.confirmed" },
+        { "title": "Payments failed (mixed business/ops)", "instrument": "payments.failed" }
+      ]
+    },
+    {
+      "id": "webhooks",
+      "title": "Webhooks",
+      "sloRefs": [],
+      "panels": [
+        { "title": "Received", "instrument": "paypal.webhooks.received" },
+        { "title": "Duplicate", "instrument": "paypal.webhooks.duplicate" },
+        { "title": "Ignored", "instrument": "paypal.webhooks.ignored" },
+        { "title": "Failed (mixed business/ops)", "instrument": "paypal.webhooks.failed" }
+      ]
+    },
+    {
+      "id": "reconciliation",
+      "title": "Reconciliation and ledger",
+      "sloRefs": ["SLO-RECONCILE"],
+      "panels": [
+        { "title": "Ledger drift", "instrument": "seller.ledger.drift_detected" },
+        { "title": "Ledger corrected", "instrument": "seller.ledger.corrected" },
+        { "title": "Outbox published", "instrument": "outbox.published" },
+        { "title": "Outbox retry", "instrument": "outbox.retry" },
+        { "title": "Outbox failed", "instrument": "outbox.failed" }
+      ]
+    },
+    {
+      "id": "database",
+      "title": "Database",
+      "sloRefs": [],
+      "panels": [
+        { "title": "Prisma duration", "instrument": "db.client.operation.duration" },
+        { "title": "Prisma errors", "instrument": "db.client.errors" }
+      ]
+    }
+  ]
+}

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -59,6 +59,39 @@ Do not point Render at `/health`. That would keep a draining or DB-less instance
 
 A new Render deploy does not take traffic until `GET /ready` is 2xx/3xx (Postgres up, not shutting down).
 
+## Diagnose with request ID and trace ID
+
+Do not search logs for emails, JWTs, PayPal access tokens, or `paypal-transmission-sig`. Use the correlation IDs the API already writes.
+
+1. Take `X-Request-Id` from the client response header, the storefront error page, or the inbound header if the client sent one. The middleware echoes it on every response.
+2. In Render logs for `neon-arsenal-api`, search that value as Pino `requestId`. The same string is `request.id` on span `http.server.request`.
+3. If OpenTelemetry was on, the same log line should also have `trace_id` and `span_id` (Pino mixin when a span is active). Follow `trace_id` to child spans: `orders.create`, `payments.create_link` / `payments.capture` / `payments.confirm`, `paypal.webhook.verify` / `paypal.webhook.handle`, `paypal.*`, `db.prisma`.
+4. Read `app.outcome` on the workflow span. `reservation_conflict`, `idempotency_conflict`, `idempotency_replay`, `webhook_duplicate`, `webhook_ignored`, and `reservation_expired` are expected business results (span status UNSET). `timeout`, `provider_error`, and `error` are operational (span status ERROR).
+5. If the failure is payment-shaped, continue with **Inspect payments and reservations** below. `paypal.webhooks.failed` / `payments.failed` alone do not mean an outage — they also increment on capture-after-expiry.
+6. If OTEL is off, stop at step 2 and use SQL + log messages (`paypal webhook received`, `paypal capture webhook processed`, `paypal reconciliation skipped: reservation expired`). There is no second correlation scheme.
+
+Dashboard map: [`dashboards.md`](./dashboards.md). SLOs: [`slos.md`](./slos.md).
+
+## Alert thresholds (no pager)
+
+These are investigation triggers for a human. This repository does not add a pager, Grafana Cloud, or Prometheus.
+
+| Signal | Threshold | First look |
+|---|---|---|
+| `http.server.errors / http.server.request.count` | &gt; 1% over ~15 minutes of recorded samples | SLO-AVAIL-01. Filter `http.route`. Diagnose with request ID. |
+| Catalog `http.server.request.duration` p95 | &gt; 50 ms on GET `/listings` / `/products` (and `/api/v1` twins) | SLO-LAT-CATALOG. `docs/architecture/scaling-path.md`. |
+| `POST /orders` duration p95 | &gt; 1 s | SLO-LAT-CHECKOUT-RESERVE. `orders.create` + `db.prisma`. |
+| `paypal.client.request.duration` p95 | &gt; 8 s | Approaching 10 s timeout. PayPal sandbox/live health. |
+| `paypal.client.timeouts` | Any point in 15 minutes | 504 path. Do not retry `OrdersCreate` / `OrdersCapture`. |
+| `paypal.client.errors` ratio | &gt; 5% of `paypal.client.request.count` | SLO-ERR-PAYPAL. Check `PAYPAL_CLIENT_AUTH_FAILED` in logs. |
+| `seller.ledger.drift_detected` | Any increment | Ledger span + `SellerTransaction` SUM. Correction should follow (`seller.ledger.corrected`). |
+| `outbox.failed` | Any increment | `outbox.dispatch` retries exhausted. Rows stay in PostgreSQL. |
+| `db.client.errors` | Any increment | Prisma exceptions. No SQL text in spans — use Render logs. |
+| `paypal.webhooks.failed` | Rising while `app.outcome` is not `reservation_expired` | Verify `PAYPAL_WEBHOOK_ID`, signature, `order_not_resolved` (503). |
+| Pending PayPal orders older than 5 minutes | SQL count &gt; 0 and not dropping | Instance asleep, GET sweep stuck, or capture-after-expiry. |
+
+Render free-tier spin-down produces **no** metric samples. A silent dashboard is not “100% available.”
+
 ## Shutdown drain
 
 On SIGTERM/SIGINT (`docs/adr/0005-external-retry-and-graceful-shutdown.md`):

--- a/docs/operations/slos.md
+++ b/docs/operations/slos.md
@@ -1,0 +1,129 @@
+# Service level objectives
+
+Portfolio / demo operating targets for Neon Arsenal Market. They are **not** a paid customer SLA. Every SLI names an instrument that exists today in `server/src/shared/observability/`, or is marked unmeasurable with an existing proxy.
+
+Contract: `SPEC-0008`. Panels: [`dashboards.md`](./dashboards.md). Performance evidence: [`../performance.md`](../performance.md). Scaling triggers: [`../architecture/scaling-path.md`](../architecture/scaling-path.md).
+
+Window: **30 days of recorded samples**. If `OTEL_ENABLED` is false, these SLIs have no time series; use Render logs and SQL only.
+
+## What “availability” means here
+
+| Included | Excluded |
+|---|---|
+| HTTP requests that emit `http.server.request.count` | `/health`, `/ready` (not instrumented) |
+| 5xx via `http.server.errors` | 4xx business results (401, 404, 409 conflict/expiry, validation) |
+| Time the process is awake and exporting | Render free-tier spin-down (no samples) |
+| | Storefront / Vercel / PayPal website availability |
+
+`app.outcome` values such as `reservation_conflict`, `idempotency_conflict`, and `reservation_expired` are correct business answers. They must not burn the availability error budget.
+
+## SLO catalog
+
+### SLO-AVAIL-01 — Recorded HTTP availability
+
+| Field | Value |
+|---|---|
+| SLI | `1 - sum(http.server.errors) / sum(http.server.request.count)` |
+| Target | **99.0%** over 30 days of recorded requests |
+| Dashboard | [API](./dashboards.md#dashboard-1--api) |
+| Why this number | No production baseline exists. 99.0% is an initial operating target for a single Render instance, not 99.9% (that would require traffic history this repo does not have). |
+| Error budget | 1.0% of recorded HTTP requests may be 5xx in the window |
+
+Probe failures on `GET /ready` are a Render rotation signal, not this SLI.
+
+### SLO-LAT-CATALOG — Catalog read latency
+
+| Field | Value |
+|---|---|
+| SLI | p95 of `http.server.request.duration` (seconds) where `http.request.method=GET` and `http.route` is a catalog route below |
+| Target | **p95 &lt; 50 ms** |
+| Dashboard | [API](./dashboards.md#dashboard-1--api) |
+| Why this number | Existing scaling trigger in `docs/architecture/scaling-path.md`. Local evidence: `listingsService.list` p95 ~4 ms at 2.5k listings (`docs/performance.md`). |
+| Routes | `/listings`, `/listings/:id`, `/products`, `/products/:id`, and the same four under `/api/v1` |
+
+If p95 crosses 50 ms, follow the scaling-path mitigation (cursor pagination / drop `COUNT(*)`). Do not add Redis.
+
+### SLO-LAT-CHECKOUT-RESERVE — Order create latency
+
+| Field | Value |
+|---|---|
+| SLI | p95 of `http.server.request.duration` where `http.request.method=POST` and `http.route` is `/orders` or `/api/v1/orders` |
+| Target | **Watch: p95 &lt; 1 s** |
+| Dashboard | [API](./dashboards.md#dashboard-1--api), [Orders](./dashboards.md#dashboard-2--orders-and-reservations) |
+| Why this number | The path is PK / conditional `UPDATE` (`docs/performance.md`). There is no production p95. 1 s is a coarse watch so a lock-contention or event-loop stall is visible. It is not a customer SLA. |
+| Trace | `orders.create` → `orders.create.transaction` → `listings.reserve` |
+
+### SLO-LAT-PAYPAL-HTTP — PayPal client latency
+
+| Field | Value |
+|---|---|
+| SLI | p95 of `paypal.client.request.duration` (seconds) |
+| Target | **p95 &lt; 8 s** (80% of `DEFAULT_PAYPAL_API_TIMEOUT_MS` = 10 s) |
+| Dashboard | [Payments](./dashboards.md#dashboard-3--payments) |
+| Why this number | Derived from the existing timeout in `server/src/shared/config/paypal.ts`, not from invented traffic. Crossing 8 s means we are near 504 `timeout`. |
+| Companion | `paypal.client.timeouts` should stay at 0 in a healthy window; any timeout is an investigation |
+
+`POST /payments/create` and `POST /payments/capture` HTTP p95 are dominated by this client, not by PostgreSQL.
+
+### SLO-ERR-PAYPAL — PayPal client error ratio
+
+| Field | Value |
+|---|---|
+| SLI | `(paypal.client.errors + paypal.client.timeouts) / paypal.client.request.count` |
+| Target | **&lt; 5%** over 30 days of recorded PayPal calls |
+| Dashboard | [Payments](./dashboards.md#dashboard-3--payments) |
+| Why this number | Provider unreliability is expected (`docs/architecture/failure-modes.md`). 5% is an operating watch until OTLP production samples exist. Sandbox auth failures (`PAYPAL_CLIENT_AUTH_FAILED`) will burn this budget. |
+
+Do **not** use `payments.failed` or `paypal.webhooks.failed` as this SLI. Both increment on expected `reservation_expired`.
+
+### SLO-RECONCILE — Reconciliation freshness (proxy)
+
+| Field | Value |
+|---|---|
+| Requested SLI | Lag from PayPal `COMPLETED` to local `PAID` |
+| Measurable today? | **No.** There is no lag histogram or pending-age gauge. |
+| Proxy | Config floor + span `payments.reconcile` duration + `paypal.client.request.duration` `{paypal.operation=orders_get}` |
+| Operating expectation | Orders younger than **2 minutes** are ignored (`PAYPAL_RECONCILE_MIN_AGE_MS`). The next sweep is at most **60 s** later (`PAYPAL_RECONCILE_INTERVAL_MS`), batch 20. A sleeping free Render instance adds unbounded delay until wake. |
+| Dashboard | [Reconciliation](./dashboards.md#dashboard-5--reconciliation-and-ledger) |
+| SQL proxy | Count `Order` rows with `paymentStatus = PENDING`, non-null `paypalOrderId`, `updatedAt` older than 5 minutes (runbook). That query is the operator lag signal. |
+
+### Unmeasurable: buyer payment confirmation time
+
+Time from buyer approval to local `PAID` is not a histogram. Proxies when traces are exported:
+
+- span `payments.capture` or `paypal.webhook.handle` duration (request-scoped, not end-to-end);
+- span `payments.confirm` duration (local claim/sell/ledger only).
+
+Do not invent a “p95 payment confirmation = N seconds” SLO until a dedicated instrument exists.
+
+## Error budget
+
+**Budget:** for SLO-AVAIL-01, **1.0%** of recorded HTTP requests in the last 30 days may be 5xx.
+
+```text
+error_budget_remaining =
+  1 - (sum(http.server.errors) / (0.01 * sum(http.server.request.count)))
+```
+
+When `http.server.request.count` is 0 (OTEL off, or no traffic), the budget is **undefined**. Do not treat that as 100% healthy.
+
+### How to spend it
+
+| Remaining budget | Action |
+|---|---|
+| &gt; 50% | Normal feature work |
+| 10–50% | Prefer reliability fixes on the burning route (`http.route`) |
+| &lt; 10% or exhausted | Freeze non-correctness work. Diagnose with [`runbook.md`](./runbook.md#diagnose-with-request-id-and-trace-id). |
+
+Latency SLOs do not share this numeric budget. A catalog p95 breach is the scaling-path trigger, not an availability burn. PayPal timeout burns SLO-ERR-PAYPAL and should be investigated even if HTTP 5xx stay inside SLO-AVAIL-01 (some PayPal failures map to 502/504 and will burn both).
+
+## Mapping cheat sheet
+
+| SLO | Primary instrument | Dashboard |
+|---|---|---|
+| SLO-AVAIL-01 | `http.server.errors`, `http.server.request.count` | API |
+| SLO-LAT-CATALOG | `http.server.request.duration` | API |
+| SLO-LAT-CHECKOUT-RESERVE | `http.server.request.duration` | API + Orders |
+| SLO-LAT-PAYPAL-HTTP | `paypal.client.request.duration` | Payments |
+| SLO-ERR-PAYPAL | `paypal.client.errors`, `paypal.client.timeouts`, `paypal.client.request.count` | Payments |
+| SLO-RECONCILE | *(unmeasurable)* proxy: `payments.reconcile` + SQL | Reconciliation |

--- a/docs/plans/PLAN-0005-operational-dashboards-and-slos.md
+++ b/docs/plans/PLAN-0005-operational-dashboards-and-slos.md
@@ -1,0 +1,131 @@
+---
+id: PLAN-0005
+status: Ready
+version: 1
+source_spec: SPEC-0008
+source_spec_version: 1
+baseline_revision: 27c94eb46d24353aee866852236c83134a89702e
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [PLAN-0005] — Operational dashboards and SLOs from existing telemetry
+
+## Status
+
+`Ready`
+
+## Source
+
+- Specification: `SPEC-0008` v1
+- Issue: `#62` (grouped with `#63`)
+- Planning task: Backend → Reliability → Security → Test → Verification
+- Baseline: `27c94eb46d24353aee866852236c83134a89702e`
+
+The Plan derives implementation work from the Specification. It may narrow implementation choices but must not add, remove, or reinterpret acceptance criteria.
+
+## Current State
+
+Inspected at the baseline:
+
+- `server/src/shared/observability/metrics.ts` defines HTTP, DB, PayPal, and unlabeled business counters. No pending-order gauge.
+- `http.ts` records `http.route` as `${baseUrl}${route.path}` (unversioned and `/api/v1` prefixes). Skips `/health` and `/ready`. Sets `request.id`.
+- Workflow spans exist in orders, listings, payments, commissions, outbox, Prisma, and PayPal helpers. `docs/observability.md` omits `payments.create_link` and `payments.capture`.
+- `payments.failed` and `paypal.webhooks.failed` increment on `reservation_expired` as well as operational errors.
+- Reconciliation: `PAYPAL_RECONCILE_INTERVAL_MS = 60_000`, `PAYPAL_RECONCILE_MIN_AGE_MS = 2 * 60 * 1000`, batch 20. Span attributes `app.reconcile_scanned` / `app.reconcile_confirmed`. No lag histogram.
+- PayPal HTTP timeout default 10 s (`PAYPAL_API_TIMEOUT_MS`).
+- Catalog p95 trigger already documented at ~50 ms (`docs/architecture/scaling-path.md`). Local `listingsService.list` p95 ~4 ms (`docs/performance.md`).
+- ADR 0004 forbids a local Grafana/Prometheus/Jaeger dependency. ADR 0007 keeps Render.
+- No `docs/operations/dashboards.md` or `docs/operations/slos.md` at baseline.
+
+## Goal
+
+Publish operator dashboards, SLOs, error budget, alert thresholds, and a request/trace diagnosis procedure that cite only existing telemetry, plus a unit test that the catalog still matches code.
+
+## Affected Areas
+
+- `docs/operations/dashboards.md`, `docs/operations/slos.md`, `docs/operations/dashboards/neon-arsenal-api.json`
+- `docs/observability.md`, `docs/operations/runbook.md`
+- `docs/architecture/current-state.md`, `docs/roadmap.md`, `README.md` (pointers only)
+- `docs/specs/SPEC-0008-*`, this Plan, `TASK-0008`, `TASK-0009`
+- `server/src/shared/observability/__tests__/instrument-catalog.test.ts` only
+
+Do not edit `src/`. Do not change reservation/payment runtime.
+
+## Architecture
+
+Modular monolith on Render + PostgreSQL. Optional OTLP export. Dashboards are committed definitions, not a running observability platform. PostgreSQL remains SoT for pending-order and webhook investigation.
+
+## Database
+
+No schema or migration changes. Operators continue to use the existing runbook SQL for `PENDING` orders and `PaymentWebhookEvent`.
+
+## Implementation Sequence
+
+1. Accept `SPEC-0008` and mark this Plan Ready against baseline `27c94eb46d24353aee866852236c83134a89702e`.
+2. Write the vendor-neutral dashboard JSON and markdown map (`TASK-0008`).
+3. Write SLOs, proxies, error budget, runbook alerts, and diagnosis (`TASK-0009` docs half).
+4. Add the instrument-catalog unit test (`TASK-0009` test half).
+5. Link from observability, current-state, roadmap, and README.
+6. Verify with unit tests and factory validation.
+
+## Task Graph
+
+```text
+TASK-0008 → TASK-0009
+```
+
+`TASK-0009` consumes the JSON catalog from `TASK-0008` as the executable name list.
+
+## Testing Strategy
+
+Unit test records every documented histogram/counter and asserts names plus allowed attribute keys. It also asserts documented span name strings still appear in the files that create them. Existing telemetry redaction and business-outcome tests remain. No integration test: no runtime semantics change.
+
+## Verification Strategy
+
+```bash
+python3 scripts/ai-factory/validate.py
+cd server && npm run test:unit
+```
+
+Map: AC-01–AC-06 → dashboard/SLO/runbook docs; AC-07 → instrument-catalog test; AC-08 → diff review (no `src/`, no payment/reservation edits).
+
+## Risks
+
+- Treating `paypal.webhooks.failed` as an availability SLI would page on expected `reservation_expired`. Mitigation: BR-08; SLOs use `http.server.errors` and PayPal client timeouts/errors.
+- Inventing catalog/checkout p95 targets without production samples. Mitigation: catalog uses the existing 50 ms scaling trigger; checkout/payment numeric targets are watches derived from the 10 s PayPal timeout or are marked unmeasurable.
+- Dual `http.route` prefixes splitting series. Mitigation: dashboards and SLOs name both `/listings` and `/api/v1/listings` (and the other pairs).
+
+## Dependencies
+
+`SPEC-0008` Accepted. Baseline commit present in the worktree.
+
+## Stop Conditions
+
+- A requirement to add Grafana Cloud, Prometheus, Redis, or a new meter.
+- A requirement to invent a PayPal refund API or change payment confirmation.
+- Contradiction between an SLO number and the instruments that exist at baseline.
+
+## Definition of Done
+
+Dashboard + SLO docs exist, cite only real instruments, include diagnosis and error budget, catalog unit test passes, factory validation passes, and the diff does not change reservation/payment semantics.
+
+## Traceability
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+- Issue: `#62` / `#63`
+- Spec: `SPEC-0008` v1
+- Plan: `PLAN-0005`
+- Tasks: `TASK-0008`, `TASK-0009`
+- PR: pending
+- Verification/Convergence: pending
+- Evaluation: pending
+- Memory: pending
+
+## Change History
+
+- `v1` — Ready plan for SPEC-0008 — 2026-09-06

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,9 +63,10 @@ Implemented:
 - optional OpenTelemetry SDK (`OTEL_ENABLED`, exporters `none` / `console` / `otlp`);
 - HTTP, Prisma, PayPal and critical workflow spans;
 - engineering and business counters with low-cardinality attributes;
-- expected business results distinguished from operational errors.
+- expected business results distinguished from operational errors;
+- operator dashboards, SLOs, error budget, and request/trace diagnosis documented from those instruments (`SPEC-0008`, issues #62 / #63). No Grafana/Prometheus server.
 
-See `docs/observability.md` and `docs/adr/0004-opentelemetry.md`.
+See `docs/observability.md`, `docs/operations/dashboards.md`, `docs/operations/slos.md`, and `docs/adr/0004-opentelemetry.md`.
 
 ### P1.3 Resilience
 
@@ -139,6 +140,8 @@ Maintain:
 - `docs/architecture/threat-model.md`
 - `docs/adr/`
 - `docs/operations/runbook.md`
+- `docs/operations/dashboards.md`
+- `docs/operations/slos.md`
 - `docs/agents/`
 
 Documentation is part of the implementation whenever a design or operational decision changes.

--- a/docs/specs/SPEC-0008-operational-dashboards-and-slos.md
+++ b/docs/specs/SPEC-0008-operational-dashboards-and-slos.md
@@ -1,0 +1,192 @@
+---
+id: SPEC-0008
+status: Accepted
+version: 1
+source_issue: "#62"
+owner: "Neon Arsenal Engineering"
+created: 2026-09-06
+updated: 2026-09-06
+---
+
+# [SPEC-0008] — Operational dashboards and SLOs from existing telemetry
+
+## Status
+
+`Accepted`
+
+Issues `#62` and `#63` authorize turning the existing OpenTelemetry instruments into operator-facing dashboards, alerts, SLOs, and a request/trace diagnosis procedure. This Specification is the contract. It does not authorize a metrics vendor, a Grafana/Prometheus server, Redis, Kafka, SQS, AWS, or new business metrics.
+
+## Problem
+
+HTTP, Prisma, PayPal, and checkout workflow telemetry already exist (`docs/observability.md`, ADR 0004). Operators still lack:
+
+- a dashboard map that names the real meters, labels, and spans;
+- alert thresholds written as runbook guidance;
+- a repeatable way to diagnose a failure with `X-Request-Id` / `trace_id`;
+- SLOs that cite instruments that can be measured today, plus an error-budget rule.
+
+Inventing Grafana Cloud, Prometheus, or new gauges would hide the fact that some requested SLIs (buyer time-to-PAID, reconciliation lag) are not instrumented.
+
+## Goal
+
+An operator can diagnose API, order, payment, webhook, reconciliation, and database incidents using only instruments and attributes that already exist in `server/src/shared/observability/`, plus PostgreSQL queries already in the runbook. Each SLO names its SLI instrument. Where a requested SLI cannot be measured, the document says so and names the existing proxy.
+
+## Actors
+
+- Operator reading Render logs and optional OTLP export
+- API process (`neon-arsenal-api` on Render)
+- PostgreSQL (source of truth for pending orders, webhook rows, listings)
+- PayPal (unreliable external ledger)
+- In-process jobs: reservation expiry, PayPal GET reconciliation, seller ledger reconciliation, outbox dispatch
+
+## Scope
+
+- Dashboard definitions for API, Orders, Payments, webhooks, reconciliation, and database.
+- Critical traces, allowed labels, and alert thresholds as runbook guidance.
+- Diagnosis procedure: `X-Request-Id` → `request.id` → `trace_id` / `span_id` → child spans → logs → SQL.
+- SLOs for availability, catalog/checkout latency, payment-path errors, and reconciliation using existing instruments or documented proxies.
+- Basic error-budget rule.
+- A unit test that the documented metric names and span names still exist.
+
+## Non-goals
+
+- Grafana, Prometheus, Tempo, Jaeger, Grafana Cloud, or any metrics SaaS.
+- Redis, Kafka, SQS, AWS, CloudWatch, Terraform.
+- New meters, gauges, env vars, or span names.
+- Changing reservation, payment, webhook, or refund semantics.
+- Inventing a PayPal refund/void API.
+- A pending-order gauge (ADR 0004: query PostgreSQL).
+- Buyer-perceived time from checkout start to `PAID` (not instrumented).
+- Storefront product-analytics events (`docs/product-analytics.md`).
+- Editing `src/`.
+
+## Business Rules
+
+- `BR-01`: Dashboard panels and SLOs may cite only meter names, histogram units, span names, and attribute keys that exist in `server/src/shared/observability/` (or config constants those spans already record).
+- `BR-02`: Metric attributes stay low-cardinality: HTTP method/route/status, Prisma `db.operation`/`db.collection`, PayPal `paypal.operation`. No user, order, listing, email, or token labels.
+- `BR-03`: HTTP 4xx business outcomes (`app.outcome` such as `reservation_conflict`, `idempotency_conflict`, `reservation_expired`) are not availability failures. Availability uses `http.server.errors` (5xx) over `http.server.request.count`.
+- `BR-04`: `/health` and `/ready` are excluded from HTTP metrics and spans. Render readiness is a separate probe, not an SLI sample.
+- `BR-05`: If a requested SLI has no instrument, document it as unmeasurable and name the existing proxy. Do not invent a number that cannot be computed from current export.
+- `BR-06`: Alerts are runbook thresholds. Do not add a pager vendor.
+- `BR-07`: Diagnosis uses `X-Request-Id` / `request.id` / `trace_id` / `span_id`. Do not tell operators to search logs for JWTs, PayPal tokens, webhook signatures, or emails.
+- `BR-08`: `paypal.webhooks.failed` and `payments.failed` mix operational failures with expected business results (including `reservation_expired`). They are investigation signals, not availability SLIs.
+- `BR-09`: Production remains Render (ADR 0007). Optional OTLP is not CloudWatch.
+
+## Invariants
+
+No domain invariant changes. Relevant existing invariants stay authoritative:
+
+- `INV-LISTING-EXCLUSIVE-RESERVE`
+- Payment confirmation remains PayPal-trusted (`INV-PAYMENT-TRUSTED-CONFIRM` in code comments)
+- Seller ledger: `Seller.balance` is a projection of PAID `SellerTransaction` SUM
+
+## State Transitions
+
+None. This Specification does not change listing, order, payment, webhook, or outbox state machines.
+
+```text
+(no domain transitions)
+```
+
+## API / Data Contract
+
+No new HTTP routes, headers, env vars, or Prisma fields.
+
+The operational contract is the instrument catalog in `docs/operations/dashboards/neon-arsenal-api.json` and the SLO table in `docs/operations/slos.md`. HTTP `http.route` includes both unversioned paths and the `/api/v1` prefix (SPEC-0007).
+
+## Concurrency Model
+
+Documentation and a catalog test only. No new concurrent writes. Existing reservation, idempotency, webhook claim, and reconciliation concurrency are unchanged.
+
+## Failure Modes
+
+- OTEL off (`OTEL_ENABLED` unset): logs still have `X-Request-Id`. Spans/metrics are not exported. Diagnosis falls back to Render logs + SQL.
+- OTEL on, exporter `none`/`console`: in-process correlation only; dashboard queries need an OTLP backend the operator already has, or console output.
+- Unreachable OTLP endpoint: request handling continues (existing SDK behavior).
+- Render free-tier spin-down: no HTTP samples while the instance is asleep. Availability SLI is defined only over recorded requests.
+- Process crash after PayPal capture: webhook retry + GET reconciliation (existing). No new recovery path.
+- Capture after reservation expiry: still 409 locally, HTTP 200 to PayPal, manual PayPal dashboard reversal (`docs/operations/runbook.md`). Metrics increment `payments.failed` / `paypal.webhooks.failed` with span `app.outcome=reservation_expired`.
+
+## Security
+
+Telemetry must not include passwords, JWTs, `Authorization`, PayPal access tokens, `paypal-transmission-sig`, payment credentials, SQL text, bind parameters, or user/order/listing IDs as metric labels (`safeAttributes()`). Dashboard JSON and SLO docs must not add those dimensions. Diagnosis must not ask operators to paste secrets into tickets.
+
+## Observability
+
+This Specification *is* the observability operations contract. It reuses:
+
+- HTTP: `http.server.request.count`, `http.server.request.duration`, `http.server.errors`
+- Database: `db.client.operation.duration`, `db.client.errors`
+- PayPal client: `paypal.client.request.count`, `paypal.client.errors`, `paypal.client.timeouts`, `paypal.client.request.duration`
+- Business counters already listed in `docs/observability.md`
+- Spans already listed there, plus `payments.create_link` and `payments.capture` which exist in code
+- Correlation: `X-Request-Id` = `request.id` = Pino `requestId`; `trace_id` / `span_id` on logs when a span is active
+
+## Backward Compatibility
+
+No API, schema, or client change. Enabling `OTEL_ENABLED` remains optional. Existing tests that assert low-cardinality attributes and secret redaction stay in force.
+
+## Acceptance Criteria
+
+- [ ] `AC-01` — Dashboards for API, Orders, Payments, webhooks, reconciliation, and database name only existing meters, labels, and spans. **Evidence:** static check
+- [ ] `AC-02` — Alert thresholds exist as runbook guidance and do not introduce a pager or metrics vendor. **Evidence:** static check
+- [ ] `AC-03` — A written procedure diagnoses a failure using `X-Request-Id` / `request.id` / `trace_id` without searching for secrets. **Evidence:** static check
+- [ ] `AC-04` — Each SLO cites an existing instrument or an explicit unmeasurable + proxy. **Evidence:** static check
+- [ ] `AC-05` — Availability SLI uses 5xx (`http.server.errors`) over recorded HTTP (`http.server.request.count`), not 4xx business outcomes. **Evidence:** static check
+- [ ] `AC-06` — Error budget is defined from the availability SLO over a 30-day window of recorded requests. **Evidence:** static check
+- [ ] `AC-07` — A unit test proves documented metric names still exist and keep documented attribute keys. **Evidence:** test
+- [ ] `AC-08` — Reservation and payment semantics, env vars, and PayPal contracts are unchanged. **Evidence:** manual review
+
+### Acceptance rules
+
+1. Criteria must describe observable outcomes, not implementation steps.
+2. Criteria must be deterministic enough for an independent verifier to judge.
+3. Criteria must cover important failure and security behavior, not only the happy path.
+4. A criterion is not accepted because a test passes when the test does not actually prove the criterion.
+
+## Verification Strategy
+
+- Required commands/checks: `cd server && npm run test:unit`; `python3 scripts/ai-factory/validate.py`
+- Unit tests: instrument catalog vs `docs/operations/dashboards/neon-arsenal-api.json` and source span names
+- Integration/concurrency tests: not required (no runtime semantics change)
+- Security/contract checks: catalog test forbids high-cardinality / sensitive metric attributes
+- Runtime/manual checks: none required (no Grafana server)
+- Required external evidence: none
+
+The final implementation must be traceable from each material acceptance criterion to evidence.
+
+## Decisions / References
+
+- ADR 0004 — OpenTelemetry without an observability platform
+- ADR 0007 — Render is the production target
+- `docs/observability.md` — instrument list
+- `docs/operations/runbook.md` — deploy, probes, payment inspection
+- `docs/architecture/failure-modes.md` — recovery map
+- `docs/performance.md` / `docs/architecture/scaling-path.md` — catalog p95 trigger (~50 ms)
+- `server/src/shared/config/paypal.ts` — 10 s PayPal timeout, 60 s reconcile, 2 min min-age
+- Issues `#62`, `#63`
+
+## Traceability
+
+Material changes must preserve this chain:
+
+```text
+GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+### Traceability metadata
+
+- Issue: `#62` (grouped with `#63`)
+- Spec: `SPEC-0008`
+- Plan: `PLAN-0005`
+- Tasks: `TASK-0008`, `TASK-0009`
+- PR: pending
+- Verification/Convergence: pending
+- Evaluation: pending
+- Memory: pending
+
+The frontmatter `source_issue` must use the canonical GitHub Issue reference format `#<number>` and identify the material Issue that authorized this Specification.
+
+## Change History
+
+- `v1` — Initial accepted contract for issues #62 and #63 — 2026-09-06

--- a/docs/tasks/TASK-0008-operational-dashboards.md
+++ b/docs/tasks/TASK-0008-operational-dashboards.md
@@ -1,0 +1,46 @@
+# [TASK-0008] — Operational dashboard definitions
+
+## Source
+
+- Specification: `SPEC-0008`
+- Plan: `PLAN-0005`
+- Issue: #62
+
+## Objective
+
+Publish operator dashboards for API, Orders, Payments, webhooks, reconciliation, and database that map to meters, labels, and spans already in `server/src/shared/observability/`.
+
+## Scope
+
+`docs/operations/dashboards.md`, `docs/operations/dashboards/neon-arsenal-api.json`, span list update in `docs/observability.md`.
+
+Out of scope: Grafana/Prometheus server, new instruments, `src/`, payment semantics.
+
+## Preconditions
+
+Worktree from `origin/main` at PLAN-0005 `baseline_revision`. `SPEC-0008` Accepted.
+
+## Acceptance Criteria
+
+- [ ] AC-01: Six dashboard groups exist and cite only existing instruments
+- [ ] AC-02: JSON catalog lists every meter name, type, unit, and allowed attributes
+- [ ] AC-03: Critical traces and `app.outcome` values are named
+- [ ] AC-04: Dual `http.route` prefixes (`/` and `/api/v1`) are documented
+
+## Dependencies
+
+None.
+
+## Risks
+
+Omitting `/api/v1` routes would under-count SLI traffic.
+
+## Verification Command
+
+```bash
+python3 scripts/ai-factory/validate.py
+```
+
+## Expected Evidence
+
+Dashboard markdown and JSON exist. Factory validation passes after TASK-0009 artifacts land.

--- a/docs/tasks/TASK-0009-slos-and-instrument-catalog.md
+++ b/docs/tasks/TASK-0009-slos-and-instrument-catalog.md
@@ -1,0 +1,49 @@
+# [TASK-0009] — SLOs, error budget, diagnosis, catalog test
+
+## Source
+
+- Specification: `SPEC-0008`
+- Plan: `PLAN-0005`
+- Issue: #63
+
+## Objective
+
+Define measurable SLOs and a 30-day error budget from existing instruments, document request/trace diagnosis and runbook alert thresholds, and add a unit test that the documented catalog still exists.
+
+## Scope
+
+`docs/operations/slos.md`, runbook diagnosis/alerts, observability/current-state/roadmap/README pointers, `server/src/shared/observability/__tests__/instrument-catalog.test.ts`.
+
+Out of scope: new meters, pager vendor, `src/`, reservation/payment code.
+
+## Preconditions
+
+`TASK-0008` JSON catalog exists. `SPEC-0008` Accepted.
+
+## Acceptance Criteria
+
+- [ ] AC-01: Each SLO cites an existing instrument or an explicit unmeasurable + proxy
+- [ ] AC-02: Availability SLI is 5xx / recorded HTTP, not 4xx
+- [ ] AC-03: Error budget is 30-day recorded-request remainder
+- [ ] AC-04: Diagnosis uses request.id / trace_id and forbids secret search
+- [ ] AC-05: Unit test proves documented metric names and attribute keys
+- [ ] AC-06: No payment/reservation semantic change
+
+## Dependencies
+
+`TASK-0008`
+
+## Risks
+
+`payments.failed` / `paypal.webhooks.failed` mix business expiry with ops failures.
+
+## Verification Command
+
+```bash
+python3 scripts/ai-factory/validate.py
+cd server && npm run test:unit
+```
+
+## Expected Evidence
+
+Commands exit 0. Catalog test covers documented meters. Diff review shows no `src/` or payment runtime edits.

--- a/server/src/shared/observability/__tests__/instrument-catalog.test.ts
+++ b/server/src/shared/observability/__tests__/instrument-catalog.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { appMetrics } from "../metrics.js";
+import {
+  collectMetrics,
+  metricAttributeKeys,
+  resetTestTelemetry,
+  shutdownTelemetry,
+  telemetryContainsSensitive,
+  useTestTelemetry,
+} from "../test.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../../../");
+const CATALOG_PATH = join(REPO_ROOT, "docs/operations/dashboards/neon-arsenal-api.json");
+
+type CatalogInstrument = {
+  name: string;
+  type: "counter" | "histogram";
+  unit: string;
+  attributes: string[];
+};
+
+type CatalogSpan = {
+  name: string;
+  file: string;
+};
+
+type Catalog = {
+  meter: string;
+  instruments: CatalogInstrument[];
+  spans: CatalogSpan[];
+  dashboards: Array<{ id: string; panels: Array<{ instrument: string }> }>;
+  security: { forbiddenMetricLabels: string[] };
+};
+
+function loadCatalog(): Catalog {
+  return JSON.parse(readFileSync(CATALOG_PATH, "utf8")) as Catalog;
+}
+
+function recordDocumentedMetrics() {
+  appMetrics.recordHttpRequest({ method: "GET", route: "/listings", statusCode: 200 }, 0.004);
+  appMetrics.recordHttpRequest({ method: "POST", route: "/orders", statusCode: 500 }, 0.02);
+  appMetrics.recordDbOperation({ operation: "findMany", model: "Listing" }, 0.001, false);
+  appMetrics.recordDbOperation({ operation: "updateMany", model: "Listing" }, 0.002, true);
+  appMetrics.recordPaypalRequest("orders_create", 0.2, "success");
+  appMetrics.recordPaypalRequest("orders_get", 0.3, "error");
+  appMetrics.recordPaypalRequest("orders_capture", 0.4, "timeout");
+  appMetrics.ordersCreated();
+  appMetrics.ordersCreationFailed();
+  appMetrics.ordersIdempotencyReplay();
+  appMetrics.ordersIdempotencyConflict();
+  appMetrics.reservationsCreated();
+  appMetrics.reservationsConflict();
+  appMetrics.reservationsExpired();
+  appMetrics.paymentsConfirmed();
+  appMetrics.paymentsFailed();
+  appMetrics.webhooksReceived();
+  appMetrics.webhooksDuplicate();
+  appMetrics.webhooksIgnored();
+  appMetrics.webhooksFailed();
+  appMetrics.sellerLedgerDriftDetected();
+  appMetrics.sellerLedgerCorrected();
+  appMetrics.outboxPublished();
+  appMetrics.outboxRetry();
+  appMetrics.outboxFailed();
+}
+
+describe("documented operational instrument catalog", () => {
+  const catalog = loadCatalog();
+
+  beforeAll(async () => {
+    await useTestTelemetry();
+  });
+
+  afterAll(async () => {
+    await shutdownTelemetry();
+  });
+
+  beforeEach(async () => {
+    await resetTestTelemetry();
+  });
+
+  it("lists every meter the dashboards and SLOs cite", () => {
+    const names = catalog.instruments.map((instrument) => instrument.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(catalog.meter).toBe("neon-arsenal-api");
+    expect(catalog.dashboards.map((dashboard) => dashboard.id)).toEqual([
+      "api",
+      "orders",
+      "payments",
+      "webhooks",
+      "reconciliation",
+      "database",
+    ]);
+
+    const panelInstruments = catalog.dashboards.flatMap((dashboard) =>
+      dashboard.panels.map((panel) => panel.instrument)
+    );
+    for (const name of panelInstruments) {
+      expect(names).toContain(name);
+    }
+  });
+
+  it("records every documented metric with only the documented attribute keys", async () => {
+    recordDocumentedMetrics();
+
+    const metrics = await collectMetrics();
+    const recorded = new Set(metrics.map((metric) => metric.descriptor.name));
+
+    for (const instrument of catalog.instruments) {
+      expect(recorded, `missing ${instrument.name}`).toContain(instrument.name);
+      const keys = [...metricAttributeKeys(metrics, instrument.name)].sort();
+      const allowed = [...instrument.attributes].sort();
+      expect(keys, instrument.name).toEqual(allowed);
+    }
+
+    expect(telemetryContainsSensitive([], metrics)).toBe(false);
+    for (const label of catalog.security.forbiddenMetricLabels) {
+      for (const instrument of catalog.instruments) {
+        expect(metricAttributeKeys(metrics, instrument.name).has(label)).toBe(false);
+      }
+    }
+  });
+
+  it("keeps documented span names in the files that create them", () => {
+    for (const span of catalog.spans) {
+      const source = readFileSync(join(REPO_ROOT, span.file), "utf8");
+      if (span.name === "paypal.") {
+        expect(source).toContain("paypal.${operation}");
+        continue;
+      }
+      expect(source, span.file).toContain(`"${span.name}"`);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #62
Closes #63

Map existing OpenTelemetry instruments to operator dashboards and measurable SLOs. No Grafana/Prometheus/Redis/AWS. No `src/` edits. No reservation/payment semantic change.

## #62 — Operational dashboards

- `docs/operations/dashboards.md` for API, Orders, Payments, webhooks, reconciliation, database
- Vendor-neutral catalog: `docs/operations/dashboards/neon-arsenal-api.json`
- Runbook: diagnose with request ID / trace ID; alert thresholds without a pager vendor
- Unit test that documented instruments still exist

## #63 — SLOs

- `docs/operations/slos.md`: availability, catalog p95, checkout watch, PayPal latency/error, reconciliation proxy
- Each SLO cites real meter/span names in `server/src/shared/observability/`
- Unmeasurable targets (buyer time-to-PAID, exact reconcile lag) are named as proxies, not invented series

## Verification

- `python3 scripts/ai-factory/validate.py` → PASS
- `cd server && npm run test:unit` → 383 passed

Do not merge from this agent. Do not close issues from `gh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

