### PR TITLE
#120 — Extract SellerListings CRUD into testable hooks and dialogs

### DIFF
--- a/src/components/seller/ListingCancelDialog.tsx
+++ b/src/components/seller/ListingCancelDialog.tsx
@@ -1,0 +1,55 @@
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { Listing } from "@/types/api";
+
+export function ListingCancelDialog({
+  listing,
+  deleting,
+  onOpenChange,
+  onConfirm,
+}: {
+  listing: Listing | null;
+  deleting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog
+      open={!!listing}
+      onOpenChange={(open) => {
+        if (!open) onOpenChange(false);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Cancelar listing?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Esta ação cancelará o listing permanentemente.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={deleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {deleting ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : null}
+            Confirmar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/seller/ListingFormDialog.tsx
+++ b/src/components/seller/ListingFormDialog.tsx
@@ -1,0 +1,272 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { ProductCatalogPicker } from "@/components/seller/ProductCatalogPicker";
+import { productDisplayName, SkinVisual } from "@/components/ProductCard";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import {
+  emptyListingForm,
+  listingToForm,
+  parseListingForm,
+  type ListingFormValues,
+} from "@/lib/sellerListingForm";
+import type { Listing, Product } from "@/types/api";
+
+export type ListingFormCreateInput = {
+  productId: string;
+  floatValue: number;
+  pattern?: number;
+  price: number;
+  currency: string;
+  tradeLockUntil?: string;
+  steamAssetId?: string;
+};
+
+export type ListingFormUpdateInput = {
+  price: number;
+  tradeLockUntil: string | null;
+};
+
+export type ListingFormSubmit =
+  | { mode: "create"; input: ListingFormCreateInput }
+  | { mode: "update"; input: ListingFormUpdateInput };
+
+export function ListingFormDialog({
+  open,
+  listing,
+  saving,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  listing: Listing | null;
+  saving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (payload: ListingFormSubmit) => Promise<void>;
+}) {
+  const { toast } = useToast();
+  const [form, setForm] = useState<ListingFormValues>(emptyListingForm);
+  const [selectedProduct, setSelectedProduct] = useState<Product | undefined>();
+
+  useEffect(() => {
+    if (!open) return;
+    if (listing) {
+      setForm(listingToForm(listing));
+      setSelectedProduct(listing.product);
+      return;
+    }
+    setForm(emptyListingForm);
+    setSelectedProduct(undefined);
+  }, [open, listing]);
+
+  const handleSave = async () => {
+    const parsed = parseListingForm(form);
+    if ("title" in parsed) {
+      toast({ title: parsed.title, variant: "destructive" });
+      return;
+    }
+
+    if (listing) {
+      await onSubmit({
+        mode: "update",
+        input: {
+          price: parsed.value.price,
+          tradeLockUntil: form.tradeLockUntil ? form.tradeLockUntil : null,
+        },
+      });
+      return;
+    }
+
+    await onSubmit({
+      mode: "create",
+      input: {
+        productId: form.productId,
+        floatValue: parsed.value.floatValue,
+        pattern: parsed.value.pattern,
+        price: parsed.value.price,
+        currency: form.currency,
+        tradeLockUntil: form.tradeLockUntil || undefined,
+        steamAssetId: form.steamAssetId || undefined,
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {listing ? "Editar listing" : "Novo listing"}
+          </DialogTitle>
+          <DialogDescription>
+            {listing
+              ? "Atualize os dados deste item único."
+              : "Cadastre um item único a partir do catálogo."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label id="productId-label">Produto</Label>
+            {listing ? null : (
+              <ProductCatalogPicker
+                selectedProduct={selectedProduct}
+                enabled={open}
+                onSelect={(product) => {
+                  setSelectedProduct(product);
+                  setForm((current) => ({ ...current, productId: product.id }));
+                }}
+              />
+            )}
+            {selectedProduct ? (
+              <div className="flex items-center gap-3 rounded-md border border-border bg-muted/40 p-3">
+                <div className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/40 ring-1 ring-border">
+                  <SkinVisual
+                    product={selectedProduct}
+                    className="text-sm"
+                    padded={false}
+                  />
+                </div>
+                <p className="text-sm font-medium">
+                  {productDisplayName(selectedProduct)}
+                </p>
+              </div>
+            ) : null}
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="floatValue">Float (0-1)</Label>
+              <Input
+                id="floatValue"
+                type="number"
+                min="0"
+                max="1"
+                step="0.00000001"
+                value={form.floatValue}
+                onChange={(e) =>
+                  setForm((current) => ({
+                    ...current,
+                    floatValue: e.target.value,
+                  }))
+                }
+                placeholder="0.00000000"
+                disabled={!!listing}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="pattern">Pattern (opcional)</Label>
+              <Input
+                id="pattern"
+                type="number"
+                min="0"
+                value={form.pattern}
+                onChange={(e) =>
+                  setForm((current) => ({
+                    ...current,
+                    pattern: e.target.value,
+                  }))
+                }
+                placeholder="Opcional"
+                disabled={!!listing}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="price">Preço</Label>
+              <Input
+                id="price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.price}
+                onChange={(e) =>
+                  setForm((current) => ({ ...current, price: e.target.value }))
+                }
+                placeholder="0.00"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="currency" id="currency-label">
+                Moeda
+              </Label>
+              <Select
+                value={form.currency}
+                onValueChange={(value) =>
+                  setForm((current) => ({ ...current, currency: value }))
+                }
+              >
+                <SelectTrigger id="currency" aria-labelledby="currency-label">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="USD">USD</SelectItem>
+                  <SelectItem value="BRL">BRL</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="tradeLockUntil">Trade Lock Até (opcional)</Label>
+              <Input
+                id="tradeLockUntil"
+                type="datetime-local"
+                value={form.tradeLockUntil}
+                onChange={(e) =>
+                  setForm((current) => ({
+                    ...current,
+                    tradeLockUntil: e.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="steamAssetId">Steam Asset ID (opcional)</Label>
+              <Input
+                id="steamAssetId"
+                value={form.steamAssetId}
+                onChange={(e) =>
+                  setForm((current) => ({
+                    ...current,
+                    steamAssetId: e.target.value,
+                  }))
+                }
+                placeholder="Opcional"
+              />
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancelar
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={saving}>
+            {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+            {listing ? "Salvar" : "Criar"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/seller/ListingPriceDialog.tsx
+++ b/src/components/seller/ListingPriceDialog.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { parseListingPrice } from "@/lib/sellerListingForm";
+import type { Listing } from "@/types/api";
+
+export function ListingPriceDialog({
+  open,
+  listing,
+  saving,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  listing: Listing | null;
+  saving: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (newPrice: number) => Promise<void>;
+}) {
+  const { toast } = useToast();
+  const [newPrice, setNewPrice] = useState("");
+
+  useEffect(() => {
+    if (!open || !listing) return;
+    setNewPrice(String(listing.price));
+  }, [open, listing]);
+
+  const handleUpdate = async () => {
+    const parsed = parseListingPrice(newPrice);
+    if ("title" in parsed) {
+      toast({ title: parsed.title, variant: "destructive" });
+      return;
+    }
+    if (!listing) return;
+    await onSubmit(parsed.price);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Atualizar Preço</DialogTitle>
+          <DialogDescription>
+            Informe o novo preço deste listing.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="newPrice">Novo Preço</Label>
+            <Input
+              id="newPrice"
+              type="number"
+              min="0"
+              step="0.01"
+              value={newPrice}
+              onChange={(e) => setNewPrice(e.target.value)}
+              placeholder="0.00"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancelar
+          </Button>
+          <Button onClick={() => void handleUpdate()} disabled={saving}>
+            {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+            Atualizar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/seller/SellerListingsTable.tsx
+++ b/src/components/seller/SellerListingsTable.tsx
@@ -1,0 +1,124 @@
+import { DollarSign, EyeOff, Pencil, Trash2 } from "lucide-react";
+import { productDisplayName, SkinThumb } from "@/components/ProductCard";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { listingStatusLabel } from "@/lib/userFacingApiError";
+import type { Listing } from "@/types/api";
+
+export function SellerListingsTable({
+  listings,
+  onEditPrice,
+  onEdit,
+  onCancel,
+  onDelete,
+}: {
+  listings: Listing[];
+  onEditPrice: (listing: Listing) => void;
+  onEdit: (listing: Listing) => void;
+  onCancel: (listing: Listing) => void;
+  onDelete: (listing: Listing) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Skin</TableHead>
+            <TableHead className="hidden md:table-cell">Float</TableHead>
+            <TableHead>Preço</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="text-right">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {listings.map((listing) => {
+            const productName = productDisplayName(listing.product);
+            return (
+              <TableRow key={listing.id}>
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <SkinThumb product={listing.product} size="md" decorative />
+                    <span className="font-medium">{productName}</span>
+                  </div>
+                </TableCell>
+                <TableCell className="hidden md:table-cell text-muted-foreground">
+                  {Number(listing.floatValue).toFixed(8)}
+                </TableCell>
+                <TableCell className="tabular-nums font-medium">
+                  ${Number(listing.price).toFixed(2)}
+                </TableCell>
+                <TableCell>
+                  <span
+                    className={`text-xs font-medium px-2 py-1 rounded ${
+                      listing.status === "ACTIVE"
+                        ? "bg-primary/10 text-primary"
+                        : listing.status === "SOLD"
+                          ? "bg-green-500/10 text-green-500"
+                          : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {listingStatusLabel(listing.status)}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    {listing.status === "ACTIVE" && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onEditPrice(listing)}
+                          title="Atualizar preço"
+                          aria-label="Atualizar preço"
+                        >
+                          <DollarSign className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onEdit(listing)}
+                          title="Editar"
+                          aria-label="Editar"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      </>
+                    )}
+                    {listing.status === "ACTIVE" && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => onCancel(listing)}
+                        title="Cancelar listing"
+                        aria-label="Cancelar listing"
+                      >
+                        <EyeOff className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onDelete(listing)}
+                      title="Excluir"
+                      aria-label="Excluir"
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/seller/__tests__/ListingCancelDialog.test.tsx
+++ b/src/components/seller/__tests__/ListingCancelDialog.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Listing, Product } from "@/types/api";
+import { ListingCancelDialog } from "../ListingCancelDialog";
+
+function listing(): Listing {
+  const catalog: Product = {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  return {
+    id: "listing-1",
+    productId: catalog.id,
+    sellerId: "seller-1",
+    floatValue: 0.25,
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: catalog,
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+  };
+}
+
+describe("ListingCancelDialog", () => {
+  it("confirms cancel for the selected listing", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ListingCancelDialog
+        listing={listing()}
+        deleting={false}
+        onOpenChange={vi.fn()}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(screen.getByText("Cancelar listing?")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("stays closed when no listing is selected", () => {
+    render(
+      <ListingCancelDialog
+        listing={null}
+        deleting={false}
+        onOpenChange={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Cancelar listing?")).toBeNull();
+  });
+});

--- a/src/components/seller/__tests__/ListingFormDialog.test.tsx
+++ b/src/components/seller/__tests__/ListingFormDialog.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Listing, Product } from "@/types/api";
+import { ListingFormDialog } from "../ListingFormDialog";
+
+const toast = vi.fn();
+const listProducts = vi.fn();
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+function product(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: "https://cs2.sh/image/ak-redline.png",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function listing(): Listing {
+  const catalog = product();
+  return {
+    id: "listing-1",
+    productId: catalog.id,
+    sellerId: "seller-1",
+    floatValue: 0.25,
+    pattern: 123,
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: catalog,
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+  };
+}
+
+describe("ListingFormDialog", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+    toast.mockReset();
+    listProducts.mockReset();
+    listProducts.mockResolvedValue({
+      items: [product()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+  });
+
+  it("validates create input before submitting", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <ListingFormDialog
+        open
+        listing={null}
+        saving={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Criar" }));
+
+    expect(toast).toHaveBeenCalledWith({
+      title: "Produto é obrigatório",
+      variant: "destructive",
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits a create payload after catalog selection", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ListingFormDialog
+        open
+        listing={null}
+        saving={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("option", {
+        name: "AK-47 | Redline (Field-Tested)",
+      }),
+    );
+    fireEvent.change(screen.getByLabelText("Float (0-1)"), {
+      target: { value: "0.25" },
+    });
+    fireEvent.change(screen.getByLabelText("Preço"), {
+      target: { value: "18.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Criar" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        mode: "create",
+        input: {
+          productId: "ak-redline-ft",
+          floatValue: 0.25,
+          pattern: undefined,
+          price: 18.5,
+          currency: "USD",
+          tradeLockUntil: undefined,
+          steamAssetId: undefined,
+        },
+      });
+    });
+  });
+
+  it("shows the product preview and disables float when editing", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ListingFormDialog
+        open
+        listing={listing()}
+        saving={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(await screen.findByText("Editar listing")).toBeTruthy();
+    expect(screen.getByLabelText("Float (0-1)")).toBeDisabled();
+    expect(
+      screen.getByRole("img", { name: "AK-47 | Redline (Field-Tested)" }),
+    ).toHaveAttribute("src", "https://cs2.sh/image/ak-redline.png");
+
+    fireEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        mode: "update",
+        input: {
+          price: 18.5,
+          tradeLockUntil: null,
+        },
+      });
+    });
+  });
+});

--- a/src/components/seller/__tests__/ListingPriceDialog.test.tsx
+++ b/src/components/seller/__tests__/ListingPriceDialog.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Listing, Product } from "@/types/api";
+import { ListingPriceDialog } from "../ListingPriceDialog";
+
+const toast = vi.fn();
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
+
+function listing(): Listing {
+  const catalog: Product = {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  return {
+    id: "listing-1",
+    productId: catalog.id,
+    sellerId: "seller-1",
+    floatValue: 0.25,
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: catalog,
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+  };
+}
+
+describe("ListingPriceDialog", () => {
+  beforeEach(() => {
+    toast.mockReset();
+  });
+
+  it("toasts invalid prices and does not submit", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ListingPriceDialog
+        open
+        listing={listing()}
+        saving={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Novo Preço"), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Atualizar" }));
+
+    expect(toast).toHaveBeenCalledWith({
+      title: "Preço inválido",
+      variant: "destructive",
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits a parsed positive price", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ListingPriceDialog
+        open
+        listing={listing()}
+        saving={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Novo Preço"), {
+      target: { value: "22.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Atualizar" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(22.5);
+    });
+  });
+});

--- a/src/hooks/__tests__/useSellerListings.test.tsx
+++ b/src/hooks/__tests__/useSellerListings.test.tsx
@@ -1,0 +1,232 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Listing, Product, Seller } from "@/types/api";
+import {
+  setAnalyticsCollector,
+  type AnalyticsEventName,
+  type AnalyticsProps,
+} from "@/lib/analytics";
+import { useSellerListings } from "../useSellerListings";
+
+const getSellerMe = vi.fn();
+const getSellerListings = vi.fn();
+const createListing = vi.fn();
+const updateListing = vi.fn();
+const updateListingPrice = vi.fn();
+const cancelListing = vi.fn();
+const toast = vi.fn();
+
+vi.mock("@/api", () => ({
+  getSellerMe: (...args: unknown[]) => getSellerMe(...args),
+  getSellerListings: (...args: unknown[]) => getSellerListings(...args),
+  createListing: (...args: unknown[]) => createListing(...args),
+  updateListing: (...args: unknown[]) => updateListing(...args),
+  updateListingPrice: (...args: unknown[]) => updateListingPrice(...args),
+  cancelListing: (...args: unknown[]) => cancelListing(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
+
+function seller(overrides: Partial<Seller> = {}): Seller {
+  return {
+    id: "seller-1",
+    userId: "user-1",
+    storeName: "NeonTrader Store",
+    balance: 0,
+    rating: 0,
+    isApproved: true,
+    ...overrides,
+  };
+}
+
+function product(): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: "https://cs2.sh/image/ak-redline.png",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function listing(overrides: Partial<Listing> = {}): Listing {
+  const catalog = product();
+  return {
+    id: "listing-1",
+    productId: catalog.id,
+    sellerId: "seller-1",
+    floatValue: 0.25,
+    pattern: 123,
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: catalog,
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+    ...overrides,
+  };
+}
+
+const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
+  [];
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useSellerListings", () => {
+  beforeEach(() => {
+    analyticsEvents.length = 0;
+    setAnalyticsCollector((event, props) => {
+      analyticsEvents.push({ event, props });
+    });
+    toast.mockReset();
+    getSellerMe.mockReset();
+    getSellerListings.mockReset();
+    createListing.mockReset();
+    updateListing.mockReset();
+    updateListingPrice.mockReset();
+    cancelListing.mockReset();
+    getSellerMe.mockResolvedValue(seller());
+    getSellerListings.mockResolvedValue({ items: [listing()], total: 1 });
+  });
+
+  afterEach(() => {
+    setAnalyticsCollector(null);
+  });
+
+  it("loads seller and listings through React Query", async () => {
+    const { result } = renderHook(() => useSellerListings(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.listings).toHaveLength(1);
+    });
+
+    expect(getSellerMe).toHaveBeenCalled();
+    expect(getSellerListings).toHaveBeenCalled();
+    expect(result.current.canCreateListing).toBe(true);
+    expect(result.current.pendingApproval).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not fetch when disabled", async () => {
+    const { result } = renderHook(() => useSellerListings({ enabled: false }), {
+      wrapper: wrapper(),
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(getSellerMe).not.toHaveBeenCalled();
+    expect(getSellerListings).not.toHaveBeenCalled();
+  });
+
+  it("blocks create when the seller is pending approval", async () => {
+    getSellerMe.mockResolvedValue(seller({ isApproved: false }));
+
+    const { result } = renderHook(() => useSellerListings(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.seller?.isApproved).toBe(false);
+    });
+
+    expect(result.current.canCreateListing).toBe(false);
+    expect(result.current.pendingApproval).toBe(true);
+  });
+
+  it("surfaces a load error for retry", async () => {
+    getSellerMe.mockRejectedValue(new Error("sessão expirada"));
+
+    const { result } = renderHook(() => useSellerListings(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(getSellerListings).not.toHaveBeenCalled();
+  });
+
+  it("creates a listing, tracks analytics, and invalidates the list", async () => {
+    const created = listing({ id: "listing-new", price: 18.5 });
+    createListing.mockResolvedValue(created);
+
+    const { result } = renderHook(() => useSellerListings(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await result.current.create.mutateAsync({
+      productId: created.productId,
+      floatValue: 0.25,
+      price: 18.5,
+    });
+
+    await waitFor(() => {
+      expect(createListing).toHaveBeenCalled();
+      expect(analyticsEvents).toContainEqual({
+        event: "seller_listing_created",
+        props: {
+          listingId: "listing-new",
+          productId: "ak-redline-ft",
+          price: "18.5",
+          source: "seller",
+        },
+      });
+      expect(toast).toHaveBeenCalledWith({ title: "Listing criado" });
+      expect(getSellerListings.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  it("updates price and cancels through isolated mutations", async () => {
+    updateListingPrice.mockResolvedValue(listing({ price: 22 }));
+    cancelListing.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSellerListings(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await result.current.updatePrice.mutateAsync({
+      id: "listing-1",
+      newPrice: 22,
+    });
+    await result.current.cancel.mutateAsync(listing());
+
+    expect(updateListingPrice).toHaveBeenCalledWith("listing-1", {
+      newPrice: 22,
+    });
+    expect(cancelListing).toHaveBeenCalledWith("listing-1");
+    expect(toast).toHaveBeenCalledWith({ title: "Preço atualizado" });
+    expect(toast).toHaveBeenCalledWith({ title: "Listing cancelado" });
+  });
+});

--- a/src/hooks/useSellerListings.ts
+++ b/src/hooks/useSellerListings.ts
@@ -1,0 +1,161 @@
+import { useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  cancelListing,
+  createListing,
+  getSellerListings,
+  getSellerMe,
+  updateListing,
+  updateListingPrice,
+} from "@/api";
+import { useToast } from "@/hooks/use-toast";
+import { analyticsPrice, track } from "@/lib/analytics";
+import {
+  logTechnicalError,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
+import type { Listing } from "@/types/api";
+
+export const SELLER_ME_QUERY_KEY = ["sellerMe"] as const;
+export const SELLER_LISTINGS_QUERY_KEY = ["sellerListings"] as const;
+
+type CreateListingInput = Parameters<typeof createListing>[0];
+type UpdateListingBody = Parameters<typeof updateListing>[1];
+
+export function useSellerListings(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled ?? true;
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const sellerQuery = useQuery({
+    queryKey: SELLER_ME_QUERY_KEY,
+    queryFn: getSellerMe,
+    enabled,
+  });
+
+  const listingsQuery = useQuery({
+    queryKey: SELLER_LISTINGS_QUERY_KEY,
+    queryFn: getSellerListings,
+    enabled: enabled && sellerQuery.isSuccess,
+  });
+
+  const queryError = sellerQuery.isError
+    ? sellerQuery.error
+    : listingsQuery.isError
+      ? listingsQuery.error
+      : null;
+  const isRetrying =
+    Boolean(queryError) && (sellerQuery.isFetching || listingsQuery.isFetching);
+  const loading =
+    sellerQuery.isLoading || listingsQuery.isLoading || isRetrying;
+  const error =
+    queryError && !isRetrying ? userFacingApiError(queryError) : null;
+
+  useEffect(() => {
+    if (queryError && !isRetrying) {
+      logTechnicalError(queryError);
+    }
+  }, [queryError, isRetrying]);
+
+  const invalidateListings = () =>
+    queryClient.invalidateQueries({ queryKey: SELLER_LISTINGS_QUERY_KEY });
+
+  const create = useMutation({
+    mutationFn: (input: CreateListingInput) => createListing(input),
+    onSuccess: (created) => {
+      track("seller_listing_created", {
+        listingId: created.id,
+        productId: created.productId,
+        price: analyticsPrice(created.price),
+        source: "seller",
+      });
+      toast({ title: "Listing criado" });
+      void invalidateListings();
+    },
+    onError: (e) => {
+      logTechnicalError(e);
+      toast({
+        title: "Erro ao criar",
+        description: userFacingApiError(e),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateListingBody }) =>
+      updateListing(id, body),
+    onSuccess: () => {
+      toast({ title: "Listing atualizado" });
+      void invalidateListings();
+    },
+    onError: (e) => {
+      logTechnicalError(e);
+      toast({
+        title: "Erro ao atualizar",
+        description: userFacingApiError(e),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updatePrice = useMutation({
+    mutationFn: ({ id, newPrice }: { id: string; newPrice: number }) =>
+      updateListingPrice(id, { newPrice }),
+    onSuccess: () => {
+      toast({ title: "Preço atualizado" });
+      void invalidateListings();
+    },
+    onError: (e) => {
+      logTechnicalError(e);
+      toast({
+        title: "Erro ao atualizar preço",
+        description: userFacingApiError(e),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const cancel = useMutation({
+    mutationFn: (listing: Listing) => cancelListing(listing.id),
+    onSuccess: () => {
+      toast({ title: "Listing cancelado" });
+      void invalidateListings();
+    },
+    onError: (e) => {
+      toast({
+        title: "Erro ao cancelar",
+        description: userFacingApiError(e),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const seller = sellerQuery.data ?? null;
+  const pendingApproval = seller?.isApproved === false;
+  const canCreateListing = seller?.isApproved === true;
+
+  const reload = async () => {
+    const sellerResult = await sellerQuery.refetch();
+    if (sellerResult.isSuccess) {
+      await listingsQuery.refetch();
+    }
+  };
+
+  return {
+    seller,
+    listings: listingsQuery.data?.items ?? [],
+    total: listingsQuery.data?.total ?? 0,
+    loading,
+    error,
+    reload,
+    canCreateListing,
+    pendingApproval,
+    create,
+    update,
+    updatePrice,
+    cancel,
+    isSaving: create.isPending || update.isPending || updatePrice.isPending,
+    isCanceling: cancel.isPending,
+  };
+}

--- a/src/lib/__tests__/sellerListingForm.test.ts
+++ b/src/lib/__tests__/sellerListingForm.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { Listing, Product } from "@/types/api";
+import {
+  emptyListingForm,
+  listingToForm,
+  parseListingForm,
+  parseListingPrice,
+} from "../sellerListingForm";
+
+function product(): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    isStattrak: false,
+    isSouvenir: false,
+    imageUrl: "https://cs2.sh/image/ak-redline.png",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function listing(overrides: Partial<Listing> = {}): Listing {
+  const catalog = product();
+  return {
+    id: "listing-1",
+    productId: catalog.id,
+    sellerId: "seller-1",
+    floatValue: 0.25,
+    pattern: 123,
+    price: 18.5,
+    currency: "USD",
+    status: "ACTIVE",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    product: catalog,
+    seller: { id: "seller-1", storeName: "NeonTrader Store" },
+    ...overrides,
+  };
+}
+
+describe("parseListingForm", () => {
+  it("requires a product", () => {
+    expect(
+      parseListingForm({
+        ...emptyListingForm,
+        floatValue: "0.2",
+        price: "10",
+      }),
+    ).toEqual({ title: "Produto é obrigatório" });
+  });
+
+  it("rejects float outside 0-1", () => {
+    expect(
+      parseListingForm({
+        ...emptyListingForm,
+        productId: "ak-redline-ft",
+        floatValue: "1.2",
+        price: "10",
+      }),
+    ).toEqual({ title: "Float deve estar entre 0 e 1" });
+  });
+
+  it("rejects non-positive price", () => {
+    expect(
+      parseListingForm({
+        ...emptyListingForm,
+        productId: "ak-redline-ft",
+        floatValue: "0.2",
+        price: "0",
+      }),
+    ).toEqual({ title: "Preço inválido" });
+  });
+
+  it("rejects a negative pattern", () => {
+    expect(
+      parseListingForm({
+        ...emptyListingForm,
+        productId: "ak-redline-ft",
+        floatValue: "0.2",
+        price: "10",
+        pattern: "-1",
+      }),
+    ).toEqual({ title: "Pattern inválido" });
+  });
+
+  it("parses a valid create payload", () => {
+    expect(
+      parseListingForm({
+        ...emptyListingForm,
+        productId: "ak-redline-ft",
+        floatValue: "0.25",
+        price: "18.5",
+        pattern: "123",
+      }),
+    ).toEqual({
+      value: { floatValue: 0.25, price: 18.5, pattern: 123 },
+    });
+  });
+});
+
+describe("parseListingPrice", () => {
+  it("rejects invalid prices", () => {
+    expect(parseListingPrice("")).toEqual({
+      title: "Preço inválido",
+    });
+    expect(parseListingPrice("0")).toEqual({
+      title: "Preço inválido",
+    });
+  });
+
+  it("accepts a positive price", () => {
+    expect(parseListingPrice("19.99")).toEqual({ price: 19.99 });
+  });
+});
+
+describe("listingToForm", () => {
+  it("maps an existing listing into the dialog form", () => {
+    expect(listingToForm(listing())).toMatchObject({
+      productId: "ak-redline-ft",
+      floatValue: "0.25",
+      pattern: "123",
+      price: "18.5",
+      currency: "USD",
+    });
+  });
+});

--- a/src/lib/sellerListingForm.ts
+++ b/src/lib/sellerListingForm.ts
@@ -1,0 +1,72 @@
+import type { Listing } from "@/types/api";
+
+export const emptyListingForm = {
+  productId: "",
+  floatValue: "",
+  pattern: "",
+  price: "",
+  currency: "USD",
+  tradeLockUntil: "",
+  steamAssetId: "",
+};
+
+export type ListingFormValues = typeof emptyListingForm;
+
+export type ListingFormIssue =
+  | "Produto é obrigatório"
+  | "Float deve estar entre 0 e 1"
+  | "Preço inválido"
+  | "Pattern inválido";
+
+export type ParsedListingForm = {
+  floatValue: number;
+  price: number;
+  pattern?: number;
+};
+
+export function listingToForm(listing: Listing): ListingFormValues {
+  return {
+    productId: listing.productId,
+    floatValue: String(listing.floatValue),
+    pattern: listing.pattern ? String(listing.pattern) : "",
+    price: String(listing.price),
+    currency: listing.currency,
+    tradeLockUntil: listing.tradeLockUntil
+      ? new Date(listing.tradeLockUntil).toISOString().slice(0, 16)
+      : "",
+    steamAssetId: listing.steamAssetId || "",
+  };
+}
+
+export function parseListingForm(
+  form: ListingFormValues,
+): { title: ListingFormIssue } | { value: ParsedListingForm } {
+  const floatValue = parseFloat(form.floatValue);
+  const price = parseFloat(form.price);
+  const pattern = form.pattern ? parseInt(form.pattern, 10) : undefined;
+
+  if (!form.productId) {
+    return { title: "Produto é obrigatório" };
+  }
+  if (isNaN(floatValue) || floatValue < 0 || floatValue > 1) {
+    return { title: "Float deve estar entre 0 e 1" };
+  }
+  if (isNaN(price) || price <= 0) {
+    return { title: "Preço inválido" };
+  }
+  if (pattern !== undefined && (isNaN(pattern) || pattern < 0)) {
+    return { title: "Pattern inválido" };
+  }
+
+  return { value: { floatValue, price, pattern } };
+}
+
+export function parseListingPrice(
+  raw: string,
+): { title: "Preço inválido" } | { price: number } {
+  const price = parseFloat(raw);
+  if (isNaN(price) || price <= 0) {
+    return { title: "Preço inválido" };
+  }
+  return { price };
+}

--- a/src/pages/seller/SellerListings.tsx
+++ b/src/pages/seller/SellerListings.tsx
@@ -1,309 +1,70 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Navigate } from "react-router-dom";
-import {
-  Package,
-  Pencil,
-  Trash2,
-  EyeOff,
-  Loader2,
-  DollarSign,
-} from "lucide-react";
-import {
-  getSellerMe,
-  getSellerListings,
-  createListing,
-  updateListing,
-  updateListingPrice,
-  cancelListing,
-} from "@/api";
-import type { Seller, Listing, Product } from "@/types/api";
-import { ProductCatalogPicker } from "@/components/seller/ProductCatalogPicker";
-import { Button } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Loader2, Package } from "lucide-react";
+import { ListingCancelDialog } from "@/components/seller/ListingCancelDialog";
+import { ListingFormDialog } from "@/components/seller/ListingFormDialog";
+import { ListingPriceDialog } from "@/components/seller/ListingPriceDialog";
+import { SellerListingsTable } from "@/components/seller/SellerListingsTable";
 import { EmptyState, ErrorState } from "@/components/page-state";
-import {
-  productDisplayName,
-  SkinThumb,
-  SkinVisual,
-} from "@/components/ProductCard";
-import { analyticsPrice, track } from "@/lib/analytics";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/contexts/AuthContext";
-import { useToast } from "@/hooks/use-toast";
-import {
-  listingStatusLabel,
-  logTechnicalError,
-  userFacingApiError,
-} from "@/lib/userFacingApiError";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { useSellerListings } from "@/hooks/useSellerListings";
+import type { Listing } from "@/types/api";
 
-const emptyForm = {
-  productId: "",
-  floatValue: "",
-  pattern: "",
-  price: "",
-  currency: "USD",
-  tradeLockUntil: "",
-  steamAssetId: "",
-};
+function CreateListingButton({
+  canCreateListing,
+  pendingApproval,
+  onClick,
+}: {
+  canCreateListing: boolean;
+  pendingApproval: boolean;
+  onClick: () => void;
+}) {
+  const label = pendingApproval ? "Disponível após aprovação" : "Novo Listing";
+  return (
+    <Button
+      onClick={onClick}
+      disabled={!canCreateListing}
+      title={pendingApproval ? "Disponível após aprovação" : undefined}
+    >
+      {canCreateListing ? <Package className="mr-2 h-4 w-4" /> : null}
+      {label}
+    </Button>
+  );
+}
 
 export default function SellerListings() {
   const { user } = useAuth();
   const isAdmin = user?.role === "ADMIN";
-  const [seller, setSeller] = useState<Seller | null>(null);
-  const [listings, setListings] = useState<Listing[]>([]);
-  const [selectedProduct, setSelectedProduct] = useState<Product | undefined>();
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    listings,
+    loading,
+    error,
+    reload,
+    canCreateListing,
+    pendingApproval,
+    create,
+    update,
+    updatePrice,
+    cancel,
+    isSaving,
+    isCanceling,
+  } = useSellerListings({ enabled: !isAdmin });
+
   const [formOpen, setFormOpen] = useState(false);
-  const [priceFormOpen, setPriceFormOpen] = useState(false);
   const [editingListing, setEditingListing] = useState<Listing | null>(null);
   const [priceListing, setPriceListing] = useState<Listing | null>(null);
-  const [form, setForm] = useState(emptyForm);
-  const [newPrice, setNewPrice] = useState("");
-  const [saving, setSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Listing | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const { toast } = useToast();
-
-  const loadSeller = async () => {
-    try {
-      const s = await getSellerMe();
-      setSeller(s);
-      return s.id;
-    } catch (e) {
-      logTechnicalError(e);
-      setError(userFacingApiError(e));
-      return null;
-    }
-  };
-
-  const loadListings = async () => {
-    try {
-      const res = await getSellerListings();
-      setListings(res.items);
-      setTotal(res.total);
-    } catch (e) {
-      logTechnicalError(e);
-      setError(userFacingApiError(e));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const reload = async () => {
-    setLoading(true);
-    setError(null);
-    const sellerId = await loadSeller();
-    if (!sellerId) {
-      setLoading(false);
-      return;
-    }
-    await loadListings();
-  };
-
-  useEffect(() => {
-    if (isAdmin) return;
-    void reload();
-    // Mount + explicit retry via reload(); load helpers close over setters only.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin]);
 
   if (isAdmin) {
     return <Navigate to="/admin" replace />;
   }
 
-  const canCreateListing = seller?.isApproved === true;
-  const pendingApproval = seller?.isApproved === false;
-  const createListingLabel = pendingApproval
-    ? "Disponível após aprovação"
-    : "Novo Listing";
-
   const openCreate = () => {
     if (!canCreateListing) return;
     setEditingListing(null);
-    setSelectedProduct(undefined);
-    setForm(emptyForm);
     setFormOpen(true);
   };
-
-  const openEdit = (l: Listing) => {
-    setEditingListing(l);
-    setSelectedProduct(l.product);
-    setForm({
-      productId: l.productId,
-      floatValue: String(l.floatValue),
-      pattern: l.pattern ? String(l.pattern) : "",
-      price: String(l.price),
-      currency: l.currency,
-      tradeLockUntil: l.tradeLockUntil
-        ? new Date(l.tradeLockUntil).toISOString().slice(0, 16)
-        : "",
-      steamAssetId: l.steamAssetId || "",
-    });
-    setFormOpen(true);
-  };
-
-  const openPriceEdit = (l: Listing) => {
-    setPriceListing(l);
-    setNewPrice(String(l.price));
-    setPriceFormOpen(true);
-  };
-
-  const handleSave = async () => {
-    const floatValue = parseFloat(form.floatValue);
-    const price = parseFloat(form.price);
-    const pattern = form.pattern ? parseInt(form.pattern, 10) : undefined;
-
-    if (!form.productId) {
-      toast({ title: "Produto é obrigatório", variant: "destructive" });
-      return;
-    }
-    if (isNaN(floatValue) || floatValue < 0 || floatValue > 1) {
-      toast({ title: "Float deve estar entre 0 e 1", variant: "destructive" });
-      return;
-    }
-    if (isNaN(price) || price <= 0) {
-      toast({ title: "Preço inválido", variant: "destructive" });
-      return;
-    }
-    if (pattern !== undefined && (isNaN(pattern) || pattern < 0)) {
-      toast({ title: "Pattern inválido", variant: "destructive" });
-      return;
-    }
-
-    setSaving(true);
-    try {
-      if (editingListing) {
-        await updateListing(editingListing.id, {
-          price,
-          tradeLockUntil: form.tradeLockUntil ? form.tradeLockUntil : null,
-        });
-        toast({ title: "Listing atualizado" });
-      } else {
-        const created = await createListing({
-          productId: form.productId,
-          floatValue,
-          pattern,
-          price,
-          currency: form.currency,
-          tradeLockUntil: form.tradeLockUntil || undefined,
-          steamAssetId: form.steamAssetId || undefined,
-        });
-        track("seller_listing_created", {
-          listingId: created.id,
-          productId: created.productId,
-          price: analyticsPrice(created.price),
-          source: "seller",
-        });
-        toast({ title: "Listing criado" });
-      }
-      setFormOpen(false);
-      await loadListings();
-    } catch (e) {
-      logTechnicalError(e);
-      toast({
-        title: editingListing ? "Erro ao atualizar" : "Erro ao criar",
-        description: userFacingApiError(e),
-        variant: "destructive",
-      });
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handlePriceUpdate = async () => {
-    const price = parseFloat(newPrice);
-    if (!priceListing) return;
-    if (isNaN(price) || price <= 0) {
-      toast({ title: "Preço inválido", variant: "destructive" });
-      return;
-    }
-    setSaving(true);
-    try {
-      await updateListingPrice(priceListing.id, { newPrice: price });
-      toast({ title: "Preço atualizado" });
-      setPriceFormOpen(false);
-      await loadListings();
-    } catch (e) {
-      logTechnicalError(e);
-      toast({
-        title: "Erro ao atualizar preço",
-        description: userFacingApiError(e),
-        variant: "destructive",
-      });
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleCancel = async (l: Listing) => {
-    try {
-      await cancelListing(l.id);
-      toast({ title: "Listing cancelado" });
-      await loadListings();
-    } catch (e) {
-      toast({
-        title: "Erro ao cancelar",
-        description: userFacingApiError(e),
-        variant: "destructive",
-      });
-    }
-  };
-
-  const confirmDelete = async () => {
-    if (!deleteTarget) return;
-    setDeleting(true);
-    try {
-      await cancelListing(deleteTarget.id);
-      toast({ title: "Listing cancelado" });
-      setDeleteTarget(null);
-      await loadListings();
-    } catch (e) {
-      toast({
-        title: "Erro ao cancelar",
-        description: userFacingApiError(e),
-        variant: "destructive",
-      });
-    } finally {
-      setDeleting(false);
-    }
-  };
-
-  const selectedFormProduct = selectedProduct;
 
   if (error) {
     return (
@@ -330,14 +91,11 @@ export default function SellerListings() {
             CRUD de itens únicos. O catálogo de produtos é somente leitura.
           </p>
         </div>
-        <Button
+        <CreateListingButton
+          canCreateListing={canCreateListing}
+          pendingApproval={pendingApproval}
           onClick={openCreate}
-          disabled={!canCreateListing}
-          title={pendingApproval ? "Disponível após aprovação" : undefined}
-        >
-          {canCreateListing ? <Package className="mr-2 h-4 w-4" /> : null}
-          {createListingLabel}
-        </Button>
+        />
       </div>
 
       {loading ? (
@@ -357,330 +115,89 @@ export default function SellerListings() {
               : "Crie um item único a partir do catálogo de produtos."
           }
           action={
-            <Button
+            <CreateListingButton
+              canCreateListing={canCreateListing}
+              pendingApproval={pendingApproval}
               onClick={openCreate}
-              disabled={!canCreateListing}
-              title={pendingApproval ? "Disponível após aprovação" : undefined}
-            >
-              {createListingLabel}
-            </Button>
+            />
           }
         />
       ) : (
-        <div className="overflow-hidden rounded-lg border border-border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Skin</TableHead>
-                <TableHead className="hidden md:table-cell">Float</TableHead>
-                <TableHead>Preço</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="text-right">Ações</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {listings.map((l) => {
-                const productName = productDisplayName(l.product);
-                return (
-                  <TableRow key={l.id}>
-                    <TableCell>
-                      <div className="flex items-center gap-3">
-                        <SkinThumb product={l.product} size="md" decorative />
-                        <span className="font-medium">{productName}</span>
-                      </div>
-                    </TableCell>
-                    <TableCell className="hidden md:table-cell text-muted-foreground">
-                      {Number(l.floatValue).toFixed(8)}
-                    </TableCell>
-                    <TableCell className="tabular-nums font-medium">
-                      ${Number(l.price).toFixed(2)}
-                    </TableCell>
-                    <TableCell>
-                      <span
-                        className={`text-xs font-medium px-2 py-1 rounded ${
-                          l.status === "ACTIVE"
-                            ? "bg-primary/10 text-primary"
-                            : l.status === "SOLD"
-                              ? "bg-green-500/10 text-green-500"
-                              : "bg-muted text-muted-foreground"
-                        }`}
-                      >
-                        {listingStatusLabel(l.status)}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex items-center justify-end gap-1">
-                        {l.status === "ACTIVE" && (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => openPriceEdit(l)}
-                              title="Atualizar preço"
-                              aria-label="Atualizar preço"
-                            >
-                              <DollarSign className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() => openEdit(l)}
-                              title="Editar"
-                              aria-label="Editar"
-                            >
-                              <Pencil className="h-4 w-4" />
-                            </Button>
-                          </>
-                        )}
-                        {l.status === "ACTIVE" && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => handleCancel(l)}
-                            title="Cancelar listing"
-                            aria-label="Cancelar listing"
-                          >
-                            <EyeOff className="h-4 w-4" />
-                          </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => setDeleteTarget(l)}
-                          title="Excluir"
-                          aria-label="Excluir"
-                          className="text-destructive hover:text-destructive"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
+        <SellerListingsTable
+          listings={listings}
+          onEditPrice={setPriceListing}
+          onEdit={(listing) => {
+            setEditingListing(listing);
+            setFormOpen(true);
+          }}
+          onCancel={(listing) => {
+            void cancel.mutateAsync(listing).catch(() => undefined);
+          }}
+          onDelete={setDeleteTarget}
+        />
       )}
 
-      <Dialog open={formOpen} onOpenChange={setFormOpen}>
-        <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>
-              {editingListing ? "Editar listing" : "Novo listing"}
-            </DialogTitle>
-            <DialogDescription>
-              {editingListing
-                ? "Atualize os dados deste item único."
-                : "Cadastre um item único a partir do catálogo."}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label id="productId-label">Produto</Label>
-              {editingListing ? null : (
-                <ProductCatalogPicker
-                  selectedProduct={selectedProduct}
-                  enabled={formOpen}
-                  onSelect={(product) => {
-                    setSelectedProduct(product);
-                    setForm((f) => ({ ...f, productId: product.id }));
-                  }}
-                />
-              )}
-              {selectedFormProduct ? (
-                <div className="flex items-center gap-3 rounded-md border border-border bg-muted/40 p-3">
-                  <div className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden rounded-md bg-black/40 ring-1 ring-border">
-                    <SkinVisual
-                      product={selectedFormProduct}
-                      className="text-sm"
-                      padded={false}
-                    />
-                  </div>
-                  <p className="text-sm font-medium">
-                    {productDisplayName(selectedFormProduct)}
-                  </p>
-                </div>
-              ) : null}
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="floatValue">Float (0-1)</Label>
-                <Input
-                  id="floatValue"
-                  type="number"
-                  min="0"
-                  max="1"
-                  step="0.00000001"
-                  value={form.floatValue}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, floatValue: e.target.value }))
-                  }
-                  placeholder="0.00000000"
-                  disabled={!!editingListing}
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="pattern">Pattern (opcional)</Label>
-                <Input
-                  id="pattern"
-                  type="number"
-                  min="0"
-                  value={form.pattern}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, pattern: e.target.value }))
-                  }
-                  placeholder="Opcional"
-                  disabled={!!editingListing}
-                />
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="price">Preço</Label>
-                <Input
-                  id="price"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={form.price}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, price: e.target.value }))
-                  }
-                  placeholder="0.00"
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="currency" id="currency-label">
-                  Moeda
-                </Label>
-                <Select
-                  value={form.currency}
-                  onValueChange={(value) =>
-                    setForm((f) => ({ ...f, currency: value }))
-                  }
-                >
-                  <SelectTrigger id="currency" aria-labelledby="currency-label">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="USD">USD</SelectItem>
-                    <SelectItem value="BRL">BRL</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="grid gap-2">
-                <Label htmlFor="tradeLockUntil">
-                  Trade Lock Até (opcional)
-                </Label>
-                <Input
-                  id="tradeLockUntil"
-                  type="datetime-local"
-                  value={form.tradeLockUntil}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, tradeLockUntil: e.target.value }))
-                  }
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="steamAssetId">Steam Asset ID (opcional)</Label>
-                <Input
-                  id="steamAssetId"
-                  value={form.steamAssetId}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, steamAssetId: e.target.value }))
-                  }
-                  placeholder="Opcional"
-                />
-              </div>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setFormOpen(false)}
-              disabled={saving}
-            >
-              Cancelar
-            </Button>
-            <Button onClick={handleSave} disabled={saving}>
-              {saving ? (
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              ) : null}
-              {editingListing ? "Salvar" : "Criar"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ListingFormDialog
+        open={formOpen}
+        listing={editingListing}
+        saving={isSaving}
+        onOpenChange={(open) => {
+          setFormOpen(open);
+          if (!open) setEditingListing(null);
+        }}
+        onSubmit={async (payload) => {
+          try {
+            if (payload.mode === "update") {
+              if (!editingListing) return;
+              await update.mutateAsync({
+                id: editingListing.id,
+                body: payload.input,
+              });
+            } else {
+              await create.mutateAsync(payload.input);
+            }
+            setFormOpen(false);
+            setEditingListing(null);
+          } catch {
+            // Toast is owned by the mutation.
+          }
+        }}
+      />
 
-      <Dialog open={priceFormOpen} onOpenChange={setPriceFormOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Atualizar Preço</DialogTitle>
-            <DialogDescription>
-              Informe o novo preço deste listing.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="newPrice">Novo Preço</Label>
-              <Input
-                id="newPrice"
-                type="number"
-                min="0"
-                step="0.01"
-                value={newPrice}
-                onChange={(e) => setNewPrice(e.target.value)}
-                placeholder="0.00"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setPriceFormOpen(false)}
-              disabled={saving}
-            >
-              Cancelar
-            </Button>
-            <Button onClick={handlePriceUpdate} disabled={saving}>
-              {saving ? (
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              ) : null}
-              Atualizar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ListingPriceDialog
+        open={!!priceListing}
+        listing={priceListing}
+        saving={isSaving}
+        onOpenChange={(open) => {
+          if (!open) setPriceListing(null);
+        }}
+        onSubmit={async (newPrice) => {
+          if (!priceListing) return;
+          try {
+            await updatePrice.mutateAsync({ id: priceListing.id, newPrice });
+            setPriceListing(null);
+          } catch {
+            // Toast is owned by the mutation.
+          }
+        }}
+      />
 
-      <AlertDialog
-        open={!!deleteTarget}
-        onOpenChange={(open) => !open && setDeleteTarget(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Cancelar listing?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Esta ação cancelará o listing permanentemente.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={confirmDelete}
-              disabled={deleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {deleting ? (
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              ) : null}
-              Confirmar
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ListingCancelDialog
+        listing={deleteTarget}
+        deleting={isCanceling}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        onConfirm={() => {
+          if (!deleteTarget) return;
+          void cancel
+            .mutateAsync(deleteTarget)
+            .then(() => {
+              setDeleteTarget(null);
+            })
+            .catch(() => undefined);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -161,9 +161,9 @@ describe("SellerListings", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: "Novo Listing" }),
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
     ).toBeTruthy();
-    expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Novo Listing" })).toBeTruthy();
     expect(screen.getByTitle("Editar")).toBeTruthy();
     expect(screen.getByTitle("Atualizar preço")).toBeTruthy();
     expect(screen.getByTitle("Cancelar listing")).toBeTruthy();

--- a/src/pages/seller/__tests__/SellerListings.test.tsx
+++ b/src/pages/seller/__tests__/SellerListings.test.tsx
@@ -1,6 +1,8 @@
+import type { ReactElement } from "react";
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SellerListings from "../SellerListings";
 import { createListing } from "@/api";
 import type { Listing, Product, Seller, User } from "@/types/api";
@@ -94,6 +96,15 @@ function listing(overrides: Partial<Listing> = {}): Listing {
 const analyticsEvents: { event: AnalyticsEventName; props: AnalyticsProps }[] =
   [];
 
+function renderListings(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("SellerListings", () => {
   beforeEach(() => {
     analyticsEvents.length = 0;
@@ -127,7 +138,7 @@ describe("SellerListings", () => {
   it("disables Novo Listing when getSellerMe reports a pending store", async () => {
     getSellerMe.mockResolvedValue(seller({ isApproved: false }));
 
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -143,7 +154,7 @@ describe("SellerListings", () => {
   });
 
   it("keeps unique-item listing CRUD on /seller/listings", async () => {
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -163,7 +174,7 @@ describe("SellerListings", () => {
   it("shows an empty state when the seller has no listings", async () => {
     getSellerListings.mockResolvedValue({ items: [], total: 0 });
 
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -178,7 +189,7 @@ describe("SellerListings", () => {
   it("shows an error state that can be retried", async () => {
     getSellerMe.mockRejectedValue(new Error("sessão expirada"));
 
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -200,7 +211,7 @@ describe("SellerListings", () => {
     };
     getSellerMe.mockRejectedValue(new Error("Seller not found"));
 
-    render(
+    renderListings(
       <MemoryRouter initialEntries={["/seller/listings"]}>
         <Routes>
           <Route path="/seller/listings" element={<SellerListings />} />
@@ -217,7 +228,7 @@ describe("SellerListings", () => {
   });
 
   it("shows a catalog thumbnail in each listing row", async () => {
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -233,7 +244,7 @@ describe("SellerListings", () => {
   });
 
   it("shows a product preview in the edit listing dialog", async () => {
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -260,7 +271,7 @@ describe("SellerListings", () => {
       limit: 20,
     });
 
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,
@@ -303,7 +314,7 @@ describe("SellerListings", () => {
     const created = listing({ id: "listing-new", price: 18.5 });
     vi.mocked(createListing).mockResolvedValue(created);
 
-    render(
+    renderListings(
       <MemoryRouter>
         <SellerListings />
       </MemoryRouter>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #120

Frontend-only extract. No new seller feature, no `server/` edits, no API contract change.

## What changed

- `SellerListings.tsx` is now an orchestrator (~203 lines)
- `useSellerListings` (React Query) for list/create/price/cancel
- Isolated dialogs + table; form validation in `sellerListingForm`
- Pending-seller `#113` banner and disabled create preserved
- listings stay unique-item CRUD; products stay read-only

## Verification

- `npm run typecheck` → PASS
- `npm run lint` → PASS
- `npm test` → 369 passed
- Browser: list/create/price/edit/cancel; pending seller stays disabled

[Approved seller listings table after create](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listings-table.png)
[Create listing dialog](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listings-create-dialog.png)
[Pending seller banner and disabled create](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fseller-listings-pending-disabled.png)

## Risks

- React Query refetch-on-focus is a small difference from the old one-shot `useEffect`

Do not merge from this agent. Do not close issues from `gh`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

