### PR TITLE
#68 #70 #71 #74 — Container hardening, diagrams, ADRs, and scale model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,26 @@ jobs:
         continue-on-error: true
 
   # ─────────────────────────────────────────────
+  # Security: Trivy filesystem (#68)
+  # No image registry in this repo; Render builds at deploy. Report-only,
+  # same policy as npm audit (docs/operations/ci-protection.md).
+  # ─────────────────────────────────────────────
+  trivy:
+    name: Security (Trivy filesystem)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Trivy scan server/ (Dockerfile + lockfile)
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          scan-type: fs
+          scan-ref: server
+          severity: CRITICAL,HIGH
+          exit-code: "0"
+
+  # ─────────────────────────────────────────────
   # Build verification (frontend + backend)
   # ─────────────────────────────────────────────
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,14 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    # #68: local stand-in for Render instance limits + read-only root.
+    # Production Render does not expose read_only in the Blueprint; /tmp stays
+    # the only required writable path (Prisma/Node scratch).
+    read_only: true
+    tmpfs:
+      - /tmp:mode=1777
+    mem_limit: 512m
+    cpus: "1.0"
     ports:
       - "3001:3001"
     environment:

--- a/docs/adr/0018-redis-not-adopted.md
+++ b/docs/adr/0018-redis-not-adopted.md
@@ -1,0 +1,32 @@
+# ADR 0018 — Redis is not adopted
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #71 asks for an explicit decision on Redis. Several ADRs already reject Redis as an alternative for a single concern (idempotency, webhooks, pagination, rate limits, outbox). Nothing in the repo runs Redis, Render Key Value, or an in-process Redis client.
+
+The remaining question is whether Redis should exist as a **platform dependency** for cache, sessions, or a shared rate-limit store.
+
+## Decision
+
+**Do not adopt Redis.** PostgreSQL remains the source of truth for transactional state. HTTP rate limits stay in-process memory (documented in the threat model and runbook). Listing pages are not cached. Scale-out is more Render API instances plus PostgreSQL connection limits (`docs/architecture/capacity.md`, `docs/architecture/scaling-path.md`).
+
+Rejected alternatives:
+
+- Redis as a cache in front of `GET /listings` — `docs/performance.md` shows the page index scan is ~0.02 ms at 2.5k `ACTIVE` rows; `COUNT(*)` is the slower sibling and is still sub-millisecond. No measured trigger.
+- Redis as the idempotency or webhook-event store — not durable across crash the way a unique PostgreSQL row is; ADRs 0002 and 0003 already rejected this.
+- Render Key Value “because the Blueprint can provision it” — that would add a failure mode (cache/store down) the application does not have.
+
+## Consequences
+
+- Agents must not add `ioredis`, `redis`, or a Render `keyvalue` service unless a later ADR supersedes this one with a measured trigger from `docs/architecture/scaling-path.md`.
+- Multiple API replicas do **not** share rate-limit counters. That is accepted (threat model).
+- Interview answer: Redis was considered and rejected; uniqueness and payment identity live in PostgreSQL.
+
+## What this ADR does not change
+
+- Existing ADRs 0001–0017 (not rewritten).
+- Application code, env vars, or `render.yaml`.

--- a/docs/adr/0019-async-workers-sqs-not-adopted.md
+++ b/docs/adr/0019-async-workers-sqs-not-adopted.md
@@ -1,0 +1,33 @@
+# ADR 0019 — Async workers and SQS are not adopted
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #71 asks for an explicit decision on asynchronous processing. Issue #53 (SQS) is still a separate intake item; it must not be implemented while ADR 0007 keeps Render and there is no measured queueing trigger.
+
+The API already runs **in-process** timers after `listen`: reservation expiry (30s), PayPal GET reconciliation (60s), seller-ledger reconciliation (60s), and the transactional outbox dispatcher (ADR 0012, `FOR UPDATE SKIP LOCKED`). Those are not a second deployable and not a broker.
+
+## Decision
+
+**Do not adopt SQS, SNS, Kafka, RabbitMQ, or a separate worker service.** Background work stays in the API process and is coordinated by PostgreSQL conditional updates.
+
+Rejected alternatives:
+
+- SQS + worker for webhooks or expiry — duplicates what unique constraints and `RESERVED`/`SOLD` predicates already serialize. Extra hop after PayPal would not make capture more reliable than webhook retry + GET reconcile (ADR 0002).
+- A Render Background Worker that shares the same image — a second process that still needs the same DB invariants, plus split deploys, without a measured event-loop freeze.
+- “Async” meaning fire-and-forget payment confirmation — forbidden. `confirmPayment` stays one local transaction.
+
+## Consequences
+
+- Sequence diagrams must not draw a queue or worker (`docs/architecture/sequences.md`).
+- Extra API replicas duplicate timers; that is safe because sweeps are idempotent.
+- A later SQS ADR would have to supersede this one **and** show a trigger from `docs/architecture/scaling-path.md` (for example expiry delayed by a frozen event loop on every replica). Until then, agents must not add AWS SQS.
+
+## What this ADR does not change
+
+- ADR 0012 (outbox stays in-process).
+- PayPal `OrdersCreate` / `OrdersCapture` no-retry policy (ADR 0005).
+- `render.yaml` (no worker service).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,31 @@
+# Architecture Decision Records
+
+Numbered ADRs under this directory. **Do not rewrite accepted ADRs** to restyle them. Add a new ADR when a decision is missing or an old one is superseded.
+
+Issue #71 inventory. Decisions already recorded before this change are listed, not restated.
+
+| ADR | Decision |
+|---|---|
+| [0001](./0001-in-process-reservation-expiry.md) | Concurrent reserve + in-process expiry; PostgreSQL predicates |
+| [0002](./0002-paypal-webhook-reliability.md) | Payment / webhook consistency; GET reconciliation |
+| [0003](./0003-order-creation-idempotency.md) | Order create idempotency in PostgreSQL |
+| [0004](./0004-opentelemetry.md) | Optional OpenTelemetry |
+| [0005](./0005-external-retry-and-graceful-shutdown.md) | External retry classification + SIGTERM drain |
+| [0006](./0006-hot-path-indexes.md) | Indexes from `EXPLAIN ANALYZE` |
+| [0007](./0007-cloud-target-render.md) | Cloud = Render; PostgreSQL is SoT wherever compute runs; ECS is not live |
+| [0008](./0008-c2-skip-terraform.md) | No Terraform while 0007 stands |
+| [0009](./0009-prisma-domain-enums.md) | Domain enums in PostgreSQL |
+| [0010](./0010-audit-log.md) | Append-only audit |
+| [0011](./0011-seller-ledger.md) | Seller ledger + in-process reconcile |
+| [0012](./0012-transactional-outbox.md) | In-process outbox; not a broker |
+| [0013](./0013-cursor-pagination.md) | Optional keyset pagination |
+| [0014](./0014-cs2sh-catalog-import.md) | cs2.sh import |
+| [0015](./0015-refresh-token-families.md) | Refresh-token families |
+| [0016](./0016-modular-monolith-boundaries.md) | Modular monolith + import graph |
+| [0017](./0017-api-url-versioning.md) | `/api/v1` + unversioned aliases |
+| [0018](./0018-redis-not-adopted.md) | **Redis not adopted** (#71) |
+| [0019](./0019-async-workers-sqs-not-adopted.md) | **SQS / worker not adopted** (#71) |
+
+PostgreSQL as source of truth is already a decision in ADR 0007 §4 and is assumed by 0001–0003, 0005, 0011, 0012, and 0016. No duplicate SoT ADR.
+
+Diagrams: `docs/architecture/c4.md`, `docs/architecture/sequences.md`. Capacity: `docs/architecture/capacity.md`.

--- a/docs/architecture/c4.md
+++ b/docs/architecture/c4.md
@@ -6,7 +6,7 @@ This is the **current** system, as deployed and as coded. It is not an AWS targe
 
 A **future** ECS/Fargate sketch exists on the P2 roadmap (`docs/roadmap.md`). That sketch is a portfolio option until activity **C1** writes an ADR. Do not read this file as if ECS were running.
 
-**Related:** `docs/architecture/current-state.md`, `docs/operations/runbook.md`, `docs/architecture/threat-model.md`, `docs/architecture/scaling-path.md`.
+**Related:** `docs/architecture/current-state.md`, `docs/architecture/sequences.md` (checkout, concurrent reserve, webhook, reconciliation), `docs/operations/runbook.md`, `docs/architecture/threat-model.md`, `docs/architecture/scaling-path.md`, `docs/architecture/capacity.md`.
 
 ---
 
@@ -218,7 +218,7 @@ C4Component
 
 - Trust boundaries and abuse controls: `docs/architecture/threat-model.md`.
 - Crash, retry, webhook duplicate, capture-after-expiry: `docs/architecture/failure-modes.md` and `docs/operations/runbook.md`.
-- Scaling: stay on this container diagram until a **measured** trigger in `docs/architecture/scaling-path.md`. Extra API replicas are more of the same container, not new services.
+- Scaling: stay on this container diagram until a **measured** trigger in `docs/architecture/scaling-path.md`. Extra API replicas are more of the same container, not new services. Sequence diagrams: `docs/architecture/sequences.md`.
 
 ---
 

--- a/docs/architecture/capacity.md
+++ b/docs/architecture/capacity.md
@@ -1,0 +1,42 @@
+# Capacity hypotheses and scale model
+
+Issue #74. These are **hypotheses** for a portfolio/demo marketplace on Render, tied to measurements that already exist. They are **not** k6 results. Issue #55 (load testing) is not done; do not invent RPS, p95-under-load, or error-rate numbers.
+
+Evidence that **is** in-repo:
+
+- `docs/performance.md` — `EXPLAIN ANALYZE` + `listingsService.list` timings at 2 500 `ACTIVE` listings (`cd server && npm run perf:evidence`)
+- `docs/architecture/scaling-path.md` — measured triggers; explicit non-goals (Redis/Kafka/SQS)
+- `docs/adr/0006-hot-path-indexes.md` — why those indexes exist
+- `render.yaml` — one Docker API + one managed PostgreSQL (ADR 0007)
+
+## Hypotheses (planning, not SLOs)
+
+| Dimension | Hypothesis | What we actually measured |
+|---|---|---|
+| Users | Single-operator demo: tens of concurrent browsers, not a claimed MAU | None. No analytics-backed user count in this repo. |
+| RPS | Browse-dominated. Checkout and webhooks are rare relative to `GET /listings`. A single Render instance is assumed enough until a **measured** listing p95 or CPU trigger fires | No k6. Listing list p95 **~4 ms** on the evidence VM at 2.5k rows — that is query time, not offered load |
+| Read / write mix | ~browse/PDP reads vs reserve/payment writes. Writes are PK/conditional updates, not scans | Hot-path table in `docs/performance.md`. Write cost is the listing row lock, not a sequential scan |
+| Catalog size | Comfortable at a few thousand `ACTIVE` listings (current evidence set). Re-run `perf:evidence` after ~10× growth | 2 500 `ACTIVE` + 80 `RESERVED` + 80 `SOLD` in the evidence fixture |
+| Checkout concurrency | Unique listings: N buyers on the **same** listing → one `ACTIVE → RESERVED` winner. Buyers on **different** listings contend on different rows | Integration tests for concurrent reserve; not a load-test RPS |
+| PostgreSQL connections | Prisma default pool is roughly `num_physical_cpus * 2 + 1` per API process (no `connection_limit` in `DATABASE_URL` today; do not add an env var here). Render current-gen Postgres **under 8 GB RAM** typically allows **100** connections. `replicas × pool` must stay under that, plus one for migrations/ops | No production `pg_stat_activity` capture in-repo |
+| Events | Webhook + reconcile volume ≈ captured checkouts. Sweeps: expiry 30s; PayPal GET batch 20 / 60s; ledger 60s; outbox skip-locked | Intervals from ADR 0001 / 0002 / 0011 / 0012, not event-bus throughput |
+
+## Scale-out (what we will actually do)
+
+```text
+Internet → N × Render web instances (same Docker image)
+                → one Render PostgreSQL
+                → PayPal / Resend
+```
+
+1. **API:** add Render instances of `neon-arsenal-api`. Invariants live in PostgreSQL, so replicas are safe (duplicate in-process timers are no-ops).
+2. **PostgreSQL:** stay on one primary. The ceiling is **connections and row locks**, not “add Kafka.” If lock waits dominate on **different** listings, more API replicas + watching the connection budget is the first move (`scaling-path.md`).
+3. **Do not** add Redis, Kafka, SQS, a worker service, or read replicas for correctness.
+
+Free Render web instances spin down after ~15 minutes idle; a sleeping instance cannot sweep until the next request (`docs/operations/runbook.md`). That is an operational limit, not a capacity number.
+
+## When to replace hypotheses with measurements
+
+Run issue #55 (k6 or equivalent) against a production-like API + Postgres **before** quoting RPS targets in SLOs. Until then, operators use `docs/operations/slos.md` (instrument-based) and `docs/performance.md` (plan shape), not invented load-test tables.
+
+If `GET /listings` p95 exceeds ~50 ms with an EXPLAIN that blames `COUNT(*)` or deep `OFFSET`, follow `scaling-path.md` (cursor mode is already shipped). That still does not justify Redis (ADR 0018).

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -113,7 +113,7 @@ See `docs/testing.md`.
 
 ## Performance
 
-Market browse (`status = ACTIVE ORDER BY createdAt DESC, id DESC`) and PayPal reconciliation have composite indexes chosen from `EXPLAIN ANALYZE`. Offset `COUNT(*)` for listing pagination is the slower sibling of the page query and is still cheap at a few thousand rows. Cursor mode on `GET /listings` and `GET /products` skips that count (ADR 0013). Scaling triggers: `docs/architecture/scaling-path.md`. Measurements: `docs/performance.md`.
+Market browse (`status = ACTIVE ORDER BY createdAt DESC, id DESC`) and PayPal reconciliation have composite indexes chosen from `EXPLAIN ANALYZE`. Offset `COUNT(*)` for listing pagination is the slower sibling of the page query and is still cheap at a few thousand rows. Cursor mode on `GET /listings` and `GET /products` skips that count (ADR 0013). Scaling triggers: `docs/architecture/scaling-path.md`. Measurements: `docs/performance.md`. Capacity hypotheses (not k6): `docs/architecture/capacity.md`. Checkout / reserve / webhook / reconcile sequences: `docs/architecture/sequences.md`.
 
 ## Runtime configuration
 

--- a/docs/architecture/scaling-path.md
+++ b/docs/architecture/scaling-path.md
@@ -1,6 +1,6 @@
 # Scaling path
 
-Neon Arsenal stays a modular monolith on PostgreSQL until a **measured** trigger says otherwise. See `docs/performance.md` for the current numbers.
+Neon Arsenal stays a modular monolith on PostgreSQL until a **measured** trigger says otherwise. See `docs/performance.md` for the current numbers. Planning hypotheses (users/RPS/catalog/connections, **not** k6): `docs/architecture/capacity.md`.
 
 ## Current shape
 
@@ -34,3 +34,7 @@ At ~2.5k `ACTIVE` listings, market page index scans are ~0.02 ms; `listingsSer
 - Splitting payments or listings into their own deployable
 
 When a trigger fires, record the measurement, the EXPLAIN, and the mitigation in `docs/performance.md` and a new ADR.
+
+## Scale-out (Render)
+
+Horizontal scale is **more `neon-arsenal-api` instances** on Render plus the PostgreSQL connection ceiling on `neon-arsenal-db`. It is not Redis, Kafka, SQS, or a worker split (ADR 0018, ADR 0019). Connection budget: `docs/architecture/capacity.md`.

--- a/docs/architecture/sequences.md
+++ b/docs/architecture/sequences.md
@@ -1,0 +1,137 @@
+# Sequence diagrams
+
+Issue #70. These match **current code**, not a target AWS architecture. There is no SQS, Redis, Kafka, or worker service (ADR 0018, ADR 0019). In-process timers are drawn as `Jobs` inside the same API process.
+
+Architecture (C4): `docs/architecture/c4.md`. Invariants: `docs/architecture/current-state.md`.
+
+## Checkout (order + payment link)
+
+`POST /orders` reserves in one PostgreSQL transaction. PayPal `OrdersCreate` runs **after** a `PaymentLink` claim and **outside** that transaction. The client “paid” flag is not trusted.
+
+```mermaid
+sequenceDiagram
+  actor Buyer
+  participant API as Express API
+  participant PG as PostgreSQL
+  participant PP as PayPal
+
+  Buyer->>API: POST /orders (Idempotency-Key, listingIds)
+  API->>PG: BEGIN
+  API->>PG: INSERT OrderIdempotencyKey (customerId, key)
+  API->>PG: UPDATE Listing SET RESERVED WHERE ACTIVE (same listings)
+  alt no row or conflict
+    API->>PG: ROLLBACK
+    API-->>Buyer: 409 reservation / idempotency conflict
+  else reserved
+    API->>PG: INSERT Order + OrderItems
+    API->>PG: COMMIT
+    API-->>Buyer: 201 order PENDING
+  end
+
+  Buyer->>API: POST /payments (orderId)
+  API->>PG: claim PaymentLink
+  API->>PP: OrdersCreate (no retry)
+  PP-->>API: paypalOrderId + approve URL
+  API->>PG: store paypalOrderId
+  API-->>Buyer: approve URL
+  Buyer->>PP: approve on PayPal
+```
+
+## Concurrent reserve (same unique listing)
+
+Only the conditional `ACTIVE → RESERVED` update wins. Two API replicas are the same protocol.
+
+```mermaid
+sequenceDiagram
+  actor BuyerA
+  actor BuyerB
+  participant API as Express API (any replica)
+  participant PG as PostgreSQL
+
+  par same listing
+    BuyerA->>API: POST /orders listing L
+    BuyerB->>API: POST /orders listing L
+  end
+  API->>PG: UPDATE Listing L SET RESERVED WHERE status = ACTIVE
+  Note over PG: one statement covers the row; the other updates 0 rows
+  API-->>BuyerA: 201 order (winner)
+  API-->>BuyerB: 409 reservation conflict
+```
+
+## Payment webhook
+
+Unsigned until RSA-SHA256 verifies. Only `PAYMENT.CAPTURE.COMPLETED` sells. Duplicates are a unique `(provider, externalEventId)` no-op.
+
+```mermaid
+sequenceDiagram
+  participant PP as PayPal
+  participant API as Express API
+  participant PG as PostgreSQL
+
+  PP->>API: POST /payments/webhook (raw body)
+  API->>API: verify RSA-SHA256 + transmission time ±5m
+  alt bad signature or skew
+    API-->>PP: 401 / 400
+  else verified
+    API->>PG: INSERT PaymentWebhookEvent (unique event id)
+    alt duplicate PROCESSED or IGNORED
+      API-->>PP: 200 no-op
+    else PAYMENT.CAPTURE.COMPLETED
+      API->>PG: confirmPayment TX (claim order, sell hold, ledger, outbox)
+      alt hold expired or not this order
+        API->>PG: do not SOLD; HTTP 200 (PayPal stops retry)
+      else sold
+        API-->>PP: 200
+      end
+    else CHECKOUT.ORDER.APPROVED
+      API->>PG: mark IGNORED
+      API-->>PP: 200
+    end
+  end
+```
+
+Capture on the return page (`POST /payments/capture`) and GET reconciliation of a live `APPROVED` hold call `OrdersCapture` once, then the same `confirmPayment`.
+
+## Reconciliation (PayPal GET + in-process jobs)
+
+Lost webhooks are recovered by an in-process sweep (60s, min age 2 minutes, batch 20). This is not a queue consumer.
+
+```mermaid
+sequenceDiagram
+  participant Jobs as API process timers
+  participant PG as PostgreSQL
+  participant PP as PayPal
+
+  loop every 60s (unref interval)
+    Jobs->>PG: stale PENDING orders with paypalOrderId (batch 20)
+    Jobs->>PP: OrdersGet (retry 5xx/429 only)
+    alt COMPLETED
+      Jobs->>PG: confirmPayment (same TX as webhook)
+    else APPROVED and hold still live
+      Jobs->>PP: OrdersCapture once (no retry)
+      Jobs->>PG: confirmPayment
+    else hold expired
+      Note over Jobs,PG: do not SOLD (same as webhook)
+    end
+  end
+
+  loop every 30s
+    Jobs->>PG: RESERVED and reservationExpiresAt <= now → ACTIVE
+    Jobs->>PG: cancel unpaid orders that no longer hold listings
+  end
+
+  loop seller ledger 60s
+    Jobs->>PG: SET Seller.balance = SUM(PAID netAmount) if drifted
+  end
+
+  loop outbox (skip locked)
+    Jobs->>PG: claim OutboxEvent; log + metric; mark PUBLISHED
+  end
+```
+
+## What not to draw
+
+- SQS / SNS / Kafka / RabbitMQ
+- A second worker container
+- Redis
+- ALB → ECS → RDS as **current** (ADR 0007: Render is live)

--- a/docs/operations/ci-protection.md
+++ b/docs/operations/ci-protection.md
@@ -12,6 +12,7 @@ Production remains Render (`render.yaml`, ADR 0007). This document does not add 
 | `backend` | Prisma generate + migrate, typecheck, unit, integration (Postgres 16) |
 | `contract` | `cd server && npm run test:contract` — OpenAPI vs real HTTP handlers |
 | `security` | `npm audit --audit-level=high` at the repo root and in `server/` (logged; not a hard fail yet) |
+| `trivy` | Filesystem scan of `server/` (Dockerfile + lockfile). Report-only (`exit-code: 0`). No GHCR/ECR. Local image command: `docs/operations/container-hardening.md` |
 | `build` | Frontend Vite build and `server` `tsc` build, after the jobs above |
 
 Node 20. Backend integration uses `postgres:16-alpine` with the same `DATABASE_URL` pattern as before.
@@ -33,7 +34,7 @@ These #69 items stay human/admin work. Agents must not invent them:
 
 1. **GitHub branch protection and required checks** — enabling rules, required status checks, required reviews, or conversation resolution needs org/admin write. Suggested required checks once an admin can apply them: `AI Factory (artifact validation)`, `Frontend (lint · typecheck · test)`, `Backend (typecheck · unit · integration)`, `Contract (OpenAPI)`, `Security (npm audit)`, `Build check`.
 2. **Staging environment, smoke tests, and controlled production promotion** — no staging Render service, preview promotion, or deploy workflow exists. Production deploys follow Render auto-deploy / dashboard rollback (`docs/operations/runbook.md`). Do not add a second cloud.
-3. **Container image scanning and a container registry** — `server/Dockerfile` is built by Render. There is no GHCR/ECR push in CI. Image/CVE scanning is an operator choice on Render or a later CI job, not invented here.
+3. **Container registry / deploy-time image CVE gate** — `server/Dockerfile` is built by Render. There is no GHCR/ECR push. CI now runs a **filesystem** Trivy job on `server/` (report-only). A failing image gate still needs a registry or a Render-side scanner; do not invent one.
 4. **AWS / Terraform / ECS promotion** — blocked while ADR 0007 selects Render.
 5. **Hard-failing npm audit** — current root and `server/` lockfiles already report high/critical findings (including `bcrypt` → `tar`, `react-router`, Vite/Vitest). Making `npm audit --audit-level=high` a failing gate would go red on `origin/main` and force unrelated upgrades (`npm audit fix --force` wants `bcrypt@6`). The job still runs and publishes the report. A dedicated dependency-upgrade PR can flip the steps to hard-fail.
 

--- a/docs/operations/container-hardening.md
+++ b/docs/operations/container-hardening.md
@@ -1,0 +1,49 @@
+# Production container hardening
+
+Issue #68. Live compute is **Render** (`render.yaml`, ADR 0007). This is not AWS/ECS.
+
+The API image is `server/Dockerfile` (context `server/`). Start sequence is unchanged: `entrypoint.sh` → `prisma migrate deploy` → optional seed → `exec node dist/index.js` on `0.0.0.0:$PORT`. Do not invent env vars.
+
+## What the image already does
+
+| Control | Where |
+|---|---|
+| Multi-stage build | `builder` compiles TypeScript + Prisma client; `production` is the runtime |
+| Minimal runtime | `node:20-alpine`; compile toolchain (`python3`, `make`, `g++`) is removed after `npm ci` |
+| Non-root | `USER expressjs` (uid 1001) |
+| Healthcheck | Docker `HEALTHCHECK` → `GET /health` (liveness). Render `healthCheckPath: /ready` |
+| SIGTERM / graceful shutdown | App already drains HTTP 10s, stops jobs, disconnects Prisma (ADR 0005). `exec` in the entrypoint so the signal reaches Node. Blueprint `maxShutdownDelaySeconds: 30` |
+| Resource limits | Compose `mem_limit` / `cpus` below. Render instance RAM/CPU is the **service plan**, not a Docker flag. Do not add a paid plan in the Blueprint to “look hardened.” |
+
+## Read-only root filesystem
+
+Node and Prisma only need a writable `/tmp` after the image is built. Local Compose sets `read_only: true` plus `tmpfs: /tmp`.
+
+Render’s Blueprint schema does **not** expose a read-only root option for Docker web services. Production on Render keeps a writable container filesystem (ephemeral; lost on every deploy/restart). That is a platform limit, not a reason to add a volume or Redis.
+
+## Resource limits (local / documented)
+
+`docker-compose.yml` `api` service:
+
+- `mem_limit: 512m` — same order as a Render free/starter web instance
+- `cpus: "1.0"`
+- `read_only: true` + `tmpfs: /tmp`
+
+Scale-out on Render is **more API instances**, bounded by PostgreSQL connections (`docs/architecture/capacity.md`). Not Redis, not a worker service.
+
+## Vulnerability scan (Trivy)
+
+CI job `Security (Trivy filesystem)` in `.github/workflows/ci.yml` runs Trivy against `server/` (Dockerfile + lockfile; no image registry). It **reports** CRITICAL/HIGH and does not fail the pipeline — the same policy as `npm audit` (`docs/operations/ci-protection.md`). Base-image CVEs are expected on `node:20-alpine` and are not a reason to invent ECR/GHCR.
+
+Local commands (not required in CI):
+
+```bash
+# Filesystem / lockfile (same scope as CI)
+docker run --rm -v "$PWD:/src" aquasec/trivy:latest fs --severity HIGH,CRITICAL /src/server
+
+# Built image, after `docker compose build api`
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:latest image neon-arsenal-api:latest
+```
+
+There is no container registry in this repository. Render builds the image at deploy time.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -4,7 +4,7 @@ PostgreSQL is the source of truth for listings, orders, and seller balances. Pay
 
 ## Deploy
 
-API service: `neon-arsenal-api` (Docker, `server/Dockerfile`, context `server/`).
+API service: `neon-arsenal-api` (Docker, `server/Dockerfile`, context `server/`). Container hardening (non-root, HEALTHCHECK, Trivy, read-only limits): [`container-hardening.md`](./container-hardening.md).
 
 1. Render builds the image, then starts the container.
 2. `server/entrypoint.sh` runs `prisma migrate deploy`.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -60,6 +60,7 @@ Index-only/unique lookups for `OrderIdempotencyKey(customerId, key)` and `Paymen
 - One modular-monolith API process + one PostgreSQL. In-process expiry/reconciliation timers. Horizontal API replicas are safe because invariants live in PostgreSQL.
 - Current catalog size (demo seed / a few thousand listings) is well inside the plans above.
 - OFFSET pagination remains the Market default (`page` / `limit`). `GET /listings` and `GET /products` also accept an opaque `createdAt`+`id` cursor (ADR 0013). Deep offsets are not a current product need (`limit` max 100).
+- Users/RPS, read/write mix, checkout concurrency, and PG connection budget are **hypotheses** in `docs/architecture/capacity.md`. This file does not invent k6 numbers (issue #55 is not done).
 
 ## Scaling triggers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,7 +135,9 @@ Maintain:
 - `docs/domain/invariants.md`
 - `docs/architecture/domain-invariants.md`
 - `docs/architecture/c4.md`
+- `docs/architecture/sequences.md`
 - `docs/architecture/scaling-path.md`
+- `docs/architecture/capacity.md`
 - `docs/architecture/failure-modes.md`
 - `docs/architecture/threat-model.md`
 - `docs/adr/`

--- a/render.yaml
+++ b/render.yaml
@@ -64,6 +64,9 @@ services:
     healthCheckPath: /ready
     # App drain is 10s (SHUTDOWN_DRAIN_MS). Default platform delay is 30s.
     maxShutdownDelaySeconds: 30
+    # Instance RAM/CPU = the Render plan (Dashboard / existing service). Do not
+    # add a paid plan or Redis Key Value here. Scale-out: more instances of this
+    # service; PG connection ceiling is the shared limit (docs/architecture/capacity.md).
     autoDeploy: true
 
   - type: web

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,11 +17,15 @@ RUN npx prisma generate
 RUN npm run build
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Stage 2: Production image
+# Stage 2: Production image (minimal runtime, non-root)
 # ─────────────────────────────────────────────────────────────────────────────
 FROM node:20-alpine AS production
 
-RUN apk add --no-cache openssl python3 make g++
+# openssl: Prisma query engine. wget: Docker HEALTHCHECK.
+# libstdc++/libgcc: bcrypt .node at runtime. python3/make/g++: compile only.
+RUN apk add --no-cache openssl wget libstdc++ libgcc python3 make g++ \
+  && mkdir -p /tmp \
+  && chmod 1777 /tmp
 
 WORKDIR /app
 
@@ -29,10 +33,9 @@ ENV NODE_ENV=production
 
 # Install only production dependencies (no --ignore-scripts so bcrypt native bindings compile)
 COPY package*.json ./
-RUN npm ci --omit=dev
-
-# Install prisma CLI locally so entrypoint doesn't download v7 via npx
-RUN npm install prisma@5 --save-dev
+RUN npm ci --omit=dev \
+  && npm install prisma@5 --save-dev \
+  && apk del python3 make g++
 
 # Copy built output and Prisma client
 COPY --from=builder /app/dist ./dist
@@ -52,8 +55,10 @@ USER expressjs
 
 EXPOSE 3001
 
+# Liveness only. Render probes /ready (see render.yaml). Do not use /ready
+# here: SIGTERM drain would look like a dead container (ADR 0005).
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD wget -qO- http://localhost:3001/health || exit 1
 
-# Runs migrations then starts the server
+# Runs migrations then starts the server (exec, so SIGTERM reaches Node)
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related #68
Closes #70
Closes #71
Related #74

Grouped ops/architecture work. No Redis/SQS/AWS. `src/` untouched.

## Per-issue status

**#70 DONE** — Mermaid sequences for checkout, concurrent reserve, webhook, in-process reconcile. No fictional worker/SQS.

**#71 DONE** — Only missing ADRs: 0018 Redis not adopted, 0019 SQS/worker not adopted. Existing 0001–0017 not rewritten.

**#68 PARTIAL** — Dockerfile/Compose/CI changes landed (multi-stage, non-root, healthcheck, Trivy report-only). **Docker image was not built in the agent environment.** Do not treat the container as production-proven until a local/`docker build` or CI image build succeeds.

**#74 PARTIAL** — Capacity hypotheses cite `docs/performance.md` (2.5k listings, ~4ms list). **No k6 numbers** (#55 still open). Scale-out = more Render instances + PG connection ceiling.

## Verification

- `cd server && npm run test:unit` → 383 passed
- `python3 scripts/ai-factory/validate.py` → PASS
- Integration skipped (no `server/src` runtime change)
- `docker build` → not run

Do not merge from this agent. Do not close #68 or #74 until the residuals above are evidenced.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

