### PR TITLE
#91 #92 — Market search and URL-persisted filters

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,16 @@
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Menu, ShoppingCart, X } from "lucide-react";
-import { useState } from "react";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
+import { Menu, Search, ShoppingCart, X } from "lucide-react";
+import { useEffect, useState, type FormEvent } from "react";
 import { useCart } from "@/contexts/CartContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { marketPath, parseMarketQuery } from "@/lib/marketQuery";
 
 function brandMark() {
   return (
@@ -17,6 +24,57 @@ function brandMark() {
         Neon Arsenal
       </span>
     </Link>
+  );
+}
+
+function HeaderSearch({
+  id,
+  className,
+  onSubmitted,
+}: {
+  id: string;
+  className?: string;
+  onSubmitted?: () => void;
+}) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const urlQ =
+    location.pathname === "/products" ? parseMarketQuery(searchParams).q : "";
+  const [draft, setDraft] = useState(urlQ);
+
+  useEffect(() => {
+    setDraft(urlQ);
+  }, [urlQ]);
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const term = draft.trim();
+    navigate(term ? marketPath({ q: term }) : "/products");
+    onSubmitted?.();
+  };
+
+  return (
+    <form role="search" onSubmit={submit} className={className}>
+      <label htmlFor={id} className="sr-only">
+        Buscar no Market
+      </label>
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+          aria-hidden
+        />
+        <Input
+          id={id}
+          type="search"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Buscar skins"
+          autoComplete="off"
+          className="h-9 min-h-9 pl-8"
+        />
+      </div>
+    </form>
   );
 }
 
@@ -73,6 +131,11 @@ export function Header() {
             </Link>
           ))}
         </nav>
+
+        <HeaderSearch
+          id="header-search"
+          className="mx-2 min-w-0 max-w-[14rem] flex-1 sm:max-w-[16rem] md:mx-3"
+        />
 
         <div className="flex items-center gap-1.5">
           <Link
@@ -142,6 +205,11 @@ export function Header() {
           className="space-y-1 border-t border-border bg-background p-3 md:hidden"
           aria-label="Principal"
         >
+          <HeaderSearch
+            id="header-search-mobile"
+            className="mb-2"
+            onSubmitted={() => setMenuOpen(false)}
+          />
           {navLinks.map((item) => (
             <Link
               key={item.to}

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { Header } from "../Header";
 import type { User } from "@/types/api";
 
@@ -18,10 +18,27 @@ vi.mock("@/contexts/CartContext", () => ({
   useCart: () => ({ totalItems: 0 }),
 }));
 
+function LocationEcho() {
+  const location = useLocation();
+  return (
+    <div data-testid="location">
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+}
+
 function renderHeader(path = "/") {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Header />
+      <LocationEcho />
+      <Routes>
+        <Route path="/" element={<div>home</div>} />
+        <Route path="/products" element={<div>market</div>} />
+        <Route path="/login" element={<div>login</div>} />
+        <Route path="/register" element={<div>register</div>} />
+      </Routes>
     </MemoryRouter>,
   );
 }
@@ -112,5 +129,25 @@ describe("Header", () => {
     );
     expect(screen.queryByRole("link", { name: "Dashboard" })).toBeNull();
     expect(screen.queryByRole("link", { name: "Pedidos" })).toBeNull();
+  });
+
+  it("submits header search to /products?q=", () => {
+    renderHeader();
+    fireEvent.change(screen.getByLabelText("Buscar no Market"), {
+      target: { value: "  talon " },
+    });
+    fireEvent.submit(screen.getByRole("search"));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/products?q=talon",
+    );
+  });
+
+  it("keeps an empty header search on the default Market URL", () => {
+    renderHeader("/products?q=talon&exterior=Factory+New");
+    fireEvent.change(screen.getByLabelText("Buscar no Market"), {
+      target: { value: "   " },
+    });
+    fireEvent.submit(screen.getByRole("search"));
+    expect(screen.getByTestId("location").textContent).toBe("/products");
   });
 });

--- a/src/lib/__tests__/analytics.test.ts
+++ b/src/lib/__tests__/analytics.test.ts
@@ -177,6 +177,7 @@ describe("analytics helpers", () => {
   it("serializes market filters without PII", () => {
     expect(
       marketSearchQuery({
+        q: "talon",
         productId: "ak-redline-ft",
         exterior: "Factory New",
         isStattrak: true,
@@ -184,7 +185,7 @@ describe("analytics helpers", () => {
         maxPrice: "40",
       }),
     ).toBe(
-      "productId=ak-redline-ft&exterior=Factory+New&isStattrak=true&minPrice=10&maxPrice=40",
+      "q=talon&productId=ak-redline-ft&exterior=Factory+New&isStattrak=true&minPrice=10&maxPrice=40",
     );
     expect(marketSearchQuery({})).toBeUndefined();
   });

--- a/src/lib/__tests__/homeDiscovery.test.ts
+++ b/src/lib/__tests__/homeDiscovery.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Product } from "@/types/api";
 import { similarItemsMarketPath } from "@/lib/listingCartCta";
+import { marketPath } from "@/lib/marketQuery";
 import {
   approvedSellersCountLabel,
   catalogDiscoveryLinks,
+  HOME_EXTERIOR_LINKS,
   listingsCountLabel,
 } from "../homeDiscovery";
 
@@ -53,6 +55,19 @@ describe("catalogDiscoveryLinks", () => {
       },
     ]);
     expect(links.every((link) => !link.href.includes("#"))).toBe(true);
+  });
+});
+
+describe("HOME_EXTERIOR_LINKS", () => {
+  it("deep-links Market exteriors", () => {
+    expect(HOME_EXTERIOR_LINKS[0]).toEqual({
+      exterior: "Factory New",
+      label: "Factory New",
+      href: marketPath({ exterior: "Factory New" }),
+    });
+    expect(HOME_EXTERIOR_LINKS.map((link) => link.href)).toContain(
+      "/products?exterior=Minimal+Wear",
+    );
   });
 });
 

--- a/src/lib/__tests__/marketListings.test.ts
+++ b/src/lib/__tests__/marketListings.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Listing, Product } from "@/types/api";
+import { fetchMarketListings, sortMarketListings } from "../marketListings";
+import { parseMarketQuery } from "../marketQuery";
+
+const listListings = vi.fn();
+const listProducts = vi.fn();
+
+vi.mock("@/api/listings", () => ({
+  listListings: (...args: unknown[]) => listListings(...args),
+}));
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+}));
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "ak-redline-ft",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    collection: "The Huntsman Collection",
+    imageUrl: null,
+    isStattrak: false,
+    isSouvenir: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  const product = overrides.product ?? makeProduct();
+  return {
+    id: "listing-1",
+    productId: product.id,
+    sellerId: "seller-1",
+    floatValue: 0.14,
+    pattern: 1,
+    price: 22,
+    currency: "USD",
+    status: "ACTIVE",
+    tradeLockUntil: null,
+    steamAssetId: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    product,
+    seller: {
+      id: "seller-1",
+      storeName: "Store",
+      rating: 4.5,
+      user: { id: "user-1", name: "Seller" },
+    },
+    ...overrides,
+  };
+}
+
+describe("fetchMarketListings", () => {
+  beforeEach(() => {
+    listListings.mockReset();
+    listProducts.mockReset();
+  });
+
+  it("lists ACTIVE listings without calling products when q is empty", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    const result = await fetchMarketListings(
+      parseMarketQuery(new URLSearchParams()),
+    );
+
+    expect(listProducts).not.toHaveBeenCalled();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+    });
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("resolves q through GET /products?search= then listings by productId", async () => {
+    listProducts.mockResolvedValue({
+      items: [makeProduct({ id: "talon-fade-fn", weapon: "Talon Knife" })],
+      total: 1,
+      page: 1,
+      limit: 100,
+    });
+    listListings.mockResolvedValue({
+      items: [
+        makeListing({
+          id: "listing-talon",
+          productId: "talon-fade-fn",
+          product: makeProduct({ id: "talon-fade-fn", weapon: "Talon Knife" }),
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    const result = await fetchMarketListings(
+      parseMarketQuery(new URLSearchParams("q=talon&exterior=Factory+New")),
+    );
+
+    expect(listProducts).toHaveBeenCalledWith({ search: "talon", limit: 100 });
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+      productId: "talon-fade-fn",
+      exterior: "Factory New",
+    });
+    expect(result.items[0]?.id).toBe("listing-talon");
+  });
+
+  it("returns an empty page when products search has no hits", async () => {
+    listProducts.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 100,
+    });
+
+    const result = await fetchMarketListings(
+      parseMarketQuery(new URLSearchParams("q=zzzz")),
+    );
+
+    expect(listListings).not.toHaveBeenCalled();
+    expect(result).toEqual({ items: [], total: 0, page: 1, limit: 20 });
+  });
+
+  it("merges ACTIVE listings when search matches several products", async () => {
+    listProducts.mockResolvedValue({
+      items: [
+        makeProduct({ id: "p1", skinName: "Printstream" }),
+        makeProduct({
+          id: "p2",
+          skinName: "Printstream",
+          exterior: "Minimal Wear",
+        }),
+      ],
+      total: 2,
+      page: 1,
+      limit: 100,
+    });
+    listListings.mockImplementation(async (params: { productId?: string }) => ({
+      items: [
+        makeListing({
+          id: `listing-${params.productId}`,
+          productId: params.productId,
+          price: params.productId === "p1" ? 80 : 40,
+          product: makeProduct({ id: params.productId ?? "p1" }),
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 100,
+    }));
+
+    const result = await fetchMarketListings(
+      parseMarketQuery(new URLSearchParams("q=Printstream&sort=price-asc")),
+    );
+
+    expect(listListings).toHaveBeenCalledTimes(2);
+    expect(result.total).toBe(2);
+    expect(result.items.map((item) => item.id)).toEqual([
+      "listing-p2",
+      "listing-p1",
+    ]);
+  });
+});
+
+describe("sortMarketListings", () => {
+  it("sorts by price without mutating the input", () => {
+    const a = makeListing({ id: "a", price: 30 });
+    const b = makeListing({ id: "b", price: 10 });
+    const input = [a, b];
+    expect(
+      sortMarketListings(input, "price-asc").map((item) => item.id),
+    ).toEqual(["b", "a"]);
+    expect(input.map((item) => item.id)).toEqual(["a", "b"]);
+  });
+});

--- a/src/lib/__tests__/marketQuery.test.ts
+++ b/src/lib/__tests__/marketQuery.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasMarketFilters,
+  marketPath,
+  marketSearchEmptyTitle,
+  parseMarketQuery,
+  patchMarketQuery,
+  serializeMarketQuery,
+} from "../marketQuery";
+
+describe("parseMarketQuery", () => {
+  it("reads q, filters, sort, and page from the URL", () => {
+    const query = parseMarketQuery(
+      new URLSearchParams(
+        "q=talon&exterior=Minimal+Wear&stattrak=true&minPrice=10&maxPrice=40&minFloat=0.1&maxFloat=0.3&sort=price-asc&page=2",
+      ),
+    );
+    expect(query).toEqual({
+      q: "talon",
+      productId: undefined,
+      exterior: "Minimal Wear",
+      isStattrak: true,
+      minPrice: "10",
+      maxPrice: "40",
+      minFloat: "0.1",
+      maxFloat: "0.3",
+      sort: "price-asc",
+      page: 2,
+    });
+  });
+
+  it("accepts search as an alias for q", () => {
+    expect(parseMarketQuery(new URLSearchParams("search=Printstream")).q).toBe(
+      "Printstream",
+    );
+    expect(
+      parseMarketQuery(new URLSearchParams("q=talon&search=ignored")).q,
+    ).toBe("talon");
+  });
+
+  it("falls back to defaults for invalid params", () => {
+    const query = parseMarketQuery(
+      new URLSearchParams(
+        "page=-2&sort=newest&exterior=Glossy&stattrak=maybe&minPrice=nope&maxFloat=2&minFloat=-1",
+      ),
+    );
+    expect(query).toEqual({
+      q: "",
+      productId: undefined,
+      exterior: "",
+      isStattrak: undefined,
+      minPrice: "",
+      maxPrice: "",
+      minFloat: "",
+      maxFloat: "",
+      sort: "",
+      page: 1,
+    });
+  });
+});
+
+describe("serializeMarketQuery", () => {
+  it("omits defaults so /products stays clean", () => {
+    expect(
+      serializeMarketQuery({
+        q: "",
+        exterior: "",
+        isStattrak: undefined,
+        minPrice: "",
+        maxPrice: "",
+        minFloat: "",
+        maxFloat: "",
+        sort: "",
+        page: 1,
+      }).toString(),
+    ).toBe("");
+  });
+
+  it("writes q (not search) and omits page=1", () => {
+    const qs = serializeMarketQuery({
+      q: "AK",
+      exterior: "Factory New",
+      isStattrak: false,
+      minPrice: "",
+      maxPrice: "",
+      minFloat: "",
+      maxFloat: "",
+      sort: "",
+      page: 1,
+    }).toString();
+    expect(qs).toBe("q=AK&exterior=Factory+New&stattrak=false");
+  });
+});
+
+describe("marketPath", () => {
+  it("builds shareable Market URLs for Home chips", () => {
+    expect(marketPath({ exterior: "Factory New" })).toBe(
+      "/products?exterior=Factory+New",
+    );
+    expect(marketPath({ q: "huntsman" })).toBe("/products?q=huntsman");
+    expect(marketPath()).toBe("/products");
+  });
+});
+
+describe("patchMarketQuery", () => {
+  it("resets page when a filter changes", () => {
+    const next = patchMarketQuery(
+      new URLSearchParams("exterior=Field-Tested&page=3"),
+      { exterior: "Well-Worn", page: 1 },
+    );
+    expect(next.toString()).toBe("exterior=Well-Worn");
+  });
+});
+
+describe("hasMarketFilters", () => {
+  it("is false for the default catalog", () => {
+    expect(hasMarketFilters(parseMarketQuery(new URLSearchParams()))).toBe(
+      false,
+    );
+    expect(
+      hasMarketFilters(parseMarketQuery(new URLSearchParams("q=talon"))),
+    ).toBe(true);
+  });
+});
+
+describe("marketSearchEmptyTitle", () => {
+  it("includes the typed term", () => {
+    expect(marketSearchEmptyTitle("talon")).toBe("Nenhum listing para ‘talon’");
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -97,6 +97,7 @@ export function readAnalyticsSource(
 }
 
 export function marketSearchQuery(input: {
+  q?: string;
   productId?: string;
   exterior?: string;
   isStattrak?: boolean;
@@ -104,6 +105,7 @@ export function marketSearchQuery(input: {
   maxPrice?: string;
 }): string | undefined {
   const params = new URLSearchParams();
+  if (input.q) params.set("q", input.q);
   if (input.productId) params.set("productId", input.productId);
   if (input.exterior) params.set("exterior", input.exterior);
   if (input.isStattrak !== undefined) {

--- a/src/lib/homeDiscovery.ts
+++ b/src/lib/homeDiscovery.ts
@@ -1,5 +1,6 @@
 import type { Product } from "@/types/api";
 import { similarItemsMarketPath } from "@/lib/listingCartCta";
+import { MARKET_EXTERIORS, marketPath } from "@/lib/marketQuery";
 
 export const HOME_VALUE_PROP =
   "Skins CS2 de item único, anunciadas por vendedores. A reserva começa no checkout; o pagamento é pelo PayPal.";
@@ -27,6 +28,14 @@ export const HOME_EMPTY_DESCRIPTION =
 
 export const HOME_CATALOG_SHORTCUT_LIMIT = 6;
 export const HOME_LISTING_RAIL_LIMIT = 8;
+
+export const HOME_EXTERIOR_LINKS = MARKET_EXTERIORS.filter(Boolean).map(
+  (exterior) => ({
+    exterior,
+    label: exterior,
+    href: marketPath({ exterior }),
+  }),
+);
 
 export interface CatalogShortcut {
   productId: string;

--- a/src/lib/marketListings.ts
+++ b/src/lib/marketListings.ts
@@ -1,0 +1,131 @@
+import { listListings, type ListListingsParams } from "@/api/listings";
+import { listProducts } from "@/api/products";
+import type { Listing, ListListingsResponse } from "@/types/api";
+import {
+  MARKET_PAGE_SIZE,
+  MARKET_SEARCH_PRODUCT_LIMIT,
+  type MarketQuery,
+  type MarketSort,
+} from "@/lib/marketQuery";
+
+function listingFilters(query: MarketQuery): ListListingsParams {
+  return {
+    status: "ACTIVE",
+    ...(query.productId ? { productId: query.productId } : {}),
+    ...(query.exterior ? { exterior: query.exterior } : {}),
+    ...(query.isStattrak !== undefined ? { isStattrak: query.isStattrak } : {}),
+    ...(query.minPrice ? { minPrice: parseFloat(query.minPrice) } : {}),
+    ...(query.maxPrice ? { maxPrice: parseFloat(query.maxPrice) } : {}),
+    ...(query.minFloat ? { minFloat: parseFloat(query.minFloat) } : {}),
+    ...(query.maxFloat ? { maxFloat: parseFloat(query.maxFloat) } : {}),
+  };
+}
+
+export function sortMarketListings(
+  items: Listing[],
+  sort: MarketSort,
+): Listing[] {
+  if (sort === "price-asc") {
+    return [...items].sort((a, b) => Number(a.price) - Number(b.price));
+  }
+  if (sort === "price-desc") {
+    return [...items].sort((a, b) => Number(b.price) - Number(a.price));
+  }
+  if (sort === "float-asc") {
+    return [...items].sort(
+      (a, b) => Number(a.floatValue) - Number(b.floatValue),
+    );
+  }
+  if (sort === "float-desc") {
+    return [...items].sort(
+      (a, b) => Number(b.floatValue) - Number(a.floatValue),
+    );
+  }
+  return items;
+}
+
+function emptyPage(page: number): ListListingsResponse {
+  return { items: [], total: 0, page, limit: MARKET_PAGE_SIZE };
+}
+
+function paginate(
+  items: Listing[],
+  page: number,
+  sort: MarketSort,
+): ListListingsResponse {
+  const sorted = sortMarketListings(items, sort);
+  const start = (page - 1) * MARKET_PAGE_SIZE;
+  return {
+    items: sorted.slice(start, start + MARKET_PAGE_SIZE),
+    total: sorted.length,
+    page,
+    limit: MARKET_PAGE_SIZE,
+  };
+}
+
+/**
+ * Storefront catalog. `GET /listings` has no `search`; resolve `q` through
+ * `GET /products?search=` (weapon / skin / collection / marketHashName), then
+ * load ACTIVE listings for those product ids.
+ */
+export async function fetchMarketListings(
+  query: MarketQuery,
+): Promise<ListListingsResponse> {
+  const filters = listingFilters(query);
+
+  if (!query.q) {
+    const result = await listListings({
+      ...filters,
+      page: query.page,
+      limit: MARKET_PAGE_SIZE,
+    });
+    return {
+      ...result,
+      items: sortMarketListings(result.items, query.sort),
+    };
+  }
+
+  const products = await listProducts({
+    search: query.q,
+    limit: MARKET_SEARCH_PRODUCT_LIMIT,
+  });
+  let ids = products.items.map((product) => product.id);
+  if (query.productId) {
+    ids = ids.filter((id) => id === query.productId);
+  }
+  if (ids.length === 0) return emptyPage(query.page);
+
+  if (ids.length === 1) {
+    const result = await listListings({
+      ...filters,
+      productId: ids[0],
+      page: query.page,
+      limit: MARKET_PAGE_SIZE,
+    });
+    return {
+      ...result,
+      items: sortMarketListings(result.items, query.sort),
+    };
+  }
+
+  const pages = await Promise.all(
+    ids.map((productId) =>
+      listListings({
+        ...filters,
+        productId,
+        page: 1,
+        limit: MARKET_SEARCH_PRODUCT_LIMIT,
+      }),
+    ),
+  );
+  const seen = new Set<string>();
+  const merged: Listing[] = [];
+  for (const page of pages) {
+    for (const item of page.items) {
+      if (seen.has(item.id)) continue;
+      seen.add(item.id);
+      merged.push(item);
+    }
+  }
+  return paginate(merged, query.page, query.sort);
+}

--- a/src/lib/marketQuery.ts
+++ b/src/lib/marketQuery.ts
@@ -1,0 +1,158 @@
+/** Market catalog query: URL is the source of truth. */
+
+export const MARKET_EXTERIORS = [
+  "",
+  "Factory New",
+  "Minimal Wear",
+  "Field-Tested",
+  "Well-Worn",
+  "Battle-Scarred",
+] as const;
+
+export const MARKET_SORTS = [
+  { value: "", label: "Padrão" },
+  { value: "price-asc", label: "Menor Preço" },
+  { value: "price-desc", label: "Maior Preço" },
+  { value: "float-asc", label: "Menor Float" },
+  { value: "float-desc", label: "Maior Float" },
+] as const;
+
+export const MARKET_PAGE_SIZE = 20;
+export const MARKET_SEARCH_DEBOUNCE_MS = 300;
+export const MARKET_SEARCH_PRODUCT_LIMIT = 100;
+
+export type MarketExterior = (typeof MARKET_EXTERIORS)[number];
+export type MarketSort = (typeof MARKET_SORTS)[number]["value"];
+
+export interface MarketQuery {
+  q: string;
+  productId?: string;
+  exterior: MarketExterior;
+  isStattrak: boolean | undefined;
+  minPrice: string;
+  maxPrice: string;
+  minFloat: string;
+  maxFloat: string;
+  sort: MarketSort;
+  page: number;
+}
+
+const EXTERIOR_SET = new Set<string>(MARKET_EXTERIORS.filter(Boolean));
+const SORT_SET = new Set<string>(MARKET_SORTS.map((item) => item.value));
+
+function readTrimmed(params: URLSearchParams, key: string): string {
+  return params.get(key)?.trim() ?? "";
+}
+
+function parsePage(value: string | null): number {
+  if (!value?.trim()) return 1;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
+function parseMoney(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n >= 0 ? trimmed : "";
+}
+
+function parseFloatRange(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n >= 0 && n <= 1 ? trimmed : "";
+}
+
+function parseStattrak(value: string | null): boolean | undefined {
+  if (value == null) return undefined;
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "true" || trimmed === "1") return true;
+  if (trimmed === "false" || trimmed === "0") return false;
+  return undefined;
+}
+
+function parseExterior(value: string): MarketExterior {
+  return EXTERIOR_SET.has(value) ? (value as MarketExterior) : "";
+}
+
+function parseSort(value: string): MarketSort {
+  return SORT_SET.has(value) ? (value as MarketSort) : "";
+}
+
+/** `q` wins over `search`. Empty / invalid values become defaults. */
+export function parseMarketQuery(params: URLSearchParams): MarketQuery {
+  const q = readTrimmed(params, "q") || readTrimmed(params, "search");
+  const productId = readTrimmed(params, "productId") || undefined;
+  return {
+    q,
+    productId,
+    exterior: parseExterior(readTrimmed(params, "exterior")),
+    isStattrak: parseStattrak(params.get("stattrak")),
+    minPrice: parseMoney(readTrimmed(params, "minPrice")),
+    maxPrice: parseMoney(readTrimmed(params, "maxPrice")),
+    minFloat: parseFloatRange(readTrimmed(params, "minFloat")),
+    maxFloat: parseFloatRange(readTrimmed(params, "maxFloat")),
+    sort: parseSort(readTrimmed(params, "sort")),
+    page: parsePage(params.get("page")),
+  };
+}
+
+export function serializeMarketQuery(query: MarketQuery): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query.q) params.set("q", query.q);
+  if (query.productId) params.set("productId", query.productId);
+  if (query.exterior) params.set("exterior", query.exterior);
+  if (query.isStattrak !== undefined) {
+    params.set("stattrak", String(query.isStattrak));
+  }
+  if (query.minPrice) params.set("minPrice", query.minPrice);
+  if (query.maxPrice) params.set("maxPrice", query.maxPrice);
+  if (query.minFloat) params.set("minFloat", query.minFloat);
+  if (query.maxFloat) params.set("maxFloat", query.maxFloat);
+  if (query.sort) params.set("sort", query.sort);
+  if (query.page > 1) params.set("page", String(query.page));
+  return params;
+}
+
+export function marketPath(query: Partial<MarketQuery> = {}): string {
+  const params = serializeMarketQuery({
+    q: "",
+    exterior: "",
+    isStattrak: undefined,
+    minPrice: "",
+    maxPrice: "",
+    minFloat: "",
+    maxFloat: "",
+    sort: "",
+    page: 1,
+    ...query,
+  });
+  const qs = params.toString();
+  return qs ? `/products?${qs}` : "/products";
+}
+
+export function patchMarketQuery(
+  current: URLSearchParams,
+  patch: Partial<MarketQuery>,
+): URLSearchParams {
+  return serializeMarketQuery({ ...parseMarketQuery(current), ...patch });
+}
+
+export function hasMarketFilters(query: MarketQuery): boolean {
+  return Boolean(
+    query.q ||
+    query.productId ||
+    query.exterior ||
+    query.isStattrak !== undefined ||
+    query.minPrice ||
+    query.maxPrice ||
+    query.minFloat ||
+    query.maxFloat ||
+    query.sort,
+  );
+}
+
+export function marketSearchEmptyTitle(term: string): string {
+  return `Nenhum listing para ‘${term}’`;
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,7 @@ import { useRecentlyViewedListings } from "@/hooks/useRecentlyViewedListings";
 import {
   HOME_EMPTY_DESCRIPTION,
   HOME_EMPTY_TITLE,
+  HOME_EXTERIOR_LINKS,
   HOME_LISTING_RAIL_LIMIT,
   HOME_NEW_HEADING,
   HOME_NEW_SORT_COPY,
@@ -105,6 +106,26 @@ export default function IndexPage() {
             <Button asChild variant="outline" size="sm">
               <Link to="/products">{MARKET_VIEW_CTA}</Link>
             </Button>
+            {HOME_EXTERIOR_LINKS.map((shortcut) => (
+              <Button
+                key={shortcut.exterior}
+                asChild
+                variant="outline"
+                size="sm"
+              >
+                <Link
+                  to={shortcut.href}
+                  onClick={() =>
+                    track("category_view", {
+                      category: shortcut.exterior,
+                      source: "home",
+                    })
+                  }
+                >
+                  {shortcut.label}
+                </Link>
+              </Button>
+            ))}
             {shortcuts.map((shortcut) => (
               <Button
                 key={shortcut.productId}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -4,36 +4,29 @@ import { useQuery } from "@tanstack/react-query";
 import { Filter } from "lucide-react";
 import { ListingCard } from "@/components/ProductCard";
 import { EmptyState, ErrorState } from "@/components/page-state";
-import { listListings } from "@/api/listings";
 import {
   MARKET_SIMILAR_EMPTY_DESCRIPTION,
   MARKET_SIMILAR_EMPTY_TITLE,
   MARKET_VIEW_CTA,
 } from "@/lib/listingCartCta";
+import { fetchMarketListings } from "@/lib/marketListings";
+import {
+  MARKET_EXTERIORS,
+  MARKET_PAGE_SIZE,
+  MARKET_SEARCH_DEBOUNCE_MS,
+  MARKET_SORTS,
+  hasMarketFilters,
+  marketPath,
+  marketSearchEmptyTitle,
+  parseMarketQuery,
+  serializeMarketQuery,
+  type MarketQuery,
+} from "@/lib/marketQuery";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { marketSearchQuery, track } from "@/lib/analytics";
-
-const EXTERIORS = [
-  "",
-  "Factory New",
-  "Minimal Wear",
-  "Field-Tested",
-  "Well-Worn",
-  "Battle-Scarred",
-] as const;
-
-const SORTS = [
-  { value: "", label: "Padrão" },
-  { value: "price-asc", label: "Menor Preço" },
-  { value: "price-desc", label: "Maior Preço" },
-  { value: "float-asc", label: "Menor Float" },
-  { value: "float-desc", label: "Maior Float" },
-] as const;
-
-const PAGE_SIZE = 20;
 
 function Chip({
   active,
@@ -57,68 +50,118 @@ function Chip({
   );
 }
 
+function ExteriorShortcuts({
+  onPick,
+}: {
+  onPick?: (exterior: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap justify-center gap-1.5">
+      {MARKET_EXTERIORS.filter(Boolean).map((ext) => (
+        <Button key={ext} size="sm" variant="outline" asChild>
+          <Link
+            to={marketPath({ exterior: ext })}
+            onClick={() => onPick?.(ext)}
+          >
+            {ext}
+          </Link>
+        </Button>
+      ))}
+    </div>
+  );
+}
+
 export default function Products() {
-  const [searchParams] = useSearchParams();
-  const productId = searchParams.get("productId")?.trim() || undefined;
-  const [exterior, setExterior] = useState("");
-  const [isStattrak, setIsStattrak] = useState<boolean | undefined>(undefined);
-  const [sort, setSort] = useState("");
-  const [page, setPage] = useState(1);
-  const [minPrice, setMinPrice] = useState("");
-  const [maxPrice, setMaxPrice] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = parseMarketQuery(searchParams);
+  const [searchDraft, setSearchDraft] = useState(query.q);
+  const [minPriceDraft, setMinPriceDraft] = useState(query.minPrice);
+  const [maxPriceDraft, setMaxPriceDraft] = useState(query.maxPrice);
+  const [minFloatDraft, setMinFloatDraft] = useState(query.minFloat);
+  const [maxFloatDraft, setMaxFloatDraft] = useState(query.maxFloat);
+
+  useEffect(() => {
+    setSearchDraft(query.q);
+  }, [query.q]);
+
+  useEffect(() => {
+    setMinPriceDraft(query.minPrice);
+    setMaxPriceDraft(query.maxPrice);
+    setMinFloatDraft(query.minFloat);
+    setMaxFloatDraft(query.maxFloat);
+  }, [query.minPrice, query.maxPrice, query.minFloat, query.maxFloat]);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      const next = searchDraft.trim();
+      setSearchParams(
+        (prev) => {
+          const current = parseMarketQuery(prev);
+          if (next === current.q) return prev;
+          return serializeMarketQuery({ ...current, q: next, page: 1 });
+        },
+        { replace: true },
+      );
+    }, MARKET_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [searchDraft, setSearchParams]);
+
+  const writeQuery = (
+    patch: Partial<MarketQuery>,
+    history: { replace?: boolean } = {},
+  ) => {
+    setSearchParams(
+      (prev) => serializeMarketQuery({ ...parseMarketQuery(prev), ...patch }),
+      history,
+    );
+  };
 
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: [
-      "listings",
-      { page, exterior, isStattrak, sort, minPrice, maxPrice, productId },
-    ],
-    queryFn: () =>
-      listListings({
-        page,
-        limit: PAGE_SIZE,
-        status: "ACTIVE",
-        ...(productId ? { productId } : {}),
-        ...(exterior ? { exterior } : {}),
-        ...(isStattrak !== undefined ? { isStattrak } : {}),
-        ...(minPrice ? { minPrice: parseFloat(minPrice) } : {}),
-        ...(maxPrice ? { maxPrice: parseFloat(maxPrice) } : {}),
-      }),
+    queryKey: ["listings", "market", query],
+    queryFn: () => fetchMarketListings(query),
   });
 
   const items = data?.items ?? [];
   const total = data?.total ?? 0;
   const searchQuery = marketSearchQuery({
-    productId,
-    exterior,
-    isStattrak,
-    minPrice,
-    maxPrice,
+    q: query.q || undefined,
+    productId: query.productId,
+    exterior: query.exterior || undefined,
+    isStattrak: query.isStattrak,
+    minPrice: query.minPrice || undefined,
+    maxPrice: query.maxPrice || undefined,
   });
 
   useEffect(() => {
     if (!searchQuery || isLoading || isError) return;
     track("search", {
       query: searchQuery,
-      productId,
+      productId: query.productId,
       source: "market",
       resultCount: total,
     });
-  }, [searchQuery, productId, isLoading, isError, total]);
+  }, [searchQuery, query.productId, isLoading, isError, total]);
 
-  const sortedItems =
-    sort === "price-asc"
-      ? [...items].sort((a, b) => Number(a.price) - Number(b.price))
-      : sort === "price-desc"
-        ? [...items].sort((a, b) => Number(b.price) - Number(a.price))
-        : sort === "float-asc"
-          ? [...items].sort(
-              (a, b) => Number(a.floatValue) - Number(b.floatValue),
-            )
-          : sort === "float-desc"
-            ? [...items].sort(
-                (a, b) => Number(b.floatValue) - Number(a.floatValue),
-              )
-            : items;
+  const applyPriceFloat = () => {
+    writeQuery(
+      {
+        minPrice: minPriceDraft.trim(),
+        maxPrice: maxPriceDraft.trim(),
+        minFloat: minFloatDraft.trim(),
+        maxFloat: maxFloatDraft.trim(),
+        page: 1,
+      },
+      { replace: true },
+    );
+  };
+
+  const clearFilters = () => {
+    setSearchParams(new URLSearchParams());
+  };
+
+  const clearSearch = () => {
+    writeQuery({ q: "", page: 1 }, { replace: true });
+  };
 
   return (
     <div className="container py-8">
@@ -126,29 +169,43 @@ export default function Products() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Market</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            {productId
+            {query.productId
               ? "Listings ativos desta skin · item único"
               : "Listings ativos · item único"}
           </p>
         </div>
         {!isLoading && !isError ? (
           <p className="text-sm tabular-nums text-muted-foreground">
-            {total} resultado{total !== 1 ? "s" : ""}
+            {query.q
+              ? `${total} resultado${total !== 1 ? "s" : ""} para ${query.q}`
+              : `${total} resultado${total !== 1 ? "s" : ""}`}
           </p>
         ) : null}
       </div>
 
       <div className="mb-8 space-y-4 border-b border-border pb-6">
+        <div className="space-y-1.5">
+          <Label htmlFor="market-search">Buscar</Label>
+          <Input
+            id="market-search"
+            type="search"
+            value={searchDraft}
+            onChange={(event) => setSearchDraft(event.target.value)}
+            placeholder="Arma, skin ou coleção"
+            autoComplete="off"
+            aria-label="Buscar no Market"
+          />
+        </div>
+
         <fieldset className="space-y-1.5">
           <legend className="text-xs text-muted-foreground">Exterior</legend>
           <div className="flex flex-wrap gap-1.5">
-            {EXTERIORS.map((ext) => (
+            {MARKET_EXTERIORS.map((ext) => (
               <Chip
                 key={ext || "all"}
-                active={exterior === ext}
+                active={query.exterior === ext}
                 onClick={() => {
-                  setExterior(ext);
-                  setPage(1);
+                  writeQuery({ exterior: ext, page: 1 });
                   if (ext) {
                     track("category_view", {
                       category: ext,
@@ -176,11 +233,8 @@ export default function Products() {
               ).map(({ value, label }) => (
                 <Chip
                   key={String(value)}
-                  active={isStattrak === value}
-                  onClick={() => {
-                    setIsStattrak(value);
-                    setPage(1);
-                  }}
+                  active={query.isStattrak === value}
+                  onClick={() => writeQuery({ isStattrak: value, page: 1 })}
                 >
                   {label}
                 </Chip>
@@ -200,8 +254,8 @@ export default function Products() {
                 id="minPrice"
                 type="number"
                 placeholder="Mín"
-                value={minPrice}
-                onChange={(e) => setMinPrice(e.target.value)}
+                value={minPriceDraft}
+                onChange={(e) => setMinPriceDraft(e.target.value)}
                 className="w-24"
               />
               <span className="text-sm text-muted-foreground">–</span>
@@ -212,11 +266,51 @@ export default function Products() {
                 id="maxPrice"
                 type="number"
                 placeholder="Máx"
-                value={maxPrice}
-                onChange={(e) => setMaxPrice(e.target.value)}
+                value={maxPriceDraft}
+                onChange={(e) => setMaxPriceDraft(e.target.value)}
                 className="w-24"
               />
-              <Button size="sm" variant="outline" onClick={() => setPage(1)}>
+            </div>
+          </fieldset>
+
+          <fieldset className="space-y-1.5">
+            <legend className="text-xs text-muted-foreground">Float</legend>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="minFloat" className="sr-only">
+                Float mínimo
+              </Label>
+              <Input
+                id="minFloat"
+                type="number"
+                step="0.01"
+                min="0"
+                max="1"
+                placeholder="0.00"
+                value={minFloatDraft}
+                onChange={(e) => setMinFloatDraft(e.target.value)}
+                className="w-24"
+              />
+              <span className="text-sm text-muted-foreground">–</span>
+              <Label htmlFor="maxFloat" className="sr-only">
+                Float máximo
+              </Label>
+              <Input
+                id="maxFloat"
+                type="number"
+                step="0.01"
+                min="0"
+                max="1"
+                placeholder="1.00"
+                value={maxFloatDraft}
+                onChange={(e) => setMaxFloatDraft(e.target.value)}
+                className="w-24"
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                type="button"
+                onClick={applyPriceFloat}
+              >
                 <Filter className="mr-1 h-3 w-3" />
                 Filtrar
               </Button>
@@ -227,17 +321,28 @@ export default function Products() {
         <fieldset className="space-y-1.5">
           <legend className="text-xs text-muted-foreground">Ordenar</legend>
           <div className="flex flex-wrap gap-1.5">
-            {SORTS.map(({ value, label }) => (
+            {MARKET_SORTS.map(({ value, label }) => (
               <Chip
                 key={value || "default"}
-                active={sort === value}
-                onClick={() => setSort(value)}
+                active={query.sort === value}
+                onClick={() => writeQuery({ sort: value, page: 1 })}
               >
                 {label}
               </Chip>
             ))}
           </div>
         </fieldset>
+
+        {hasMarketFilters(query) ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={clearFilters}
+          >
+            Limpar filtros
+          </Button>
+        ) : null}
       </div>
 
       {isLoading && (
@@ -266,8 +371,26 @@ export default function Products() {
 
       {!isLoading &&
         !isError &&
-        sortedItems.length === 0 &&
-        (productId ? (
+        items.length === 0 &&
+        (query.q ? (
+          <EmptyState
+            title={marketSearchEmptyTitle(query.q)}
+            description="Tente outro termo, limpe a busca ou escolha um exterior."
+            action={
+              <div className="flex flex-col items-center gap-3">
+                <div className="flex flex-wrap justify-center gap-2">
+                  <Button type="button" variant="outline" onClick={clearSearch}>
+                    Limpar busca
+                  </Button>
+                  <Button asChild>
+                    <Link to="/products">Explorar Market</Link>
+                  </Button>
+                </div>
+                <ExteriorShortcuts />
+              </div>
+            }
+          />
+        ) : query.productId ? (
           <EmptyState
             title={MARKET_SIMILAR_EMPTY_TITLE}
             description={MARKET_SIMILAR_EMPTY_DESCRIPTION}
@@ -281,34 +404,48 @@ export default function Products() {
           <EmptyState
             title="Nenhum item encontrado"
             description="Tente ajustar os filtros"
+            action={
+              hasMarketFilters(query) ? (
+                <div className="flex flex-col items-center gap-3">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={clearFilters}
+                  >
+                    Limpar filtros
+                  </Button>
+                  <ExteriorShortcuts />
+                </div>
+              ) : undefined
+            }
           />
         ))}
 
-      {!isLoading && !isError && sortedItems.length > 0 && (
+      {!isLoading && !isError && items.length > 0 && (
         <>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-            {sortedItems.map((listing) => (
+            {items.map((listing) => (
               <ListingCard key={listing.id} listing={listing} source="market" />
             ))}
           </div>
-          {total > PAGE_SIZE && (
+          {total > MARKET_PAGE_SIZE && (
             <div className="mt-8 flex justify-center gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                disabled={page === 1}
-                onClick={() => setPage((p) => p - 1)}
+                disabled={query.page === 1}
+                onClick={() => writeQuery({ page: query.page - 1 })}
               >
                 Anterior
               </Button>
               <span className="self-center text-sm tabular-nums text-muted-foreground">
-                Página {page}
+                Página {query.page}
               </span>
               <Button
                 variant="outline"
                 size="sm"
-                disabled={page * PAGE_SIZE >= total}
-                onClick={() => setPage((p) => p + 1)}
+                disabled={query.page * MARKET_PAGE_SIZE >= total}
+                onClick={() => writeQuery({ page: query.page + 1 })}
               >
                 Próxima
               </Button>

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -195,6 +195,14 @@ describe("Index", () => {
     expect(marketLinks.length).toBeGreaterThan(1);
     expect(marketLinks[0]).toHaveAttribute("href", "/products");
 
+    expect(screen.getByRole("link", { name: "Factory New" })).toHaveAttribute(
+      "href",
+      "/products?exterior=Factory+New",
+    );
+    expect(screen.getByRole("link", { name: "Minimal Wear" })).toHaveAttribute(
+      "href",
+      "/products?exterior=Minimal+Wear",
+    );
     expect(
       screen.getByRole("link", { name: "AK-47 | Redline" }),
     ).toHaveAttribute("href", similarItemsMarketPath("ak-redline-ft"));

--- a/src/pages/__tests__/Products.test.tsx
+++ b/src/pages/__tests__/Products.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useSearchParams } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Products from "../Products";
 import { CartProvider } from "@/contexts/CartContext";
@@ -18,9 +18,14 @@ import {
 } from "@/lib/analytics";
 
 const listListings = vi.fn();
+const listProducts = vi.fn();
 
 vi.mock("@/api/listings", () => ({
   listListings: (...args: unknown[]) => listListings(...args),
+}));
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
 }));
 
 vi.mock("@/hooks/use-toast", () => ({
@@ -65,6 +70,11 @@ function makeListing(overrides: Partial<Listing> = {}): Listing {
   };
 }
 
+function LocationEcho() {
+  const [params] = useSearchParams();
+  return <div data-testid="market-query">{params.toString()}</div>;
+}
+
 function renderMarket(path = "/products") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -74,7 +84,15 @@ function renderMarket(path = "/products") {
       <MemoryRouter initialEntries={[path]}>
         <CartProvider>
           <Routes>
-            <Route path="/products" element={<Products />} />
+            <Route
+              path="/products"
+              element={
+                <>
+                  <LocationEcho />
+                  <Products />
+                </>
+              }
+            />
           </Routes>
         </CartProvider>
       </MemoryRouter>
@@ -92,6 +110,13 @@ describe("Products", () => {
       analyticsEvents.push({ event, props });
     });
     listListings.mockReset();
+    listProducts.mockReset();
+    listProducts.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 100,
+    });
     localStorage.removeItem(CART_STORAGE_KEY);
   });
 
@@ -245,5 +270,194 @@ describe("Products", () => {
       event: "category_view",
       props: { category: "Factory New", source: "market" },
     });
+    expect(screen.getByTestId("market-query").textContent).toBe(
+      "exterior=Factory+New",
+    );
+  });
+
+  it("restores chips and page from the Market URL", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 40,
+      page: 2,
+      limit: 20,
+    });
+
+    renderMarket("/products?exterior=Minimal+Wear&page=2&sort=price-asc");
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Minimal Wear" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Menor Preço" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Página 2")).toBeTruthy();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 2,
+      limit: 20,
+      status: "ACTIVE",
+      exterior: "Minimal Wear",
+    });
+    expect(listProducts).not.toHaveBeenCalled();
+  });
+
+  it("ignores invalid query params without crashing", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket(
+      "/products?page=nope&sort=newest&exterior=Glossy&stattrak=maybe",
+    );
+
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+    });
+    expect(screen.getAllByRole("button", { name: "Todos" })[0]).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("resolves textual search via GET /products and ACTIVE listings", async () => {
+    listProducts.mockResolvedValue({
+      items: [
+        {
+          id: "talon-fade-fn",
+          game: "CS2",
+          weapon: "Talon Knife",
+          skinName: "Fade",
+          rarity: "Covert",
+          exterior: "Factory New",
+          collection: null,
+          imageUrl: null,
+          isStattrak: false,
+          isSouvenir: false,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 100,
+    });
+    listListings.mockResolvedValue({
+      items: [
+        makeListing({
+          id: "listing-talon",
+          productId: "talon-fade-fn",
+          product: {
+            id: "talon-fade-fn",
+            game: "CS2",
+            weapon: "Talon Knife",
+            skinName: "Fade",
+            rarity: "Covert",
+            exterior: "Factory New",
+            collection: null,
+            imageUrl: null,
+            isStattrak: false,
+            isSouvenir: false,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        }),
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?q=talon");
+
+    expect(
+      await screen.findByText("Talon Knife | Fade (Factory New)"),
+    ).toBeTruthy();
+    expect(screen.getByText("1 resultado para talon")).toBeTruthy();
+    expect(screen.getByLabelText("Buscar no Market")).toHaveValue("talon");
+    expect(listProducts).toHaveBeenCalledWith({ search: "talon", limit: 100 });
+    expect(listListings).toHaveBeenCalledWith({
+      page: 1,
+      limit: 20,
+      status: "ACTIVE",
+      productId: "talon-fade-fn",
+    });
+  });
+
+  it("shows a search empty state with clear and exterior shortcuts", async () => {
+    listProducts.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 100,
+    });
+
+    renderMarket("/products?q=zzzz");
+
+    expect(await screen.findByText("Nenhum listing para ‘zzzz’")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Limpar busca" })).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Explorar Market" }),
+    ).toHaveAttribute("href", "/products");
+    expect(screen.getByRole("link", { name: "Factory New" })).toHaveAttribute(
+      "href",
+      "/products?exterior=Factory+New",
+    );
+    expect(listListings).not.toHaveBeenCalled();
+  });
+
+  it("debounces the Market search field into the q param", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket();
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Buscar no Market"), {
+      target: { value: "huntsman" },
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("market-query").textContent).toBe(
+          "q=huntsman",
+        );
+      },
+      { timeout: 1500 },
+    );
+  });
+
+  it("clears filters back to the default catalog URL", async () => {
+    listListings.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?exterior=Field-Tested&stattrak=true");
+
+    expect(await screen.findByText("Nenhum item encontrado")).toBeTruthy();
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Limpar filtros" })[0],
+    );
+    expect(screen.getByTestId("market-query").textContent).toBe("");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #91
Closes #92

- #91: header + Market search via existing `GET /products?search=` then ACTIVE listings by `productId`. No listings search API.
- #92: Market state is the URL (`q`, exterior, StatTrak, prices, sort, page). Home chips deep-link.

#93 (server sort) not in this PR.

`npm run typecheck` / `lint` / `test` → 392 passed.

[Market search q=talon](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmarket-search-q-talon.png)
[URL restores exterior filter](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmarket-url-minimal-wear.png)

Do not merge from this agent.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

