### PR TITLE
#93 #103 #106 — Listings sort, weapon/rarity filters, and favorites API

### DIFF
--- a/docs/adr/0006-hot-path-indexes.md
+++ b/docs/adr/0006-hot-path-indexes.md
@@ -27,3 +27,7 @@ Existing single-column `Listing(status)` and `Order(paymentStatus)` indexes do n
 ## Later change (issue #49)
 
 `GET /listings` now orders by `createdAt DESC, id DESC`. `Listing(status, createdAt)` was replaced by `Listing(status, createdAt, id)` so the market keyset uses the same index. `Listing(createdAt, id)` covers unfiltered lists. See ADR 0013.
+
+## Later change (issue #93)
+
+Offset `GET /listings` accepts `sort=price_asc|price_desc|float_asc|float_desc` in addition to default `createdAt_desc`. `Listing(status, price, id)` and `Listing(status, floatValue, id)` cover those orderings. Cursor mode is unchanged.

--- a/docs/architecture/api-versioning.md
+++ b/docs/architecture/api-versioning.md
@@ -21,7 +21,7 @@ The storefront may keep calling unversioned paths. New integrations should call 
 
 Domain module routes mounted from `server/src/app.ts`:
 
-`/auth`, `/users`, `/sellers`, `/products`, `/listings`, `/orders`, `/payments`, `/commissions`, `/reviews`, `/admin`
+`/auth`, `/users`, `/sellers`, `/products`, `/listings`, `/orders`, `/payments`, `/commissions`, `/reviews`, `/favorites`, `/admin`
 
 That includes authenticated and admin routes. “Public” here means the HTTP API exposed to clients, not “unauthenticated only”.
 

--- a/docs/architecture/c4.md
+++ b/docs/architecture/c4.md
@@ -160,7 +160,7 @@ Some services still call Prisma directly; that is a known inconsistency, not a s
         ┌──────────┬──────────┬─────┴──────┬──────────┐
         │ auth     │ users    │ sellers    │ products (Catalog) │
         │ listings │ orders   │ payments   │ commissions (Ledger)│
-        │ reviews  │ admin    │ audit      │                    │
+        │ reviews  │ favorites│ admin      │ audit              │
         └──────────┴──────────┴────────────┴──────────┘
                                     │
                     shared: jwt, hash, paypal client,
@@ -179,7 +179,7 @@ C4Component
     Component(listings, "listings", "modules/listings", "Unique items; reserve/expire")
     Component(orders, "orders", "modules/orders", "Checkout + Idempotency-Key")
     Component(payments, "payments", "modules/payments", "PaymentLink, webhook, confirmPayment")
-    Component(other, "other domains", "users, sellers, products/Catalog, commissions/Ledger, reviews, admin, audit")
+    Component(other, "other domains", "users, sellers, products/Catalog, commissions/Ledger, reviews, favorites, admin, audit")
     Component(jobs, "in-process jobs", "shared/jobs", "Expiry + PayPal GET + seller ledger reconcile + outbox")
     Component(paypalc, "PayPal adapter", "shared/utils", "Create/capture/GET; webhook RSA-SHA256")
     ComponentDb(db, "PostgreSQL", "Prisma")

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -22,6 +22,7 @@ Express API
        +--> payments
        +--> commissions   (Ledger)
        +--> reviews
+       +--> favorites
        +--> admin
        +--> audit         (supporting)
        |
@@ -66,7 +67,7 @@ This is not an emergency rewrite target. Agents should avoid broad refactors. Wh
 
 PostgreSQL is the source of truth for business state. Prisma is the data-access layer.
 
-The schema contains the main marketplace entities: users, pending registrations, sellers, products, listings, orders, order items, seller transactions, payment webhook events, reviews, refresh-token families (`RefreshToken`), per-email login throttle (`LoginThrottle`), an append-only `AuditLog`, and a transactional `OutboxEvent` table. `Product.marketHashName` is the unique cs2.sh/Steam key when a row was imported; `referencePriceUsd` is catalog USD ask and is not ledger currency (`docs/adr/0014-cs2sh-catalog-import.md`). Listings contain reservation fields `reservedAt`, `reservationExpiresAt` and `reservedByOrderId`. `PaymentWebhookEvent` stores PayPal event identity with a unique `(provider, externalEventId)` constraint. Critical lifecycle columns (`User.role`, `Order.status`, `Order.paymentStatus`, `Listing.status`, payment-link and idempotency claim status, webhook processing status/provider, seller-transaction status, outbox processing status) are PostgreSQL enums. PayPal `eventType` stays text so unknown provider events can be persisted and ignored. See `docs/adr/0009-prisma-domain-enums.md`. `AuditLog` records ADMIN/seller listing/order/payment mutations with ADMIN-only read access and a 365-day retention policy (`docs/adr/0010-audit-log.md`). `OutboxEvent` is inserted in the same local transaction as payment confirmation and published by an in-process skip-locked dispatcher (`docs/adr/0012-transactional-outbox.md`).
+The schema contains the main marketplace entities: users, pending registrations, sellers, products, listings, orders, order items, seller transactions, payment webhook events, reviews, customer favorites (`Favorite`, unique `(userId, listingId)`), refresh-token families (`RefreshToken`), per-email login throttle (`LoginThrottle`), an append-only `AuditLog`, and a transactional `OutboxEvent` table. `Product.marketHashName` is the unique cs2.sh/Steam key when a row was imported; `referencePriceUsd` is catalog USD ask and is not ledger currency (`docs/adr/0014-cs2sh-catalog-import.md`). Listings contain reservation fields `reservedAt`, `reservationExpiresAt` and `reservedByOrderId`. `PaymentWebhookEvent` stores PayPal event identity with a unique `(provider, externalEventId)` constraint. Critical lifecycle columns (`User.role`, `Order.status`, `Order.paymentStatus`, `Listing.status`, payment-link and idempotency claim status, webhook processing status/provider, seller-transaction status, outbox processing status) are PostgreSQL enums. PayPal `eventType` stays text so unknown provider events can be persisted and ignored. See `docs/adr/0009-prisma-domain-enums.md`. `AuditLog` records ADMIN/seller listing/order/payment mutations with ADMIN-only read access and a 365-day retention policy (`docs/adr/0010-audit-log.md`). `OutboxEvent` is inserted in the same local transaction as payment confirmation and published by an in-process skip-locked dispatcher (`docs/adr/0012-transactional-outbox.md`).
 
 ## Critical workflows
 

--- a/docs/architecture/modular-monolith.md
+++ b/docs/architecture/modular-monolith.md
@@ -19,6 +19,7 @@ This is one Express API process and one PostgreSQL database. Modules are folders
 | Payments | `modules/payments` | PaymentLink, webhook claim, capture, `confirmPayment`, PayPal GET reconcile |
 | Ledger | `modules/commissions` | `Seller.balance` projection reads and projection-only reconcile |
 | Reviews | `modules/reviews` | Product reviews |
+| Favorites | `modules/favorites` | Account-owned saved listings (`GET/POST /favorites`, `DELETE /favorites/:listingId`) |
 | Admin | `modules/admin` | ADMIN composition: users, orders, seller approval, audit read, catalog import |
 | Audit | `modules/audit` | Append-only `AuditLog` (supporting; not a marketplace domain) |
 

--- a/server/prisma/migrations/20260906180000_listing_sort_indexes_and_favorites/migration.sql
+++ b/server/prisma/migrations/20260906180000_listing_sort_indexes_and_favorites/migration.sql
@@ -1,0 +1,25 @@
+-- GET /listings?sort=price_* / float_* (issue #93 / ADR 0006).
+-- Left-prefix still serves status-only filters; id is the sort tie-breaker.
+
+CREATE INDEX "Listing_status_price_id_idx" ON "Listing"("status", "price", "id");
+CREATE INDEX "Listing_status_floatValue_id_idx" ON "Listing"("status", "floatValue", "id");
+
+-- Customer favorites (issue #106 / SPEC-0004). Unique (userId, listingId).
+-- Cascade on user/listing hard-delete; listing lifecycle (SOLD/CANCELED)
+-- never removes the relation. Writes do not touch reservation or payment.
+
+CREATE TABLE "Favorite" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "listingId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Favorite_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "Favorite_userId_listingId_key" ON "Favorite"("userId", "listingId");
+CREATE INDEX "Favorite_userId_createdAt_idx" ON "Favorite"("userId", "createdAt");
+CREATE INDEX "Favorite_listingId_idx" ON "Favorite"("listingId");
+
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Favorite" ADD CONSTRAINT "Favorite_listingId_fkey" FOREIGN KEY ("listingId") REFERENCES "Listing"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -74,6 +74,7 @@ model User {
   orderIdempotencyKeys OrderIdempotencyKey[]
   reviews              Review[]
   refreshTokens        RefreshToken[]
+  favorites            Favorite[]
 }
 
 // Pending sign-up: user is created only after email verification (code confirmation)
@@ -229,6 +230,7 @@ model Listing {
   seller       Seller         @relation(fields: [sellerId], references: [id], onDelete: Cascade)
   priceHistory PriceHistory[]
   orderItems   OrderItem[]
+  favorites    Favorite[]
 
   @@index([productId])
   @@index([price])
@@ -237,8 +239,26 @@ model Listing {
   @@index([productId, status])
   @@index([createdAt, id])
   @@index([status, createdAt, id])
+  @@index([status, price, id])
+  @@index([status, floatValue, id])
   @@index([status, reservationExpiresAt])
   @@index([reservedByOrderId])
+}
+
+/// Account-owned saved listing. Unique (userId, listingId). Does not reserve,
+/// buy, or change Listing status (SPEC-0004 / issue #106).
+model Favorite {
+  id        String   @id @default(cuid())
+  userId    String
+  listingId String
+  createdAt DateTime @default(now())
+
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  listing Listing @relation(fields: [listingId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, listingId])
+  @@index([userId, createdAt])
+  @@index([listingId])
 }
 
 model PriceHistory {

--- a/server/src/__tests__/favorites.integration.test.ts
+++ b/server/src/__tests__/favorites.integration.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import { Prisma } from "@prisma/client";
+import { app } from "../app.js";
+import { prisma } from "../shared/database/index.js";
+import { signAccessToken } from "../shared/utils/jwt.js";
+import { API_V1_PREFIX } from "../shared/http/apiVersion.js";
+import { createListing, createProduct, createSeller, createUser } from "./helpers/index.js";
+
+function listen() {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function authHeader(user: { id: string; email: string; role: "CUSTOMER" | "SELLER" | "ADMIN" }) {
+  return `Bearer ${signAccessToken({ sub: user.id, email: user.email, role: user.role })}`;
+}
+
+describe("favorites API (postgres, #106 / SPEC-0004)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    process.env.RATE_LIMIT_API_MAX = "10000";
+    server = await listen();
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  async function seedCustomerAndListing(status: "ACTIVE" | "SOLD" = "ACTIVE") {
+    const customer = await createUser({ role: "CUSTOMER" });
+    const seller = await createSeller();
+    const product = await createProduct();
+    const listing = await createListing({
+      productId: product.id,
+      sellerId: seller.id,
+      status,
+    });
+    return { customer, listing };
+  }
+
+  it("enforces unique (userId, listingId) in PostgreSQL", async () => {
+    const { customer, listing } = await seedCustomerAndListing();
+    await prisma.favorite.create({ data: { userId: customer.id, listingId: listing.id } });
+
+    let caught: unknown;
+    try {
+      await prisma.favorite.create({ data: { userId: customer.id, listingId: listing.id } });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+    expect((caught as Prisma.PrismaClientKnownRequestError).code).toBe("P2002");
+    expect(await prisma.favorite.count({ where: { userId: customer.id } })).toBe(1);
+  });
+
+  it("rejects concurrent duplicate inserts with one P2002 and one row", async () => {
+    const { customer, listing } = await seedCustomerAndListing();
+    const payload = { userId: customer.id, listingId: listing.id };
+    const results = await Promise.allSettled([
+      prisma.favorite.create({ data: payload }),
+      prisma.favorite.create({ data: payload }),
+    ]);
+    const fulfilled = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({ code: "P2002" });
+    expect(await prisma.favorite.count({ where: payload })).toBe(1);
+  });
+
+  it("returns 401 without a JWT on /favorites and /api/v1/favorites", async () => {
+    const [alias, versioned] = await Promise.all([
+      fetch(`${baseUrl}/favorites`),
+      fetch(`${baseUrl}${API_V1_PREFIX}/favorites`),
+    ]);
+    expect(alias.status).toBe(401);
+    expect(versioned.status).toBe(401);
+  });
+
+  it("returns 403 for a SELLER token", async () => {
+    const sellerUser = await createUser({ role: "SELLER" });
+    const response = await fetch(`${baseUrl}${API_V1_PREFIX}/favorites`, {
+      headers: { Authorization: authHeader({ ...sellerUser, role: "SELLER" }) },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("POST is idempotent and GET is owner-scoped", async () => {
+    const { customer, listing } = await seedCustomerAndListing();
+    const other = await createUser({ role: "CUSTOMER" });
+    const headers = {
+      Authorization: authHeader({ ...customer, role: "CUSTOMER" }),
+      "Content-Type": "application/json",
+    };
+
+    const first = await fetch(`${baseUrl}${API_V1_PREFIX}/favorites`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ listingId: listing.id, userId: other.id }),
+    });
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toEqual({ listingId: listing.id });
+
+    const duplicate = await fetch(`${baseUrl}/favorites`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ listingId: listing.id }),
+    });
+    expect(duplicate.status).toBe(200);
+    await expect(duplicate.json()).resolves.toEqual({ listingId: listing.id });
+    expect(await prisma.favorite.count({ where: { userId: customer.id, listingId: listing.id } })).toBe(1);
+    expect(await prisma.favorite.count({ where: { userId: other.id } })).toBe(0);
+
+    const ownerList = await fetch(`${baseUrl}${API_V1_PREFIX}/favorites`, {
+      headers: { Authorization: authHeader({ ...customer, role: "CUSTOMER" }) },
+    });
+    expect(ownerList.status).toBe(200);
+    const ownerBody = (await ownerList.json()) as { items: Array<{ listingId: string }> };
+    expect(ownerBody.items.map((item) => item.listingId)).toEqual([listing.id]);
+
+    const otherList = await fetch(`${baseUrl}/favorites`, {
+      headers: { Authorization: authHeader({ ...other, role: "CUSTOMER" }) },
+    });
+    expect(otherList.status).toBe(200);
+    await expect(otherList.json()).resolves.toEqual({ items: [] });
+  });
+
+  it("cannot delete another customer's favorite and repeated DELETE is 204", async () => {
+    const { customer, listing } = await seedCustomerAndListing();
+    const other = await createUser({ role: "CUSTOMER" });
+    await prisma.favorite.create({ data: { userId: customer.id, listingId: listing.id } });
+
+    const strangerDelete = await fetch(`${baseUrl}${API_V1_PREFIX}/favorites/${listing.id}`, {
+      method: "DELETE",
+      headers: { Authorization: authHeader({ ...other, role: "CUSTOMER" }) },
+    });
+    expect(strangerDelete.status).toBe(204);
+    expect(await prisma.favorite.count({ where: { userId: customer.id, listingId: listing.id } })).toBe(1);
+
+    const ownerDelete = await fetch(`${baseUrl}/favorites/${listing.id}`, {
+      method: "DELETE",
+      headers: { Authorization: authHeader({ ...customer, role: "CUSTOMER" }) },
+    });
+    expect(ownerDelete.status).toBe(204);
+    expect(await prisma.favorite.count({ where: { userId: customer.id, listingId: listing.id } })).toBe(0);
+
+    const again = await fetch(`${baseUrl}${API_V1_PREFIX}/favorites/${listing.id}`, {
+      method: "DELETE",
+      headers: { Authorization: authHeader({ ...customer, role: "CUSTOMER" }) },
+    });
+    expect(again.status).toBe(204);
+  });
+
+  it("returns 404 for a missing listing and does not change listing status", async () => {
+    const { customer, listing } = await seedCustomerAndListing("SOLD");
+    const headers = {
+      Authorization: authHeader({ ...customer, role: "CUSTOMER" }),
+      "Content-Type": "application/json",
+    };
+
+    const missing = await fetch(`${baseUrl}${API_V1_PREFIX}/favorites`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ listingId: "clmissinglistingid0000000001" }),
+    });
+    expect(missing.status).toBe(404);
+
+    const saved = await fetch(`${baseUrl}/favorites`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ listingId: listing.id }),
+    });
+    expect(saved.status).toBe(200);
+    const after = await prisma.listing.findUnique({ where: { id: listing.id } });
+    expect(after?.status).toBe("SOLD");
+  });
+});

--- a/server/src/__tests__/helpers/factories.ts
+++ b/server/src/__tests__/helpers/factories.ts
@@ -43,16 +43,19 @@ export async function createSeller(userId?: string) {
 
 export async function createProduct(overrides: {
   skinName?: string;
+  weapon?: string;
+  rarity?: string;
+  game?: string;
   createdAt?: Date;
   id?: string;
 } = {}) {
   return prisma.product.create({
     data: {
       ...(overrides.id ? { id: overrides.id } : {}),
-      game: "CS2",
-      weapon: "AK-47",
+      game: overrides.game ?? "CS2",
+      weapon: overrides.weapon ?? "AK-47",
       skinName: overrides.skinName ?? `Skin ${uniqueSuffix()}`,
-      rarity: "Classified",
+      rarity: overrides.rarity ?? "Classified",
       exterior: "Field-Tested",
       ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
     },

--- a/server/src/__tests__/helpers/lifecycle.ts
+++ b/server/src/__tests__/helpers/lifecycle.ts
@@ -13,6 +13,7 @@ import { prisma } from "../../shared/database/index.js";
  * `deleteMany` chains copied across files.
  */
 export const BUSINESS_TABLES = [
+  "Favorite",
   "Review",
   "SellerTransaction",
   "PaymentWebhookEvent",

--- a/server/src/__tests__/listings.filters.integration.test.ts
+++ b/server/src/__tests__/listings.filters.integration.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import express from "express";
+import { errorHandler } from "../shared/errors/index.js";
+import { listingsRoutes } from "../modules/listings/listings.routes.js";
+import { listingsRepository } from "../modules/listings/listings.repository.js";
+import { createListing, createProduct, createSeller } from "./helpers/index.js";
+
+function listen(app: express.Express) {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+describe("GET /listings weapon/rarity filters (postgres, #103)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use("/listings", listingsRoutes);
+    app.use(errorHandler);
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it("GET /listings?weapon=AK-47 returns only AK-47 listings", async () => {
+    const seller = await createSeller();
+    const ak = await createProduct({ weapon: "AK-47", rarity: "Classified" });
+    const awp = await createProduct({ weapon: "AWP", rarity: "Covert" });
+    const akListing = await createListing({ productId: ak.id, sellerId: seller.id, price: "18.00" });
+    await createListing({ productId: awp.id, sellerId: seller.id, price: "110.00" });
+
+    const response = await fetch(`${baseUrl}/listings?weapon=AK-47`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { items: Array<{ id: string; product: { weapon: string } }> };
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]?.id).toBe(akListing.id);
+    expect(body.items[0]?.product.weapon).toBe("AK-47");
+  });
+
+  it("repository filters Product.rarity and Product.game", async () => {
+    const seller = await createSeller();
+    const covert = await createProduct({ weapon: "AWP", rarity: "Covert", game: "CS2" });
+    const classified = await createProduct({ weapon: "AK-47", rarity: "Classified", game: "CS2" });
+    const csgo = await createProduct({ weapon: "AWP", rarity: "Covert", game: "CSGO" });
+    const covertListing = await createListing({ productId: covert.id, sellerId: seller.id });
+    await createListing({ productId: classified.id, sellerId: seller.id });
+    await createListing({ productId: csgo.id, sellerId: seller.id });
+
+    const byRarity = await listingsRepository.findMany({
+      skip: 0,
+      take: 20,
+      where: { product: { rarity: { equals: "Covert", mode: "insensitive" } } },
+    });
+    expect(byRarity.items.map((row) => row.product.rarity).every((rarity) => rarity === "Covert")).toBe(true);
+    expect(byRarity.total).toBe(2);
+
+    const byGame = await listingsRepository.findMany({
+      skip: 0,
+      take: 20,
+      where: { product: { game: { equals: "CSGO", mode: "insensitive" } } },
+    });
+    expect(byGame.items).toHaveLength(1);
+    expect(byGame.items[0]?.productId).toBe(csgo.id);
+    expect(byRarity.items.some((row) => row.id === covertListing.id)).toBe(true);
+  });
+});

--- a/server/src/__tests__/listings.sort.integration.test.ts
+++ b/server/src/__tests__/listings.sort.integration.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Server } from "node:http";
+import express from "express";
+import { errorHandler } from "../shared/errors/index.js";
+import { listingsRoutes } from "../modules/listings/listings.routes.js";
+import { listingsRepository } from "../modules/listings/listings.repository.js";
+import { listingsService } from "../modules/listings/listings.service.js";
+import { LISTING_SORTS, listingOrderBy } from "../modules/listings/listings.sort.js";
+import { createListing, createProduct, createSeller } from "./helpers/index.js";
+
+function listen(app: express.Express) {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function seedPricedListings() {
+  const seller = await createSeller();
+  const product = await createProduct();
+  const cheap = await createListing({
+    id: "listing-cheap",
+    productId: product.id,
+    sellerId: seller.id,
+    price: "10.00",
+    floatValue: "0.40",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  const mid = await createListing({
+    id: "listing-mid",
+    productId: product.id,
+    sellerId: seller.id,
+    price: "20.00",
+    floatValue: "0.20",
+    createdAt: new Date("2026-01-02T00:00:00.000Z"),
+  });
+  const expensive = await createListing({
+    id: "listing-expensive",
+    productId: product.id,
+    sellerId: seller.id,
+    price: "50.00",
+    floatValue: "0.05",
+    createdAt: new Date("2026-01-03T00:00:00.000Z"),
+  });
+  return { cheap, mid, expensive };
+}
+
+describe("GET /listings sort (postgres, #93)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use("/listings", listingsRoutes);
+    app.use(errorHandler);
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it("repository applies each whitelist orderBy to the full catalog", async () => {
+    const { cheap, mid, expensive } = await seedPricedListings();
+    const expected: Record<(typeof LISTING_SORTS)[number], string[]> = {
+      createdAt_desc: [expensive.id, mid.id, cheap.id],
+      price_asc: [cheap.id, mid.id, expensive.id],
+      price_desc: [expensive.id, mid.id, cheap.id],
+      float_asc: [expensive.id, mid.id, cheap.id],
+      float_desc: [cheap.id, mid.id, expensive.id],
+    };
+
+    for (const sort of LISTING_SORTS) {
+      const { items } = await listingsRepository.findMany({
+        skip: 0,
+        take: 10,
+        orderBy: listingOrderBy(sort),
+      });
+      expect(items.map((row) => row.id), sort).toEqual(expected[sort]);
+    }
+  });
+
+  it("service.list price_asc puts the cheapest listing on page 1 when it would be on page 2 by createdAt", async () => {
+    const { cheap, expensive } = await seedPricedListings();
+
+    const newestFirst = await listingsService.list({ page: 1, limit: 1, sort: "createdAt_desc" });
+    expect(newestFirst.items.map((row) => row.id)).toEqual([expensive.id]);
+
+    const cheapestFirst = await listingsService.list({ page: 1, limit: 1, sort: "price_asc" });
+    expect(cheapestFirst.items.map((row) => row.id)).toEqual([cheap.id]);
+
+    const page2 = await listingsService.list({ page: 2, limit: 1, sort: "price_asc" });
+    expect(page2.items[0]?.id).not.toBe(cheap.id);
+  });
+
+  it("HTTP offset sort=price_asc returns the cheapest ACTIVE listing on page 1", async () => {
+    const { cheap } = await seedPricedListings();
+    const response = await fetch(`${baseUrl}/listings?sort=price_asc&page=1&limit=1`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { items: Array<{ id: string }> };
+    expect(body.items.map((row) => row.id)).toEqual([cheap.id]);
+  });
+});

--- a/server/src/__tests__/openapi.http.contract.test.ts
+++ b/server/src/__tests__/openapi.http.contract.test.ts
@@ -97,6 +97,7 @@ describe("OpenAPI document (single spec)", () => {
       "/auth/me",
       "/listings",
       "/products",
+      "/favorites",
       "/orders",
       "/payments/webhook",
       "/admin/audit-logs",
@@ -373,6 +374,10 @@ describe("HTTP handlers vs OpenAPI", () => {
     const overLimit = await fetch(`${baseUrl}${API_V1_PREFIX}/listings?limit=101`);
     expect(overLimit.status).toBe(400);
     assertErrorBody(await jsonOf(overLimit), spec);
+
+    const invalidSort = await fetch(`${baseUrl}${API_V1_PREFIX}/listings?sort=newest`);
+    expect(invalidSort.status).toBe(400);
+    assertErrorBody(await jsonOf(invalidSort), spec);
   });
 
   it("keeps unversioned /listings as a v1 compatibility alias of the same pagination contract", async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -17,6 +17,7 @@ import { ordersRoutes } from "./modules/orders/orders.routes.js";
 import { paymentsRoutes } from "./modules/payments/payments.routes.js";
 import { commissionsRoutes } from "./modules/commissions/commissions.routes.js";
 import { reviewsRoutes } from "./modules/reviews/reviews.routes.js";
+import { favoritesRoutes } from "./modules/favorites/favorites.routes.js";
 import { adminRoutes } from "./modules/admin/admin.routes.js";
 import { getAllowedCorsOrigins, isCorsOriginAllowed } from "./shared/config/cors.js";
 import { API_V1_PREFIX } from "./shared/http/apiVersion.js";
@@ -75,6 +76,7 @@ publicApi.use("/orders", ordersRoutes);
 publicApi.use("/payments", paymentsRoutes);
 publicApi.use("/commissions", commissionsRoutes);
 publicApi.use("/reviews", reviewsRoutes);
+publicApi.use("/favorites", favoritesRoutes);
 publicApi.use("/admin", adminRoutes);
 
 app.use(publicApi);

--- a/server/src/modules/favorites/__tests__/favorites.routes.test.ts
+++ b/server/src/modules/favorites/__tests__/favorites.routes.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import { favoritesRoutes } from "../favorites.routes.js";
+import { errorHandler } from "../../../shared/errors/index.js";
+import { signAccessToken } from "../../../shared/utils/jwt.js";
+
+function listen(app: express.Express) {
+  return new Promise<Server>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function close(server: Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function bearer(role: "CUSTOMER" | "SELLER" | "ADMIN") {
+  return `Bearer ${signAccessToken({
+    sub: `${role.toLowerCase()}-1`,
+    email: `${role.toLowerCase()}@test.local`,
+    role,
+  })}`;
+}
+
+describe("favorites HTTP auth (#106)", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use("/favorites", favoritesRoutes);
+    app.use(errorHandler);
+    server = await listen(app);
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("server has no port");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it("returns 401 for anonymous GET/POST/DELETE", async () => {
+    const get = await fetch(`${baseUrl}/favorites`);
+    const post = await fetch(`${baseUrl}/favorites`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ listingId: "listing-1" }),
+    });
+    const del = await fetch(`${baseUrl}/favorites/listing-1`, { method: "DELETE" });
+    expect(get.status).toBe(401);
+    expect(post.status).toBe(401);
+    expect(del.status).toBe(401);
+  });
+
+  it("returns 403 for SELLER and ADMIN", async () => {
+    for (const role of ["SELLER", "ADMIN"] as const) {
+      const response = await fetch(`${baseUrl}/favorites`, {
+        headers: { Authorization: bearer(role) },
+      });
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({ error: "Insufficient permissions" });
+    }
+  });
+
+  it("returns 400 for invalid listingId on POST", async () => {
+    const response = await fetch(`${baseUrl}/favorites`, {
+      method: "POST",
+      headers: {
+        Authorization: bearer("CUSTOMER"),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ listingId: "" }),
+    });
+    expect(response.status).toBe(400);
+  });
+});

--- a/server/src/modules/favorites/__tests__/favorites.service.test.ts
+++ b/server/src/modules/favorites/__tests__/favorites.service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { Prisma } from "@prisma/client";
+
+vi.mock("../../../shared/database/index.js", () => ({
+  prisma: {
+    listing: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock("../favorites.repository.js", () => ({
+  favoritesRepository: {
+    findManyByUserId: vi.fn(),
+    create: vi.fn(),
+    deleteByUserAndListing: vi.fn(),
+  },
+}));
+
+import { prisma } from "../../../shared/database/index.js";
+import { favoritesRepository } from "../favorites.repository.js";
+import { favoritesService } from "../favorites.service.js";
+import { createFavoriteDto } from "../favorites.dto.js";
+
+function uniqueConflict() {
+  return new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "5.22.0",
+    meta: { target: ["userId", "listingId"] },
+  });
+}
+
+describe("favoritesService (#106 / SPEC-0004)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives owner from the authenticated userId argument, never from body", () => {
+    const parsed = createFavoriteDto.parse({ listingId: "listing-1", userId: "attacker" });
+    expect(parsed).toEqual({ listingId: "listing-1" });
+    expect("userId" in parsed).toBe(false);
+  });
+
+  it("lists only the caller's favorites with listingId + listing", async () => {
+    vi.mocked(favoritesRepository.findManyByUserId).mockResolvedValue([
+      {
+        listingId: "listing-1",
+        listing: { id: "listing-1", status: "SOLD" },
+      },
+    ] as never);
+
+    const result = await favoritesService.list("user-1");
+    expect(favoritesRepository.findManyByUserId).toHaveBeenCalledWith("user-1");
+    expect(result).toEqual({
+      items: [{ listingId: "listing-1", listing: { id: "listing-1", status: "SOLD" } }],
+    });
+  });
+
+  it("returns 404 when the listing does not exist", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue(null);
+    await expect(favoritesService.add("user-1", { listingId: "missing" })).rejects.toMatchObject({
+      statusCode: 404,
+      message: "Listing not found",
+    });
+    expect(favoritesRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a favorite for the token subject", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue({ id: "listing-1" } as never);
+    vi.mocked(favoritesRepository.create).mockResolvedValue({ id: "fav-1" } as never);
+
+    await expect(favoritesService.add("user-1", { listingId: "listing-1" })).resolves.toEqual({
+      listingId: "listing-1",
+    });
+    expect(favoritesRepository.create).toHaveBeenCalledWith({
+      user: { connect: { id: "user-1" } },
+      listing: { connect: { id: "listing-1" } },
+    });
+  });
+
+  it("treats a unique-constraint POST as 200/no-op", async () => {
+    vi.mocked(prisma.listing.findUnique).mockResolvedValue({ id: "listing-1" } as never);
+    vi.mocked(favoritesRepository.create).mockRejectedValue(uniqueConflict());
+
+    await expect(favoritesService.add("user-1", { listingId: "listing-1" })).resolves.toEqual({
+      listingId: "listing-1",
+    });
+  });
+
+  it("deletes only the caller's row for that listing", async () => {
+    vi.mocked(favoritesRepository.deleteByUserAndListing).mockResolvedValue({ count: 0 });
+    await favoritesService.remove("user-1", "listing-1");
+    expect(favoritesRepository.deleteByUserAndListing).toHaveBeenCalledWith("user-1", "listing-1");
+  });
+});

--- a/server/src/modules/favorites/favorites.controller.ts
+++ b/server/src/modules/favorites/favorites.controller.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from "express";
+import { getAuthUser } from "../../shared/helpers/getAuthUser.js";
+import { requestParam } from "../../shared/http/requestFields.js";
+import { favoritesService } from "./favorites.service.js";
+
+export const favoritesController = {
+  async list(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const user = getAuthUser(req);
+      const result = await favoritesService.list(user.id);
+      res.json(result);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async create(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const user = getAuthUser(req);
+      const result = await favoritesService.add(user.id, req.body);
+      res.status(200).json(result);
+    } catch (e) {
+      next(e);
+    }
+  },
+
+  async remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const user = getAuthUser(req);
+      await favoritesService.remove(user.id, requestParam(req, "listingId"));
+      res.status(204).send();
+    } catch (e) {
+      next(e);
+    }
+  },
+};

--- a/server/src/modules/favorites/favorites.dto.ts
+++ b/server/src/modules/favorites/favorites.dto.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { resourceIdSchema } from "../../shared/validation/httpLimits.js";
+
+export const createFavoriteDto = z.object({
+  listingId: resourceIdSchema("Listing ID"),
+});
+
+export const favoriteListingParamsDto = z.object({
+  listingId: resourceIdSchema("Listing ID"),
+});
+
+export type CreateFavoriteInput = z.infer<typeof createFavoriteDto>;

--- a/server/src/modules/favorites/favorites.repository.ts
+++ b/server/src/modules/favorites/favorites.repository.ts
@@ -1,0 +1,38 @@
+import { prisma } from "../../shared/database/index.js";
+import type { Prisma } from "@prisma/client";
+
+const favoriteListingInclude = {
+  listing: {
+    include: {
+      product: true,
+      seller: {
+        select: {
+          id: true,
+          storeName: true,
+          rating: true,
+          user: { select: { id: true, name: true } },
+        },
+      },
+    },
+  },
+} as const;
+
+export const favoritesRepository = {
+  async findManyByUserId(userId: string) {
+    return prisma.favorite.findMany({
+      where: { userId },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      include: favoriteListingInclude,
+    });
+  },
+
+  async create(data: Prisma.FavoriteCreateInput) {
+    return prisma.favorite.create({ data });
+  },
+
+  async deleteByUserAndListing(userId: string, listingId: string) {
+    return prisma.favorite.deleteMany({
+      where: { userId, listingId },
+    });
+  },
+};

--- a/server/src/modules/favorites/favorites.routes.ts
+++ b/server/src/modules/favorites/favorites.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from "express";
+import { authenticate, requireRole, validateParams } from "../../shared/middlewares/index.js";
+import { validateBody } from "../../shared/middlewares/validateBody.js";
+import { favoritesController } from "./favorites.controller.js";
+import { createFavoriteDto, favoriteListingParamsDto } from "./favorites.dto.js";
+
+const router = Router();
+
+router.get("/", authenticate, requireRole("CUSTOMER"), favoritesController.list);
+router.post(
+  "/",
+  authenticate,
+  requireRole("CUSTOMER"),
+  validateBody(createFavoriteDto),
+  favoritesController.create
+);
+router.delete(
+  "/:listingId",
+  authenticate,
+  requireRole("CUSTOMER"),
+  validateParams(favoriteListingParamsDto),
+  favoritesController.remove
+);
+
+export const favoritesRoutes = router;

--- a/server/src/modules/favorites/favorites.service.ts
+++ b/server/src/modules/favorites/favorites.service.ts
@@ -1,0 +1,44 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../shared/database/index.js";
+import { AppError } from "../../shared/errors/AppError.js";
+import { favoritesRepository } from "./favorites.repository.js";
+import type { CreateFavoriteInput } from "./favorites.dto.js";
+
+function isUniqueViolation(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+}
+
+export const favoritesService = {
+  async list(userId: string) {
+    const rows = await favoritesRepository.findManyByUserId(userId);
+    return {
+      items: rows.map((row) => ({
+        listingId: row.listingId,
+        listing: row.listing,
+      })),
+    };
+  },
+
+  async add(userId: string, input: CreateFavoriteInput) {
+    const listing = await prisma.listing.findUnique({
+      where: { id: input.listingId },
+      select: { id: true },
+    });
+    if (!listing) throw new AppError(404, "Listing not found");
+
+    try {
+      await favoritesRepository.create({
+        user: { connect: { id: userId } },
+        listing: { connect: { id: listing.id } },
+      });
+    } catch (error) {
+      if (!isUniqueViolation(error)) throw error;
+    }
+
+    return { listingId: listing.id };
+  },
+
+  async remove(userId: string, listingId: string) {
+    await favoritesRepository.deleteByUserAndListing(userId, listingId);
+  },
+};

--- a/server/src/modules/listings/__tests__/listings.filters.test.ts
+++ b/server/src/modules/listings/__tests__/listings.filters.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { listListingsQueryDto } from "../listings.dto.js";
+
+vi.mock("../../../shared/database/index.js", () => ({
+  prisma: {
+    listing: {},
+    seller: { findUnique: vi.fn() },
+    product: { findUnique: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("../listings.repository.js", () => ({
+  listingsRepository: {
+    findMany: vi.fn(),
+    findManyByKeyset: vi.fn(),
+  },
+}));
+
+import { listingsRepository } from "../listings.repository.js";
+import { listingsService } from "../listings.service.js";
+
+describe("GET /listings weapon/rarity/game filters (#103)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listingsRepository.findMany).mockResolvedValue({ items: [], total: 0 });
+  });
+
+  it("accepts optional weapon, rarity, and game on the listings query DTO", () => {
+    expect(listListingsQueryDto.parse({ weapon: "AK-47", rarity: "Covert", game: "CS2" })).toMatchObject({
+      weapon: "AK-47",
+      rarity: "Covert",
+      game: "CS2",
+    });
+  });
+
+  it("filters via related Product.weapon / rarity / game", async () => {
+    await listingsService.list({
+      page: 1,
+      limit: 20,
+      weapon: "AK-47",
+      rarity: "Covert",
+      game: "CS2",
+    });
+
+    expect(listingsRepository.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          product: {
+            weapon: { equals: "AK-47", mode: "insensitive" },
+            rarity: { equals: "Covert", mode: "insensitive" },
+            game: { equals: "CS2", mode: "insensitive" },
+          },
+        },
+      })
+    );
+  });
+
+  it("combines catalog filters with existing exterior and StatTrak predicates", async () => {
+    await listingsService.list({
+      page: 1,
+      limit: 20,
+      weapon: "AK-47",
+      exterior: "Field-Tested",
+      isStattrak: true,
+    });
+
+    expect(listingsRepository.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          product: {
+            exterior: "Field-Tested",
+            isStattrak: true,
+            weapon: { equals: "AK-47", mode: "insensitive" },
+          },
+        },
+      })
+    );
+  });
+});

--- a/server/src/modules/listings/__tests__/listings.pagination.test.ts
+++ b/server/src/modules/listings/__tests__/listings.pagination.test.ts
@@ -47,6 +47,11 @@ describe("GET /listings and GET /products pagination query contract", () => {
       page: 9,
       limit: 20,
     });
+    expect(listListingsQueryDto.parse({ sort: "price_asc", weapon: "AK-47" })).toMatchObject({
+      sort: "price_asc",
+      weapon: "AK-47",
+    });
+    expect(listListingsQueryDto.safeParse({ sort: "newest" }).success).toBe(false);
     expect(listProductsQueryDto.parse({ cursor: "abc" })).toMatchObject({ cursor: "abc", page: 1, limit: 20 });
   });
 
@@ -54,6 +59,11 @@ describe("GET /listings and GET /products pagination query contract", () => {
     const response = await fetch(`${baseUrl}/listings?cursor=not-a-cursor&limit=2`);
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "Invalid cursor" });
+  });
+
+  it("returns 400 for an unknown listings sort key", async () => {
+    const response = await fetch(`${baseUrl}/listings?sort=newest`);
+    expect(response.status).toBe(400);
   });
 
   it("returns 400 for an invalid products cursor without requiring auth", async () => {

--- a/server/src/modules/listings/__tests__/listings.sort.test.ts
+++ b/server/src/modules/listings/__tests__/listings.sort.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { listListingsQueryDto } from "../listings.dto.js";
+import { DEFAULT_LISTING_SORT, LISTING_SORTS, listingOrderBy } from "../listings.sort.js";
+import { createdAtIdDescOrderBy } from "../../../shared/pagination/cursor.js";
+
+vi.mock("../../../shared/database/index.js", () => ({
+  prisma: {
+    listing: {},
+    seller: { findUnique: vi.fn() },
+    product: { findUnique: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("../listings.repository.js", () => ({
+  listingsRepository: {
+    findMany: vi.fn(),
+    findManyByKeyset: vi.fn(),
+  },
+}));
+
+import { listingsRepository } from "../listings.repository.js";
+import { listingsService } from "../listings.service.js";
+
+const emptyPage = { items: [], total: 0 };
+
+describe("GET /listings sort whitelist (#93)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listingsRepository.findMany).mockResolvedValue(emptyPage);
+  });
+
+  it("defaults to createdAt_desc and rejects unknown sort keys", () => {
+    expect(listListingsQueryDto.parse({}).sort).toBeUndefined();
+    expect(DEFAULT_LISTING_SORT).toBe("createdAt_desc");
+    expect(LISTING_SORTS).toEqual([
+      "createdAt_desc",
+      "price_asc",
+      "price_desc",
+      "float_asc",
+      "float_desc",
+    ]);
+    expect(listListingsQueryDto.safeParse({ sort: "popularity" }).success).toBe(false);
+    expect(listListingsQueryDto.safeParse({ sort: "createdAt_asc" }).success).toBe(false);
+  });
+
+  it("maps each whitelist value to a PostgreSQL orderBy (not a page-slice sort)", () => {
+    expect(listingOrderBy(undefined)).toEqual([...createdAtIdDescOrderBy]);
+    expect(listingOrderBy("createdAt_desc")).toEqual([...createdAtIdDescOrderBy]);
+    expect(listingOrderBy("price_asc")).toEqual([{ price: "asc" }, { id: "asc" }]);
+    expect(listingOrderBy("price_desc")).toEqual([{ price: "desc" }, { id: "desc" }]);
+    expect(listingOrderBy("float_asc")).toEqual([{ floatValue: "asc" }, { id: "asc" }]);
+    expect(listingOrderBy("float_desc")).toEqual([{ floatValue: "desc" }, { id: "desc" }]);
+  });
+
+  it.each(LISTING_SORTS)("service.list passes orderBy for %s to the repository", async (sort) => {
+    await listingsService.list({ page: 1, limit: 20, sort });
+    expect(listingsRepository.findMany).toHaveBeenCalledWith({
+      skip: 0,
+      take: 20,
+      where: undefined,
+      orderBy: listingOrderBy(sort),
+    });
+  });
+
+  it("uses createdAt_desc when sort is omitted", async () => {
+    await listingsService.list({ page: 1, limit: 20 });
+    expect(listingsRepository.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: listingOrderBy("createdAt_desc") })
+    );
+  });
+
+  it("ignores sort in cursor mode so keyset stays createdAt+id", async () => {
+    vi.mocked(listingsRepository.findManyByKeyset).mockResolvedValue({ items: [], hasMore: false });
+    await listingsService.list({ cursor: "", page: 1, limit: 20, sort: "price_asc" });
+    expect(listingsRepository.findManyByKeyset).toHaveBeenCalled();
+    expect(listingsRepository.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/listings/listings.dto.ts
+++ b/server/src/modules/listings/listings.dto.ts
@@ -7,6 +7,7 @@ import {
   STEAM_ASSET_ID_MAX,
   resourceIdSchema,
 } from "../../shared/validation/httpLimits.js";
+import { LISTING_SORTS } from "./listings.sort.js";
 
 export const createListingDto = z.object({
   productId: resourceIdSchema("Product ID"),
@@ -40,6 +41,14 @@ export const listListingsQueryDto = z.object({
   maxFloat: z.coerce.number().min(0).max(1).optional(),
   exterior: z.string().max(SEARCH_MAX).optional(),
   isStattrak: z.coerce.boolean().optional(),
+  weapon: z.string().max(SEARCH_MAX).optional(),
+  rarity: z.string().max(SEARCH_MAX).optional(),
+  game: z.string().max(SEARCH_MAX).optional(),
+  /**
+   * Offset-mode catalog sort. Default `createdAt_desc`. Ignored when `cursor` is
+   * present (keyset remains createdAt+id). Applied in SQL to the full filter set.
+   */
+  sort: z.enum(LISTING_SORTS).optional(),
   /**
    * Opaque keyset cursor (`createdAt` + `id`). When present (including empty = first
    * keyset page), `page` is ignored. Limit remains 1–100, default 20.

--- a/server/src/modules/listings/listings.service.ts
+++ b/server/src/modules/listings/listings.service.ts
@@ -15,10 +15,20 @@ import { withSpan } from "../../shared/observability/tracing.js";
 import { auditRepository } from "../audit/audit.repository.js";
 import { AuditAction, AuditResourceType, type AuditActor } from "../audit/audit.types.js";
 import {
-  createdAtIdDescOrderBy,
   decodeCreatedAtIdCursor,
   nextCreatedAtIdCursor,
 } from "../../shared/pagination/cursor.js";
+import { DEFAULT_LISTING_SORT, listingOrderBy } from "./listings.sort.js";
+
+function productRelationFilter(query: ListListingsQuery): Prisma.ProductWhereInput | undefined {
+  const product: Prisma.ProductWhereInput = {};
+  if (query.exterior) product.exterior = query.exterior;
+  if (query.isStattrak !== undefined) product.isStattrak = query.isStattrak;
+  if (query.weapon) product.weapon = { equals: query.weapon, mode: "insensitive" };
+  if (query.rarity) product.rarity = { equals: query.rarity, mode: "insensitive" };
+  if (query.game) product.game = { equals: query.game, mode: "insensitive" };
+  return Object.keys(product).length ? product : undefined;
+}
 
 export const listingsService = {
   async list(query: ListListingsQuery) {
@@ -40,15 +50,12 @@ export const listingsService = {
       if (query.maxFloat !== undefined) where.floatValue.lte = query.maxFloat;
     }
 
-    if (query.exterior || query.isStattrak !== undefined) {
-      where.product = {};
-      if (query.exterior) where.product.exterior = query.exterior;
-      if (query.isStattrak !== undefined) where.product.isStattrak = query.isStattrak;
-    }
+    const product = productRelationFilter(query);
+    if (product) where.product = product;
 
     const filters = Object.keys(where).length ? where : undefined;
 
-    // Cursor mode: ignore `page`, skip COUNT(*), keyset on createdAt+id.
+    // Cursor mode: ignore `page` and `sort`, skip COUNT(*), keyset on createdAt+id.
     if (query.cursor !== undefined) {
       const after = query.cursor === "" ? undefined : decodeCreatedAtIdCursor(query.cursor);
       const { items, hasMore } = await listingsRepository.findManyByKeyset({
@@ -63,20 +70,23 @@ export const listingsService = {
       };
     }
 
+    const sort = query.sort ?? DEFAULT_LISTING_SORT;
     const skip = (query.page - 1) * query.limit;
     const { items, total } = await listingsRepository.findMany({
       skip,
       take: query.limit,
       where: filters,
-      orderBy: createdAtIdDescOrderBy,
+      orderBy: listingOrderBy(sort),
     });
 
+    const hasMore = skip + items.length < total;
     return {
       items,
       total,
       page: query.page,
       limit: query.limit,
-      nextCursor: nextCreatedAtIdCursor(items, skip + items.length < total),
+      nextCursor:
+        sort === DEFAULT_LISTING_SORT ? nextCreatedAtIdCursor(items, hasMore) : null,
     };
   },
 

--- a/server/src/modules/listings/listings.sort.ts
+++ b/server/src/modules/listings/listings.sort.ts
@@ -1,0 +1,36 @@
+import type { Prisma } from "@prisma/client";
+import { createdAtIdDescOrderBy } from "../../shared/pagination/cursor.js";
+
+/**
+ * Offset-mode catalog sorts for GET /listings (issue #93).
+ * Applied in PostgreSQL to the full filtered set, then page/limit slices.
+ * Cursor mode (#49) stays `createdAt DESC, id DESC` and ignores this whitelist.
+ */
+export const LISTING_SORTS = [
+  "createdAt_desc",
+  "price_asc",
+  "price_desc",
+  "float_asc",
+  "float_desc",
+] as const;
+
+export type ListingSort = (typeof LISTING_SORTS)[number];
+
+export const DEFAULT_LISTING_SORT: ListingSort = "createdAt_desc";
+
+export function listingOrderBy(
+  sort: ListingSort | undefined
+): Prisma.ListingOrderByWithRelationInput[] {
+  switch (sort ?? DEFAULT_LISTING_SORT) {
+    case "price_asc":
+      return [{ price: "asc" }, { id: "asc" }];
+    case "price_desc":
+      return [{ price: "desc" }, { id: "desc" }];
+    case "float_asc":
+      return [{ floatValue: "asc" }, { id: "asc" }];
+    case "float_desc":
+      return [{ floatValue: "desc" }, { id: "desc" }];
+    case "createdAt_desc":
+      return [...createdAtIdDescOrderBy];
+  }
+}

--- a/server/src/shared/architecture/__tests__/moduleBoundaries.test.ts
+++ b/server/src/shared/architecture/__tests__/moduleBoundaries.test.ts
@@ -27,6 +27,8 @@ describe("SPEC-0006 modular monolith map", () => {
     expect(DOMAIN_MODULE_FOLDERS).toContain("products");
     expect(DOMAIN_MODULE_FOLDERS).toContain("commissions");
     expect(DOMAIN_MODULE_FOLDERS).toContain("audit");
+    expect(DOMAIN_MODULE_FOLDERS).toContain("favorites");
+    expect(LOGICAL_MODULE_NAMES.favorites).toBe("Favorites");
   });
 
   it("encodes Admin composition and Audit write edges only", () => {
@@ -38,6 +40,7 @@ describe("SPEC-0006 modular monolith map", () => {
     expect(ALLOWED_MODULE_EDGES.commissions).toEqual(["audit"]);
     expect(ALLOWED_MODULE_EDGES.auth).toEqual([]);
     expect(ALLOWED_MODULE_EDGES.reviews).toEqual([]);
+    expect(ALLOWED_MODULE_EDGES.favorites).toEqual([]);
     expect(isModuleEdgeAllowed("payments", "orders")).toBe(false);
     expect(isModuleEdgeAllowed("orders", "listings")).toBe(false);
     expect(isModuleEdgeAllowed("reviews", "products")).toBe(false);

--- a/server/src/shared/architecture/moduleBoundaries.ts
+++ b/server/src/shared/architecture/moduleBoundaries.ts
@@ -18,6 +18,7 @@ export const DOMAIN_MODULE_FOLDERS = [
   "payments",
   "commissions",
   "reviews",
+  "favorites",
   "admin",
   "audit",
 ] as const;
@@ -34,6 +35,7 @@ export const LOGICAL_MODULE_NAMES = {
   payments: "Payments",
   commissions: "Ledger",
   reviews: "Reviews",
+  favorites: "Favorites",
   admin: "Admin",
   audit: "Audit",
 } as const satisfies Record<DomainModuleFolder, string>;
@@ -62,6 +64,7 @@ export const ALLOWED_MODULE_EDGES: Record<DomainModuleFolder, readonly DomainMod
   payments: ["audit"],
   commissions: ["audit"],
   reviews: [],
+  favorites: [],
   admin: ["sellers", "orders", "products", "audit"],
   audit: [],
 };

--- a/server/src/shared/docs/openapi.ts
+++ b/server/src/shared/docs/openapi.ts
@@ -181,6 +181,31 @@ export const openApiSpec = {
           createdAt: { type: "string", format: "date-time" },
         },
       },
+      FavoriteItem: {
+        type: "object",
+        required: ["listingId", "listing"],
+        properties: {
+          listingId: { type: "string" },
+          listing: { $ref: "#/components/schemas/Listing" },
+        },
+      },
+      FavoriteList: {
+        type: "object",
+        required: ["items"],
+        properties: {
+          items: {
+            type: "array",
+            items: { $ref: "#/components/schemas/FavoriteItem" },
+          },
+        },
+      },
+      FavoriteWrite: {
+        type: "object",
+        required: ["listingId"],
+        properties: {
+          listingId: { type: "string" },
+        },
+      },
       Cs2ShImportSummary: {
         type: "object",
         properties: {
@@ -389,8 +414,10 @@ export const openApiSpec = {
         summary: "Browse listings with filters",
         description:
           "Public listing browse. Offset pagination (`page`/`limit`) remains the default so existing Market clients keep working. " +
-          "When `cursor` is present (empty string = first keyset page), `page` is ignored and the response is `{ items, limit, nextCursor }` " +
+          "When `cursor` is present (empty string = first keyset page), `page` and `sort` are ignored and the response is `{ items, limit, nextCursor }` " +
           "ordered by `createdAt DESC, id DESC`. The cursor is opaque base64url of those two keys; clients must not parse it. " +
+          "Offset mode accepts `sort` (`createdAt_desc` default, `price_asc`, `price_desc`, `float_asc`, `float_desc`) applied in PostgreSQL " +
+          "to the full filtered catalog before `page`/`limit`. `weapon`, `rarity`, and `game` filter via related Product (no category table). " +
           "Limit is 1–100 (default 20). Concurrent inserts do not skip or duplicate rows already walked by a cursor.",
         security: [],
         parameters: [
@@ -423,6 +450,35 @@ export const openApiSpec = {
           { name: "maxFloat", in: "query", schema: { type: "number" } },
           { name: "exterior", in: "query", schema: { type: "string" } },
           { name: "isStattrak", in: "query", schema: { type: "boolean" } },
+          {
+            name: "weapon",
+            in: "query",
+            schema: { type: "string" },
+            description: "Exact Product.weapon match (case-insensitive). Example: AK-47.",
+          },
+          {
+            name: "rarity",
+            in: "query",
+            schema: { type: "string" },
+            description: "Exact Product.rarity match (case-insensitive). Example: Covert.",
+          },
+          {
+            name: "game",
+            in: "query",
+            schema: { type: "string" },
+            description: "Optional exact Product.game match (case-insensitive). Example: CS2.",
+          },
+          {
+            name: "sort",
+            in: "query",
+            schema: {
+              type: "string",
+              enum: ["createdAt_desc", "price_asc", "price_desc", "float_asc", "float_desc"],
+              default: "createdAt_desc",
+            },
+            description:
+              "Offset-mode catalog sort. Default createdAt_desc (newest first). Applied in SQL to the full filter set, then paginated. Ignored in cursor mode.",
+          },
         ],
         responses: {
           200: {
@@ -725,6 +781,77 @@ export const openApiSpec = {
               },
             },
           },
+        },
+      },
+    },
+    "/favorites": {
+      get: {
+        tags: ["Favorites"],
+        summary: "List the authenticated customer's saved listings",
+        description:
+          "CUSTOMER-only. Owner is the JWT subject; userId is never accepted from the query or body. " +
+          "Does not reserve or change listing status. Saved SOLD listings remain in the list.",
+        responses: {
+          200: {
+            description: "Saved listings for the caller",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/FavoriteList" },
+              },
+            },
+          },
+          401: { description: "Missing or invalid access token" },
+          403: { description: "Caller is not CUSTOMER" },
+        },
+      },
+      post: {
+        tags: ["Favorites"],
+        summary: "Save a listing for the authenticated customer",
+        description:
+          "CUSTOMER-only. Body is `{ listingId }` only. Duplicate POST is 200/no-op (unique userId+listingId). Missing listing is 404.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/FavoriteWrite" },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "Created or already saved",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/FavoriteWrite" },
+              },
+            },
+          },
+          400: { description: "Invalid listingId" },
+          401: { description: "Missing or invalid access token" },
+          403: { description: "Caller is not CUSTOMER" },
+          404: { description: "Listing not found" },
+        },
+      },
+    },
+    "/favorites/{listingId}": {
+      delete: {
+        tags: ["Favorites"],
+        summary: "Remove a saved listing for the authenticated customer",
+        description:
+          "CUSTOMER-only. Scoped to the JWT subject. Repeated DELETE is 204/no-op. Cannot remove another user's favorite.",
+        parameters: [
+          {
+            name: "listingId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          204: { description: "Removed or already absent" },
+          400: { description: "Invalid listingId" },
+          401: { description: "Missing or invalid access token" },
+          403: { description: "Caller is not CUSTOMER" },
         },
       },
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backend contracts required by the frontend storefront sweep. New `favorites` module plus catalog sort/filter query params. `src/` is untouched.

**Closes #93 #103 #106**

### #93 — Listing sort
- `GET /listings?sort=` whitelist: `createdAt_desc` (default), `price_asc`, `price_desc`, `float_asc`, `float_desc`
- Offset pagination sorts the **full** filtered set in PostgreSQL (not the current page only)
- Cursor mode still uses existing `createdAt,id` order; `sort` is ignored with `cursor`
- Indexes: `(status, price, id)` and `(status, floatValue, id)`

### #103 — Weapon / rarity filters
- Optional `weapon`, `rarity` (and existing `game`) applied via Product relation, case-insensitive
- Combined with current catalog filters; empty result is a valid empty page

### #106 — Favorites API (SPEC-0004 HTTP)
- `Favorite` unique `(userId, listingId)`
- JWT **CUSTOMER** only
- `GET /favorites` → `{ items: [{ listingId, listing }] }`
- `POST /favorites` `{ listingId }` → 200 `{ listingId }` (duplicate is idempotent 200)
- `DELETE /favorites/:listingId` → 204 (missing favorite is a no-op)
- Mounted on `/favorites` and `/api/v1/favorites`

## Verification

- `npm --prefix server test` unit → **405** passed
- Integration (sort / weapon / favorites included) → **133** passed
- OpenAPI + module-boundary tests updated

## Merge note

Merge **before or with** the frontend sweep PR so Market sort/filters and favorites talk to a live API instead of the client-only fallback.

## Risks

- Favorites are CUSTOMER-only; seller/admin tokens get 403
- Sort is offset-mode only; cursor catalogs stay newest-first

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

