### PR TITLE
Frontend sweep — storefront, dashboards, and a11y

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { AuthProvider } from "@/contexts/AuthContext";
@@ -32,9 +32,13 @@ import AdminOrders from "./pages/admin/AdminOrders";
 import AdminOrderDetail from "./pages/admin/AdminOrderDetail";
 import AdminUsers from "./pages/admin/AdminUsers";
 import AdminCatalog from "./pages/admin/AdminCatalog";
+import AdminProducts from "./pages/admin/AdminProducts";
+import StorePage from "./pages/StorePage";
+import AccountFavoritesPage from "./pages/AccountFavorites";
 import NotFound from "./pages/NotFound";
+import { createAppQueryClient } from "@/lib/queryClient";
 
-const queryClient = new QueryClient();
+const queryClient = createAppQueryClient();
 
 const App = () => (
   <ErrorBoundary>
@@ -49,6 +53,7 @@ const App = () => (
                 <Route element={<MainLayout />}>
                   <Route path="/" element={<Index />} />
                   <Route path="/products" element={<Products />} />
+                  <Route path="/stores/:sellerId" element={<StorePage />} />
                   <Route path="/listing/:id" element={<ListingDetail />} />
                   <Route path="/cart" element={<CartPage />} />
                   <Route path="/checkout" element={<Checkout />} />
@@ -81,6 +86,14 @@ const App = () => (
                     element={
                       <ProtectedRoute>
                         <AccountPage />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/account/favorites"
+                    element={
+                      <ProtectedRoute>
+                        <AccountFavoritesPage />
                       </ProtectedRoute>
                     }
                   />
@@ -163,6 +176,14 @@ const App = () => (
                     element={
                       <ProtectedRoute allowedRoles={["ADMIN"]}>
                         <AdminCatalog />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/products"
+                    element={
+                      <ProtectedRoute allowedRoles={["ADMIN"]}>
+                        <AdminProducts />
                       </ProtectedRoute>
                     }
                   />

--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -65,11 +65,55 @@ describe("api extra headers", () => {
     fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
 
     await expect(api.get("/listings")).rejects.toMatchObject({
-      name: "ApiClientError",
+      name: "ApiError",
       code: "NETWORK",
       message: expect.stringMatching(
         /Could not reach API at .+Failed to fetch/,
       ),
+    });
+  });
+});
+
+describe("api HTTP errors", () => {
+  beforeEach(() => {
+    tokenStorage.clear();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    tokenStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it("throws ApiError with status 400", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ error: "Bad request" }, 400),
+    );
+    await expect(api.get("/listings")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 400,
+    });
+  });
+
+  it("throws ApiError with status 401", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ error: "Unauthorized" }, 401),
+    );
+    await expect(
+      api.get("/listings", { skipAuth: true }),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      status: 401,
+    });
+  });
+
+  it("throws ApiError with status 500", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({ error: "Server exploded" }, 500),
+    );
+    await expect(api.get("/listings")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 500,
     });
   });
 });

--- a/src/api/__tests__/favorites.test.ts
+++ b/src/api/__tests__/favorites.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addFavorite, listFavorites, removeFavorite } from "../favorites";
+
+const get = vi.fn();
+const post = vi.fn();
+const del = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+    delete: (...args: unknown[]) => del(...args),
+  },
+}));
+
+describe("favorites client", () => {
+  beforeEach(() => {
+    get.mockReset();
+    post.mockReset();
+    del.mockReset();
+  });
+
+  it("GETs /favorites and normalizes items", async () => {
+    get.mockResolvedValue({
+      items: [{ id: "f1", userId: "u1", listingId: "l1" }],
+    });
+    await expect(listFavorites()).resolves.toEqual([
+      { id: "f1", userId: "u1", listingId: "l1" },
+    ]);
+    expect(get).toHaveBeenCalledWith("/favorites");
+  });
+
+  it("POSTs /favorites with listingId", async () => {
+    post.mockResolvedValue({ id: "f1", userId: "u1", listingId: "l1" });
+    await addFavorite("l1");
+    expect(post).toHaveBeenCalledWith("/favorites", { listingId: "l1" });
+  });
+
+  it("DELETEs /favorites/:listingId", async () => {
+    del.mockResolvedValue(undefined);
+    await removeFavorite("l1");
+    expect(del).toHaveBeenCalledWith("/favorites/l1");
+  });
+});

--- a/src/api/__tests__/listings.test.ts
+++ b/src/api/__tests__/listings.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listListings } from "../listings";
+
+const get = vi.fn();
+
+vi.mock("../client", () => ({
+  api: {
+    get: (...args: unknown[]) => get(...args),
+  },
+}));
+
+describe("listListings", () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 });
+  });
+
+  it("sends server sort whitelist values", async () => {
+    await listListings({ sort: "price_asc", status: "ACTIVE" });
+    expect(get).toHaveBeenCalledWith("/listings?status=ACTIVE&sort=price_asc");
+  });
+
+  it("sends weapon and rarity query params", async () => {
+    await listListings({ weapon: "AK-47", rarity: "Covert", status: "ACTIVE" });
+    expect(get).toHaveBeenCalledWith(
+      "/listings?status=ACTIVE&weapon=AK-47&rarity=Covert",
+    );
+  });
+});

--- a/src/api/__tests__/sellers.test.ts
+++ b/src/api/__tests__/sellers.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listSellers } from "../sellers";
+import { applySeller, listSellers } from "../sellers";
 
 const get = vi.fn();
+const post = vi.fn();
 
 vi.mock("../client", () => ({
   api: {
     get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
   },
 }));
 
@@ -23,5 +25,15 @@ describe("listSellers", () => {
   it("sends approved=true when requested", async () => {
     await listSellers({ approved: true });
     expect(get).toHaveBeenCalledWith("/sellers?approved=true");
+  });
+});
+
+describe("applySeller", () => {
+  it("POSTs storeName only to /sellers/apply", async () => {
+    post.mockResolvedValue({ id: "s1" });
+    await applySeller({ storeName: "Loja Nova" });
+    expect(post).toHaveBeenCalledWith("/sellers/apply", {
+      storeName: "Loja Nova",
+    });
   });
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,8 @@
-import { ApiClientError, logTechnicalError } from "@/lib/userFacingApiError";
+import {
+  ApiError,
+  ApiClientError,
+  logTechnicalError,
+} from "@/lib/userFacingApiError";
 import { resolveApiBaseUrl } from "./apiBaseUrl";
 
 const API_BASE = resolveApiBaseUrl({
@@ -28,7 +32,7 @@ const tokenStorage: TokenStorage = {
 
 async function refreshAccessToken(): Promise<string> {
   const refresh = tokenStorage.getRefreshToken();
-  if (!refresh) throw new ApiClientError("No refresh token", { status: 401 });
+  if (!refresh) throw new ApiError("No refresh token", { status: 401 });
   const res = await fetch(`${API_BASE}/auth/refresh`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -37,7 +41,7 @@ async function refreshAccessToken(): Promise<string> {
   if (!res.ok) {
     tokenStorage.clear();
     const data = await res.json().catch(() => ({}));
-    throw new ApiClientError(data.error ?? "Session expired", {
+    throw new ApiError(data.error ?? "Session expired", {
       status: res.status,
     });
   }
@@ -91,12 +95,9 @@ async function request<T>(
     res = await doFetch(access);
   } catch (err) {
     const reason = err instanceof Error ? err.message : "Failed to fetch";
-    const error = new ApiClientError(
-      `Could not reach API at ${url}: ${reason}`,
-      {
-        code: "NETWORK",
-      },
-    );
+    const error = new ApiError(`Could not reach API at ${url}: ${reason}`, {
+      code: "NETWORK",
+    });
     logTechnicalError(error);
     throw error;
   }
@@ -108,7 +109,7 @@ async function request<T>(
     } catch {
       tokenStorage.clear();
       const data = await res.json().catch(() => ({}));
-      const error = new ApiClientError(data.error ?? "Unauthorized", {
+      const error = new ApiError(data.error ?? "Unauthorized", {
         status: 401,
       });
       logTechnicalError(error);
@@ -118,10 +119,9 @@ async function request<T>(
 
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
-    const error = new ApiClientError(
-      data.error ?? `Request failed: ${res.status}`,
-      { status: res.status },
-    );
+    const error = new ApiError(data.error ?? `Request failed: ${res.status}`, {
+      status: res.status,
+    });
     logTechnicalError(error);
     throw error;
   }
@@ -148,4 +148,4 @@ export const api = {
   delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
 };
 
-export { tokenStorage };
+export { tokenStorage, ApiError, ApiClientError };

--- a/src/api/favorites.ts
+++ b/src/api/favorites.ts
@@ -1,0 +1,42 @@
+import { api } from "./client";
+import type { Favorite, Listing } from "@/types/api";
+
+export interface ListFavoritesResponse {
+  items: Favorite[];
+}
+
+function normalizeFavorites(payload: unknown): Favorite[] {
+  if (Array.isArray(payload)) return payload as Favorite[];
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "items" in payload &&
+    Array.isArray((payload as ListFavoritesResponse).items)
+  ) {
+    return (payload as ListFavoritesResponse).items;
+  }
+  return [];
+}
+
+export async function listFavorites(): Promise<Favorite[]> {
+  const payload = await api.get<Favorite[] | ListFavoritesResponse>(
+    "/favorites",
+  );
+  return normalizeFavorites(payload);
+}
+
+export function addFavorite(listingId: string): Promise<Favorite> {
+  return api.post<Favorite>("/favorites", { listingId });
+}
+
+export function removeFavorite(listingId: string): Promise<void> {
+  return api.delete(`/favorites/${listingId}`);
+}
+
+export function favoriteListingId(favorite: Favorite): string {
+  return favorite.listingId ?? favorite.listing?.id ?? "";
+}
+
+export function favoriteListing(favorite: Favorite): Listing | undefined {
+  return favorite.listing;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,3 +9,4 @@ export * from "./payments";
 export * from "./sellers";
 export * from "./commissions";
 export * from "./reviews";
+export * from "./favorites";

--- a/src/api/listings.ts
+++ b/src/api/listings.ts
@@ -1,6 +1,13 @@
 import { api } from "./client";
 import type { Listing, ListListingsResponse } from "@/types/api";
 
+export type ListingSort =
+  | "createdAt_desc"
+  | "price_asc"
+  | "price_desc"
+  | "float_asc"
+  | "float_desc";
+
 export interface ListListingsParams {
   page?: number;
   limit?: number;
@@ -13,9 +20,15 @@ export interface ListListingsParams {
   maxFloat?: number;
   exterior?: string;
   isStattrak?: boolean;
+  /** Server whitelist (#93). Default on the API is createdAt_desc. */
+  sort?: ListingSort;
+  weapon?: string;
+  rarity?: string;
 }
 
-export function listListings(params?: ListListingsParams): Promise<ListListingsResponse> {
+export function listListings(
+  params?: ListListingsParams,
+): Promise<ListListingsResponse> {
   const search = new URLSearchParams();
   if (params?.page != null) search.set("page", String(params.page));
   if (params?.limit != null) search.set("limit", String(params.limit));
@@ -27,7 +40,11 @@ export function listListings(params?: ListListingsParams): Promise<ListListingsR
   if (params?.minFloat != null) search.set("minFloat", String(params.minFloat));
   if (params?.maxFloat != null) search.set("maxFloat", String(params.maxFloat));
   if (params?.exterior) search.set("exterior", params.exterior);
-  if (params?.isStattrak !== undefined) search.set("isStattrak", String(params.isStattrak));
+  if (params?.isStattrak !== undefined)
+    search.set("isStattrak", String(params.isStattrak));
+  if (params?.sort) search.set("sort", params.sort);
+  if (params?.weapon) search.set("weapon", params.weapon);
+  if (params?.rarity) search.set("rarity", params.rarity);
   const qs = search.toString();
   return api.get<ListListingsResponse>(`/listings${qs ? `?${qs}` : ""}`);
 }
@@ -54,12 +71,15 @@ export function updateListing(
     price: number;
     status: "ACTIVE" | "SOLD" | "RESERVED" | "CANCELED";
     tradeLockUntil: string | null;
-  }>
+  }>,
 ): Promise<Listing> {
   return api.patch<Listing>(`/listings/${id}`, body);
 }
 
-export function updateListingPrice(id: string, body: { newPrice: number }): Promise<Listing> {
+export function updateListingPrice(
+  id: string,
+  body: { newPrice: number },
+): Promise<Listing> {
   return api.patch<Listing>(`/listings/${id}/price`, body);
 }
 
@@ -71,6 +91,11 @@ export function cancelListing(id: string): Promise<void> {
   return api.post(`/listings/${id}/cancel`);
 }
 
-export function getSellerListings(): Promise<{ items: Listing[]; total: number }> {
-  return api.get<{ items: Listing[]; total: number }>("/listings/seller/my-listings");
+export function getSellerListings(): Promise<{
+  items: Listing[];
+  total: number;
+}> {
+  return api.get<{ items: Listing[]; total: number }>(
+    "/listings/seller/my-listings",
+  );
 }

--- a/src/api/sellers.ts
+++ b/src/api/sellers.ts
@@ -20,6 +20,10 @@ export function getSellerById(id: string): Promise<Seller> {
   return api.get<Seller>(`/sellers/${id}`);
 }
 
+export function applySeller(body: { storeName: string }): Promise<Seller> {
+  return api.post<Seller>("/sellers/apply", { storeName: body.storeName });
+}
+
 export function approveSeller(
   id: string,
   isApproved: boolean,

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+import { Heart } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { addFavorite, listFavorites, removeFavorite } from "@/api/favorites";
+import { useOptionalAuth } from "@/contexts/AuthContext";
+import { useToast } from "@/hooks/use-toast";
+import {
+  consumePendingFavoriteListingId,
+  setPendingFavoriteListingId,
+} from "@/lib/pendingFavorite";
+import { userFacingApiError } from "@/lib/userFacingApiError";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function FavoriteButton({
+  listingId,
+  className,
+}: {
+  listingId: string;
+  className?: string;
+}) {
+  const auth = useOptionalAuth();
+  const isAuthenticated = Boolean(auth?.isAuthenticated);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const favoritesQuery = useQuery({
+    queryKey: ["favorites"],
+    queryFn: listFavorites,
+    enabled: isAuthenticated,
+  });
+
+  const favorited = (favoritesQuery.data ?? []).some(
+    (item) => item.listingId === listingId || item.listing?.id === listingId,
+  );
+
+  const toggle = useMutation({
+    mutationFn: async () => {
+      if (favorited) {
+        await removeFavorite(listingId);
+        return false;
+      }
+      await addFavorite(listingId);
+      return true;
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["favorites"] });
+      const previous = queryClient.getQueryData(["favorites"]);
+      queryClient.setQueryData(["favorites"], (current: unknown) => {
+        const items = Array.isArray(current) ? current : [];
+        if (favorited) {
+          return items.filter(
+            (item: { listingId?: string; listing?: { id?: string } }) =>
+              item.listingId !== listingId && item.listing?.id !== listingId,
+          );
+        }
+        return [
+          ...items,
+          { id: `optimistic-${listingId}`, userId: "", listingId },
+        ];
+      });
+      return { previous };
+    },
+    onError: (error, _vars, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(["favorites"], context.previous);
+      }
+      toast({
+        title: userFacingApiError(error),
+        variant: "destructive",
+      });
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["favorites"] });
+    },
+  });
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    const pending = consumePendingFavoriteListingId();
+    if (pending === listingId) toggle.mutate();
+    // one-shot pending favorite after login
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, listingId]);
+
+  const onClick = () => {
+    if (!isAuthenticated) {
+      setPendingFavoriteListingId(listingId);
+      navigate("/login", {
+        state: { from: `${location.pathname}${location.search}` },
+      });
+      return;
+    }
+    toggle.mutate();
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className={cn("min-h-11 min-w-11", className)}
+      aria-pressed={favorited}
+      aria-label={
+        favorited ? "Remover dos favoritos" : "Adicionar aos favoritos"
+      }
+      disabled={toggle.isPending}
+      onClick={onClick}
+    >
+      <Heart
+        className={cn(
+          "h-4 w-4",
+          favorited
+            ? "fill-foreground text-foreground"
+            : "text-muted-foreground",
+        )}
+      />
+    </Button>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -78,7 +78,11 @@ function HeaderSearch({
   );
 }
 
-export function Header() {
+export function Header({
+  hideMobileMenu = false,
+}: {
+  hideMobileMenu?: boolean;
+}) {
   const { totalItems } = useCart();
   const { user, logout, isAuthenticated } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -89,7 +93,10 @@ export function Header() {
     { to: "/", label: "Home" },
     { to: "/products", label: "Market" },
     ...(user?.role === "CUSTOMER"
-      ? [{ to: "/account/orders", label: "Pedidos" }]
+      ? [
+          { to: "/account/orders", label: "Pedidos" },
+          { to: "/account/favorites", label: "Favoritos" },
+        ]
       : []),
     ...(user?.role === "SELLER" ? [{ to: "/seller", label: "Dashboard" }] : []),
     ...(user?.role === "ADMIN" ? [{ to: "/admin", label: "Admin" }] : []),
@@ -105,6 +112,12 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+      <a
+        href="#conteudo"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[60] focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:shadow"
+      >
+        Ir para o conteúdo
+      </a>
       <div className="container flex h-14 items-center justify-between">
         {brandMark()}
 
@@ -180,26 +193,28 @@ export function Header() {
             </div>
           )}
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden"
-            aria-expanded={menuOpen}
-            aria-controls="mobile-nav"
-            aria-haspopup="true"
-            onClick={() => setMenuOpen((open) => !open)}
-          >
-            {menuOpen ? (
-              <X className="h-4 w-4" />
-            ) : (
-              <Menu className="h-4 w-4" />
-            )}
-            <span className="sr-only">Menu</span>
-          </Button>
+          {hideMobileMenu ? null : (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="md:hidden"
+              aria-expanded={menuOpen}
+              aria-controls="mobile-nav"
+              aria-haspopup="true"
+              onClick={() => setMenuOpen((open) => !open)}
+            >
+              {menuOpen ? (
+                <X className="h-4 w-4" />
+              ) : (
+                <Menu className="h-4 w-4" />
+              )}
+              <span className="sr-only">Menu</span>
+            </Button>
+          )}
         </div>
       </div>
 
-      {menuOpen && (
+      {!hideMobileMenu && menuOpen && (
         <nav
           id="mobile-nav"
           className="space-y-1 border-t border-border bg-background p-3 md:hidden"

--- a/src/components/PriceHistorySection.tsx
+++ b/src/components/PriceHistorySection.tsx
@@ -1,0 +1,57 @@
+import type { PriceHistory } from "@/types/api";
+import {
+  PRICE_HISTORY_COPY,
+  PRICE_HISTORY_EMPTY,
+  PRICE_HISTORY_HEADING,
+  sparklinePoints,
+} from "@/lib/priceHistoryView";
+
+export function PriceHistorySection({
+  entries,
+}: {
+  entries: PriceHistory[] | undefined;
+}) {
+  const items = entries ?? [];
+  const points = sparklinePoints(items);
+
+  return (
+    <div className="rounded-md border border-border bg-card p-4">
+      <h2 className="mb-1 text-sm font-semibold tracking-tight text-foreground">
+        {PRICE_HISTORY_HEADING}
+      </h2>
+      <p className="mb-3 text-xs text-muted-foreground">{PRICE_HISTORY_COPY}</p>
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{PRICE_HISTORY_EMPTY}</p>
+      ) : (
+        <>
+          {items.length > 1 ? (
+            <svg
+              viewBox="0 0 160 36"
+              className="mb-3 h-9 w-40 text-foreground"
+              role="img"
+              aria-label="Tendência das alterações de preço deste listing"
+            >
+              <polyline
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                points={points}
+              />
+            </svg>
+          ) : null}
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {items.map((entry) => (
+              <li key={entry.id} className="flex justify-between gap-3">
+                <span>{new Date(entry.changedAt).toLocaleDateString()}</span>
+                <span className="tabular-nums">
+                  ${Number(entry.oldPrice).toFixed(2)} → $
+                  {Number(entry.newPrice).toFixed(2)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,7 +1,12 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import type { Listing, Product } from "@/types/api";
+import { FavoriteButton } from "@/components/FavoriteButton";
 import { ListingCartCta } from "@/components/ListingCartCta";
 import { analyticsPrice, track, type AnalyticsSource } from "@/lib/analytics";
+import { prefetchListingDetail } from "@/lib/prefetchListing";
+import { storePath } from "@/lib/storePath";
 
 export function productDisplayName(
   product: Pick<Product, "weapon" | "skinName" | "exterior">,
@@ -30,11 +35,17 @@ export function SkinVisual({
   padded?: boolean;
   decorative?: boolean;
 }) {
-  if (product.imageUrl) {
+  const [failed, setFailed] = useState(false);
+  const showImage = Boolean(product.imageUrl) && !failed;
+
+  if (showImage) {
     return (
       <img
-        src={product.imageUrl}
+        src={product.imageUrl ?? ""}
         alt={decorative ? "" : productDisplayName(product)}
+        loading="lazy"
+        decoding="async"
+        onError={() => setFailed(true)}
         className={
           padded
             ? "h-full w-full object-contain p-3"
@@ -84,6 +95,7 @@ export function ListingCard({
   listing: Listing;
   source?: AnalyticsSource;
 }) {
+  const queryClient = useQueryClient();
   const price =
     typeof listing.price === "number" ? listing.price : Number(listing.price);
   const sellerName =
@@ -101,23 +113,34 @@ export function ListingCard({
     });
   };
 
+  const prefetch = () => prefetchListingDetail(queryClient, listing.id);
+
   return (
-    <article className="group flex flex-col overflow-hidden rounded-md border border-border bg-card">
-      <Link
-        to={`/listing/${listing.id}`}
-        state={listingState}
-        onClick={onListingNavigate}
-        className="relative block aspect-[4/3] bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <div className="flex h-full items-center justify-center">
-          <SkinVisual product={listing.product} />
+    <article
+      className="group flex flex-col overflow-hidden rounded-md border border-border bg-card"
+      onMouseEnter={prefetch}
+      onFocus={prefetch}
+    >
+      <div className="relative">
+        <Link
+          to={`/listing/${listing.id}`}
+          state={listingState}
+          onClick={onListingNavigate}
+          className="relative block aspect-[4/3] bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <div className="flex h-full items-center justify-center">
+            <SkinVisual product={listing.product} />
+          </div>
+          {listing.product.isStattrak && (
+            <span className="absolute left-2 top-2 rounded-sm bg-background/90 px-1.5 py-0.5 text-[10px] font-medium text-foreground">
+              StatTrak™
+            </span>
+          )}
+        </Link>
+        <div className="absolute right-1 top-1 z-10">
+          <FavoriteButton listingId={listing.id} />
         </div>
-        {listing.product.isStattrak && (
-          <span className="absolute left-2 top-2 rounded-sm bg-background/90 px-1.5 py-0.5 text-[10px] font-medium text-foreground">
-            StatTrak™
-          </span>
-        )}
-      </Link>
+      </div>
 
       <div className="flex flex-1 flex-col gap-2 p-3">
         <Link
@@ -131,7 +154,16 @@ export function ListingCard({
           </h3>
         </Link>
         <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-          <span className="truncate">{sellerName}</span>
+          {listing.sellerId && sellerName ? (
+            <Link
+              to={storePath(listing.sellerId)}
+              className="truncate rounded-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {sellerName}
+            </Link>
+          ) : (
+            <span className="truncate">{sellerName}</span>
+          )}
           <span className="tabular-nums">
             Float: {Number(listing.floatValue).toFixed(8)}
           </span>

--- a/src/components/RouteFocus.tsx
+++ b/src/components/RouteFocus.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+
+/** Move keyboard/AT focus to main after client-side navigation (#117). */
+export function RouteFocus({ targetId = "conteudo" }: { targetId?: string }) {
+  const location = useLocation();
+  const first = useRef(true);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    const main = document.getElementById(targetId);
+    if (!main) return;
+    if (!main.hasAttribute("tabindex")) {
+      main.setAttribute("tabindex", "-1");
+    }
+    main.focus({ preventScroll: true });
+  }, [location.pathname, location.search, targetId]);
+
+  return null;
+}

--- a/src/components/__tests__/FavoriteButton.test.tsx
+++ b/src/components/__tests__/FavoriteButton.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { FavoriteButton } from "../FavoriteButton";
+
+const listFavorites = vi.fn();
+const addFavorite = vi.fn();
+const removeFavorite = vi.fn();
+const toast = vi.fn();
+
+const authState = {
+  isAuthenticated: false,
+  user: null as { id: string; role: string } | null,
+};
+
+vi.mock("@/api/favorites", () => ({
+  listFavorites: (...args: unknown[]) => listFavorites(...args),
+  addFavorite: (...args: unknown[]) => addFavorite(...args),
+  removeFavorite: (...args: unknown[]) => removeFavorite(...args),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useOptionalAuth: () => authState,
+  useAuth: () => authState,
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
+
+function renderButton() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/listing/listing-1"]}>
+        <Routes>
+          <Route
+            path="/listing/:id"
+            element={<FavoriteButton listingId="listing-1" />}
+          />
+          <Route path="/login" element={<div>login-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("FavoriteButton", () => {
+  beforeEach(() => {
+    listFavorites.mockReset();
+    addFavorite.mockReset();
+    removeFavorite.mockReset();
+    toast.mockReset();
+    authState.isAuthenticated = false;
+    authState.user = null;
+    listFavorites.mockResolvedValue([]);
+    addFavorite.mockResolvedValue({
+      id: "f1",
+      userId: "u1",
+      listingId: "listing-1",
+    });
+  });
+
+  it("sends guests to login with from instead of a fake local wishlist", async () => {
+    renderButton();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adicionar aos favoritos" }),
+    );
+    expect(await screen.findByText("login-page")).toBeTruthy();
+    expect(addFavorite).not.toHaveBeenCalled();
+  });
+
+  it("toggles a favorite for an authenticated customer", async () => {
+    authState.isAuthenticated = true;
+    authState.user = { id: "u1", role: "CUSTOMER" };
+    renderButton();
+    expect(
+      await screen.findByRole("button", { name: "Adicionar aos favoritos" }),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adicionar aos favoritos" }),
+    );
+    await waitFor(() => {
+      expect(addFavorite).toHaveBeenCalledWith("listing-1");
+    });
+  });
+});

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -50,6 +50,28 @@ describe("Header", () => {
     authState.logout.mockReset();
   });
 
+  it("exposes skip-to-content as the first focusable control", () => {
+    renderHeader();
+    const skip = screen.getByRole("link", { name: "Ir para o conteúdo" });
+    expect(skip).toHaveAttribute("href", "#conteudo");
+    const focusables = document.querySelectorAll(
+      "a[href], button, input, [tabindex]:not([tabindex='-1'])",
+    );
+    expect(focusables[0]).toBe(skip);
+  });
+
+  it("hides the storefront hamburger when dashboards own the mobile menu", () => {
+    render(
+      <MemoryRouter initialEntries={["/seller/listings"]}>
+        <Header hideMobileMenu />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole("button", { name: "Menu" })).toBeNull();
+    expect(
+      screen.getByRole("link", { name: "Ir para o conteúdo" }),
+    ).toBeTruthy();
+  });
+
   it("shows Neon Arsenal brand and storefront links", () => {
     renderHeader();
     expect(screen.getAllByText("Neon Arsenal").length).toBeGreaterThan(0);
@@ -101,6 +123,10 @@ describe("Header", () => {
     expect(screen.getByRole("link", { name: "Pedidos" })).toHaveAttribute(
       "href",
       "/account/orders",
+    );
+    expect(screen.getByRole("link", { name: "Favoritos" })).toHaveAttribute(
+      "href",
+      "/account/favorites",
     );
     expect(screen.getByRole("link", { name: "Buyer" })).toHaveAttribute(
       "href",

--- a/src/components/__tests__/ListingCard.test.tsx
+++ b/src/components/__tests__/ListingCard.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ListingCard, SkinThumb } from "../ProductCard";
 import { CartProvider, useCart } from "../../contexts/CartContext";
 import type { Listing } from "@/types/api";
@@ -70,13 +71,18 @@ function renderCard(
   listing: Listing,
   source?: "home" | "market" | "related" | "seller",
 ) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter>
-      <CartProvider>
-        <ListingCard listing={listing} source={source} />
-        <CartProbe />
-      </CartProvider>
-    </MemoryRouter>,
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CartProvider>
+          <ListingCard listing={listing} source={source} />
+          <CartProbe />
+        </CartProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -117,6 +123,26 @@ describe("ListingCard", () => {
     expect(screen.queryByText("AK-", { exact: true })).not.toBeInTheDocument();
   });
 
+  it("uses lazy loading on catalog images and falls back after onError", () => {
+    renderCard(makeListing());
+    const image = screen.getByRole("img", {
+      name: "AK-47 | Redline (Field-Tested)",
+    });
+    expect(image).toHaveAttribute("loading", "lazy");
+    expect(image).toHaveAttribute("decoding", "async");
+    fireEvent.error(image);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("AK-", { exact: true })).toBeInTheDocument();
+  });
+
+  it("links the seller name to the public store", () => {
+    renderCard(makeListing());
+    expect(screen.getByRole("link", { name: "Alice" })).toHaveAttribute(
+      "href",
+      "/stores/seller-1",
+    );
+  });
+
   it("falls back to the weapon monogram when imageUrl is missing", () => {
     renderCard(
       makeListing({
@@ -134,20 +160,25 @@ describe("ListingCard", () => {
     const { rerender } = renderCard(makeListing());
     expect(screen.queryByText("StatTrak™")).not.toBeInTheDocument();
 
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     rerender(
-      <MemoryRouter>
-        <CartProvider>
-          <ListingCard
-            listing={makeListing({
-              product: {
-                ...makeListing().product,
-                isStattrak: true,
-              },
-            })}
-          />
-          <CartProbe />
-        </CartProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <CartProvider>
+            <ListingCard
+              listing={makeListing({
+                product: {
+                  ...makeListing().product,
+                  isStattrak: true,
+                },
+              })}
+            />
+            <CartProbe />
+          </CartProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
     expect(screen.getByText("StatTrak™")).toBeInTheDocument();
   });
@@ -275,13 +306,18 @@ describe("ListingCard", () => {
     const { rerender } = renderCard(makeListing({ pattern: 412 }));
     expect(screen.getByText("Pattern: 412")).toBeInTheDocument();
 
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     rerender(
-      <MemoryRouter>
-        <CartProvider>
-          <ListingCard listing={makeListing({ pattern: null })} />
-          <CartProbe />
-        </CartProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <CartProvider>
+            <ListingCard listing={makeListing({ pattern: null })} />
+            <CartProbe />
+          </CartProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
     expect(screen.queryByText(/Pattern:/)).not.toBeInTheDocument();
   });

--- a/src/components/__tests__/RecentlyViewedRail.test.tsx
+++ b/src/components/__tests__/RecentlyViewedRail.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RecentlyViewedRail } from "../RecentlyViewedRail";
 import { CartProvider } from "@/contexts/CartContext";
 import type { Listing } from "@/types/api";
@@ -59,12 +60,17 @@ describe("RecentlyViewedRail", () => {
   });
 
   it("uses history copy instead of a personalization engine", () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     render(
-      <MemoryRouter>
-        <CartProvider>
-          <RecentlyViewedRail listings={[makeListing()]} />
-        </CartProvider>
-      </MemoryRouter>,
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <CartProvider>
+            <RecentlyViewedRail listings={[makeListing()]} />
+          </CartProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText(RECENTLY_VIEWED_HEADING)).toBeTruthy();

--- a/src/components/account/ApplySellerCard.tsx
+++ b/src/components/account/ApplySellerCard.tsx
@@ -1,0 +1,96 @@
+import { FormEvent, useState } from "react";
+import { Link } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { applySeller, getSellerMe } from "@/api/sellers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { userFacingApiError } from "@/lib/userFacingApiError";
+import type { User } from "@/types/api";
+
+const STORE_NAME_MAX = 120;
+
+export function ApplySellerCard({ role }: { role: User["role"] }) {
+  const queryClient = useQueryClient();
+  const [storeName, setStoreName] = useState("");
+  const sellerQuery = useQuery({
+    queryKey: ["sellerMe"],
+    queryFn: () => getSellerMe(),
+    retry: false,
+    enabled: role === "CUSTOMER" || role === "SELLER",
+  });
+
+  const apply = useMutation({
+    mutationFn: () => applySeller({ storeName: storeName.trim() }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["sellerMe"] });
+    },
+  });
+
+  if (role === "ADMIN") return null;
+
+  if (role === "SELLER" && sellerQuery.data?.isApproved) {
+    return (
+      <div className="rounded-md border border-border p-4">
+        <h2 className="text-lg font-semibold tracking-tight">Sua loja</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Conta de vendedor aprovada.
+        </p>
+        <Button asChild className="mt-3">
+          <Link to="/seller">Ir ao dashboard</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (sellerQuery.data && sellerQuery.data.isApproved === false) {
+    return (
+      <div className="rounded-md border border-border p-4">
+        <h2 className="text-lg font-semibold tracking-tight">Quero vender</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Pedido enviado para {sellerQuery.data.storeName}. Aguardando aprovação
+          de um admin.
+        </p>
+      </div>
+    );
+  }
+
+  if (role !== "CUSTOMER") return null;
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!storeName.trim() || apply.isPending) return;
+    apply.mutate();
+  };
+
+  return (
+    <div className="rounded-md border border-border p-4">
+      <h2 className="text-lg font-semibold tracking-tight">Quero vender</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Envie o nome da loja. Um admin aprova o cadastro nas telas atuais. Não
+        enviamos e-mail de aprovação por aqui.
+      </p>
+      <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+        <div>
+          <Label htmlFor="apply-store-name">Nome da loja</Label>
+          <Input
+            id="apply-store-name"
+            value={storeName}
+            maxLength={STORE_NAME_MAX}
+            onChange={(event) => setStoreName(event.target.value)}
+            className="mt-1.5"
+            required
+          />
+        </div>
+        {apply.isError ? (
+          <p className="text-sm text-destructive" role="alert">
+            {userFacingApiError(apply.error)}
+          </p>
+        ) : null}
+        <Button type="submit" disabled={!storeName.trim() || apply.isPending}>
+          {apply.isPending ? "Enviando..." : "Enviar candidatura"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/seller/OrderTrackingDialog.tsx
+++ b/src/components/seller/OrderTrackingDialog.tsx
@@ -1,0 +1,114 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateOrderTracking } from "@/api/orders";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { userFacingApiError } from "@/lib/userFacingApiError";
+import type { Order } from "@/types/api";
+
+export function OrderTrackingDialog({
+  order,
+  open,
+  onOpenChange,
+}: {
+  order: Order | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [trackingCode, setTrackingCode] = useState(order?.trackingCode ?? "");
+  const [trackingCarrier, setTrackingCarrier] = useState(
+    order?.trackingCarrier ?? "",
+  );
+
+  const save = useMutation({
+    mutationFn: () =>
+      updateOrderTracking(order!.id, {
+        trackingCode: trackingCode.trim(),
+        trackingCarrier: trackingCarrier.trim(),
+      }),
+    onSuccess: () => {
+      toast({ title: "Envio informado" });
+      void queryClient.invalidateQueries({ queryKey: ["sellerOrders"] });
+      onOpenChange(false);
+    },
+  });
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!order || !trackingCode.trim() || !trackingCarrier.trim()) return;
+    save.mutate();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (next && order) {
+          setTrackingCode(order.trackingCode ?? "");
+          setTrackingCarrier(order.trackingCarrier ?? "");
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Informar envio</DialogTitle>
+          <DialogDescription>
+            Código e transportadora deste pedido. Não altera o status do pedido.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <Label htmlFor="tracking-code">Código</Label>
+            <Input
+              id="tracking-code"
+              value={trackingCode}
+              onChange={(event) => setTrackingCode(event.target.value)}
+              className="mt-1.5"
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="tracking-carrier">Transportadora / método</Label>
+            <Input
+              id="tracking-carrier"
+              value={trackingCarrier}
+              onChange={(event) => setTrackingCarrier(event.target.value)}
+              className="mt-1.5"
+              required
+            />
+          </div>
+          {save.isError ? (
+            <p className="text-sm text-destructive" role="alert">
+              {userFacingApiError(save.error)}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="submit"
+              disabled={
+                save.isPending ||
+                !trackingCode.trim() ||
+                !trackingCarrier.trim()
+              }
+            >
+              {save.isPending ? "Salvando..." : "Salvar"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -166,3 +166,7 @@ export const useAuth = () => {
   if (!ctx) throw new Error("useAuth must be used within AuthProvider");
   return ctx;
 };
+
+export function useOptionalAuth() {
+  return useContext(AuthContext);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -151,3 +151,14 @@
 .rarity-accent-legendary {
   border-top: 2px solid hsl(var(--rarity-legendary));
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -10,10 +10,15 @@ import {
   Users,
   Shield,
   Tag,
+  Home,
+  Store,
+  LogOut,
 } from "lucide-react";
 import { getSellerMe } from "@/api/sellers";
+import { useAuth } from "@/contexts/AuthContext";
 import { SellerPendingBanner } from "@/components/seller/SellerPendingBanner";
 import { Header } from "@/components/Header";
+import { RouteFocus } from "@/components/RouteFocus";
 import { SiteFooter } from "@/components/SiteFooter";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,6 +40,7 @@ const sellerItems = [
 const adminItems = [
   { icon: BarChart3, label: "Visão Geral", href: "/admin" },
   { icon: Package, label: "Catálogo", href: "/admin/catalog" },
+  { icon: Tag, label: "Produtos", href: "/admin/products" },
   { icon: Users, label: "Vendedores", href: "/admin/sellers" },
   { icon: ShoppingBag, label: "Pedidos", href: "/admin/orders" },
   { icon: Shield, label: "Usuários", href: "/admin/users" },
@@ -81,6 +87,7 @@ function NavItems({
 
 export default function DashboardLayout() {
   const location = useLocation();
+  const { logout } = useAuth();
   const isAdmin = location.pathname.startsWith("/admin");
   const items = isAdmin ? adminItems : sellerItems;
   const [open, setOpen] = useState(false);
@@ -90,10 +97,12 @@ export default function DashboardLayout() {
     enabled: !isAdmin,
   });
   const showPendingBanner = sellerMeQuery.data?.isApproved === false;
+  const sheetTitle = isAdmin ? "Admin" : "Painel do vendedor";
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
-      <Header />
+      <RouteFocus />
+      <Header hideMobileMenu />
       <div className="flex flex-1">
         <aside className="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-56 shrink-0 border-r border-border p-4 lg:flex lg:flex-col">
           <NavItems items={items} pathname={location.pathname} />
@@ -104,28 +113,59 @@ export default function DashboardLayout() {
               variant="outline"
               size="sm"
               className="min-h-11"
+              aria-expanded={open}
+              aria-haspopup="dialog"
               onClick={() => setOpen(true)}
             >
               <Menu className="mr-2 h-4 w-4" />
-              Menu do painel
+              Menu
             </Button>
             <Sheet open={open} onOpenChange={setOpen}>
               <SheetContent side="left" className="w-72">
                 <SheetHeader>
-                  <SheetTitle>{isAdmin ? "Admin" : "Dashboard"}</SheetTitle>
-                  <SheetDescription>Navegação do painel</SheetDescription>
+                  <SheetTitle>{sheetTitle}</SheetTitle>
+                  <SheetDescription>Loja e painel</SheetDescription>
                 </SheetHeader>
-                <div className="mt-4">
+                <div className="mt-4 space-y-6">
+                  <nav className="space-y-1" aria-label="Loja">
+                    <Link
+                      to="/"
+                      onClick={() => setOpen(false)}
+                      className="flex min-h-11 items-center gap-3 rounded-md px-3 py-2.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                    >
+                      <Home className="h-4 w-4 shrink-0" />
+                      Home
+                    </Link>
+                    <Link
+                      to="/products"
+                      onClick={() => setOpen(false)}
+                      className="flex min-h-11 items-center gap-3 rounded-md px-3 py-2.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                    >
+                      <Store className="h-4 w-4 shrink-0" />
+                      Market
+                    </Link>
+                  </nav>
                   <NavItems
                     items={items}
                     pathname={location.pathname}
                     onNavigate={() => setOpen(false)}
                   />
+                  <button
+                    type="button"
+                    className="flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2.5 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                    onClick={() => {
+                      void logout();
+                      setOpen(false);
+                    }}
+                  >
+                    <LogOut className="h-4 w-4 shrink-0" />
+                    Sair
+                  </button>
                 </div>
               </SheetContent>
             </Sheet>
           </div>
-          <main className="flex-1 p-6">
+          <main id="conteudo" tabIndex={-1} className="flex-1 p-6 outline-none">
             {showPendingBanner ? <SellerPendingBanner /> : null}
             <Outlet />
           </main>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,12 +1,14 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "@/components/Header";
+import { RouteFocus } from "@/components/RouteFocus";
 import { SiteFooter } from "@/components/SiteFooter";
 
 export default function MainLayout() {
   return (
     <div className="flex min-h-screen flex-col bg-background">
+      <RouteFocus />
       <Header />
-      <main className="flex-1">
+      <main id="conteudo" tabIndex={-1} className="flex-1 outline-none">
         <Outlet />
       </main>
       <SiteFooter />

--- a/src/layouts/__tests__/DashboardLayout.test.tsx
+++ b/src/layouts/__tests__/DashboardLayout.test.tsx
@@ -20,6 +20,19 @@ vi.mock("@/api/sellers", () => ({
   getSellerMe: (...args: unknown[]) => getSellerMe(...args),
 }));
 
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    logout: vi.fn(),
+    user: { role: "SELLER" },
+    isAuthenticated: true,
+  }),
+  useOptionalAuth: () => ({
+    logout: vi.fn(),
+    user: { role: "SELLER" },
+    isAuthenticated: true,
+  }),
+}));
+
 function sellerMe(overrides: Partial<Seller> = {}): Seller {
   return {
     id: "seller-1",
@@ -43,6 +56,7 @@ function renderLayout(path: string) {
           <Route element={<DashboardLayout />}>
             <Route path="/admin" element={<div>overview</div>} />
             <Route path="/admin/catalog" element={<div>catalog-page</div>} />
+            <Route path="/admin/products" element={<div>products-page</div>} />
             <Route path="/admin/orders" element={<div>admin-orders</div>} />
             <Route path="/seller" element={<div>overview</div>} />
             <Route
@@ -79,6 +93,13 @@ describe("DashboardLayout admin nav", () => {
       screen.getAllByRole("link", { name: "Visão Geral" })[0],
     ).toHaveAttribute("href", "/admin");
     expect(getSellerMe).not.toHaveBeenCalled();
+  });
+
+  it("exposes Produtos CRUD next to Catálogo", () => {
+    renderAdminNav("/admin/products");
+    const links = screen.getAllByRole("link", { name: "Produtos" });
+    expect(links[0]).toHaveAttribute("href", "/admin/products");
+    expect(screen.getByText("products-page")).toBeTruthy();
   });
 
   it("marks Catálogo current on /admin/catalog", () => {

--- a/src/lib/__tests__/marketListings.test.ts
+++ b/src/lib/__tests__/marketListings.test.ts
@@ -81,6 +81,7 @@ describe("fetchMarketListings", () => {
       page: 1,
       limit: 20,
       status: "ACTIVE",
+      sort: "createdAt_desc",
     });
     expect(result.items).toHaveLength(1);
   });
@@ -116,6 +117,7 @@ describe("fetchMarketListings", () => {
       status: "ACTIVE",
       productId: "talon-fade-fn",
       exterior: "Factory New",
+      sort: "createdAt_desc",
     });
     expect(result.items[0]?.id).toBe("listing-talon");
   });
@@ -165,7 +167,7 @@ describe("fetchMarketListings", () => {
     }));
 
     const result = await fetchMarketListings(
-      parseMarketQuery(new URLSearchParams("q=Printstream&sort=price-asc")),
+      parseMarketQuery(new URLSearchParams("q=Printstream&sort=price_asc")),
     );
 
     expect(listListings).toHaveBeenCalledTimes(2);
@@ -183,7 +185,7 @@ describe("sortMarketListings", () => {
     const b = makeListing({ id: "b", price: 10 });
     const input = [a, b];
     expect(
-      sortMarketListings(input, "price-asc").map((item) => item.id),
+      sortMarketListings(input, "price_asc").map((item) => item.id),
     ).toEqual(["b", "a"]);
     expect(input.map((item) => item.id)).toEqual(["a", "b"]);
   });

--- a/src/lib/__tests__/marketQuery.test.ts
+++ b/src/lib/__tests__/marketQuery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   hasMarketFilters,
+  isValidNumericRange,
   marketPath,
   marketSearchEmptyTitle,
   parseMarketQuery,
@@ -24,7 +25,9 @@ describe("parseMarketQuery", () => {
       maxPrice: "40",
       minFloat: "0.1",
       maxFloat: "0.3",
-      sort: "price-asc",
+      weapon: "",
+      rarity: "",
+      sort: "price_asc",
       page: 2,
     });
   });
@@ -53,6 +56,8 @@ describe("parseMarketQuery", () => {
       maxPrice: "",
       minFloat: "",
       maxFloat: "",
+      weapon: "",
+      rarity: "",
       sort: "",
       page: 1,
     });
@@ -70,6 +75,8 @@ describe("serializeMarketQuery", () => {
         maxPrice: "",
         minFloat: "",
         maxFloat: "",
+        weapon: "",
+        rarity: "",
         sort: "",
         page: 1,
       }).toString(),
@@ -85,6 +92,8 @@ describe("serializeMarketQuery", () => {
       maxPrice: "",
       minFloat: "",
       maxFloat: "",
+      weapon: "",
+      rarity: "",
       sort: "",
       page: 1,
     }).toString();
@@ -126,5 +135,25 @@ describe("hasMarketFilters", () => {
 describe("marketSearchEmptyTitle", () => {
   it("includes the typed term", () => {
     expect(marketSearchEmptyTitle("talon")).toBe("Nenhum listing para ‘talon’");
+  });
+});
+
+describe("weapon and rarity", () => {
+  it("round-trips weapon and rarity in the Market URL", () => {
+    const query = parseMarketQuery(
+      new URLSearchParams("weapon=AK-47&rarity=Covert"),
+    );
+    expect(query.weapon).toBe("AK-47");
+    expect(query.rarity).toBe("Covert");
+    expect(serializeMarketQuery(query).toString()).toBe(
+      "weapon=AK-47&rarity=Covert",
+    );
+  });
+});
+
+describe("isValidNumericRange", () => {
+  it("rejects min greater than max", () => {
+    expect(isValidNumericRange("0.4", "0.1")).toBe(false);
+    expect(isValidNumericRange("0.1", "0.4")).toBe(true);
   });
 });

--- a/src/lib/__tests__/prefetchListing.test.ts
+++ b/src/lib/__tests__/prefetchListing.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import {
+  prefetchListingDetail,
+  resetListingPrefetchForTests,
+} from "../prefetchListing";
+
+const getListing = vi.fn();
+
+vi.mock("@/api/listings", () => ({
+  getListing: (...args: unknown[]) => getListing(...args),
+}));
+
+describe("prefetchListingDetail", () => {
+  beforeEach(() => {
+    getListing.mockReset();
+    getListing.mockResolvedValue({ id: "listing-1" });
+    resetListingPrefetchForTests();
+  });
+
+  it("issues at most one GET per listing per interval", () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    prefetchListingDetail(client, "listing-1");
+    prefetchListingDetail(client, "listing-1");
+    expect(getListing).toHaveBeenCalledTimes(1);
+    expect(getListing).toHaveBeenCalledWith("listing-1");
+  });
+});

--- a/src/lib/__tests__/priceHistoryView.test.ts
+++ b/src/lib/__tests__/priceHistoryView.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { PRICE_HISTORY_EMPTY, sparklinePoints } from "../priceHistoryView";
+
+describe("priceHistoryView", () => {
+  it("keeps empty copy honest", () => {
+    expect(PRICE_HISTORY_EMPTY).toBe("Sem alterações de preço ainda");
+  });
+
+  it("builds svg points from newPrice values", () => {
+    const points = sparklinePoints([
+      {
+        id: "1",
+        listingId: "l1",
+        oldPrice: 10,
+        newPrice: 12,
+        changedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "2",
+        listingId: "l1",
+        oldPrice: 12,
+        newPrice: 8,
+        changedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ]);
+    expect(points.split(" ")).toHaveLength(2);
+  });
+});

--- a/src/lib/__tests__/queryClient.test.ts
+++ b/src/lib/__tests__/queryClient.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  QUERY_GET_RETRY,
+  QUERY_MUTATION_RETRY,
+  createAppQueryClient,
+} from "../queryClient";
+
+describe("createAppQueryClient", () => {
+  it("retries GET once and mutations never", () => {
+    const client = createAppQueryClient();
+    expect(QUERY_GET_RETRY).toBe(1);
+    expect(QUERY_MUTATION_RETRY).toBe(0);
+    expect(client.getDefaultOptions().queries?.retry).toBe(1);
+    expect(client.getDefaultOptions().mutations?.retry).toBe(0);
+  });
+});

--- a/src/lib/__tests__/userFacingApiError.test.ts
+++ b/src/lib/__tests__/userFacingApiError.test.ts
@@ -21,6 +21,7 @@ import {
   listingStatusLabel,
   orderStatusLabel,
   paymentStatusLabel,
+  toUserMessage,
   userFacingApiError,
 } from "../userFacingApiError";
 
@@ -32,6 +33,7 @@ describe("userFacingApiError", () => {
     );
 
     expect(userFacingApiError(error)).toBe(USER_FACING_NETWORK);
+    expect(toUserMessage(error)).toBe(USER_FACING_NETWORK);
     expect(error.message).toContain("http://localhost:3001");
     expect(error.message).toContain("Failed to fetch");
     expect(userFacingApiError(error)).not.toMatch(

--- a/src/lib/catalogTaxonomy.ts
+++ b/src/lib/catalogTaxonomy.ts
@@ -1,0 +1,36 @@
+/** Static CS2 weapons aligned to the demo catalog. Not a recommendation engine. */
+export const MARKET_WEAPONS = [
+  "AK-47",
+  "AWP",
+  "M4A4",
+  "M4A1-S",
+  "USP-S",
+  "Glock-18",
+  "Desert Eagle",
+  "Karambit",
+  "Talon Knife",
+  "Butterfly Knife",
+] as const;
+
+export const MARKET_RARITIES = [
+  "Consumer Grade",
+  "Industrial Grade",
+  "Mil-Spec Grade",
+  "Restricted",
+  "Classified",
+  "Covert",
+  "Exceedingly Rare",
+  "Contraband",
+  "Extraordinary",
+] as const;
+
+export type MarketWeapon = (typeof MARKET_WEAPONS)[number] | "";
+export type MarketRarity = (typeof MARKET_RARITIES)[number] | "";
+
+export const PRODUCT_EXTERIORS = [
+  "Factory New",
+  "Minimal Wear",
+  "Field-Tested",
+  "Well-Worn",
+  "Battle-Scarred",
+] as const;

--- a/src/lib/marketListings.ts
+++ b/src/lib/marketListings.ts
@@ -4,6 +4,8 @@ import type { Listing, ListListingsResponse } from "@/types/api";
 import {
   MARKET_PAGE_SIZE,
   MARKET_SEARCH_PRODUCT_LIMIT,
+  isValidMarketRange,
+  toListingSort,
   type MarketQuery,
   type MarketSort,
 } from "@/lib/marketQuery";
@@ -11,6 +13,7 @@ import {
 function listingFilters(query: MarketQuery): ListListingsParams {
   return {
     status: "ACTIVE",
+    sort: toListingSort(query.sort),
     ...(query.productId ? { productId: query.productId } : {}),
     ...(query.exterior ? { exterior: query.exterior } : {}),
     ...(query.isStattrak !== undefined ? { isStattrak: query.isStattrak } : {}),
@@ -18,25 +21,31 @@ function listingFilters(query: MarketQuery): ListListingsParams {
     ...(query.maxPrice ? { maxPrice: parseFloat(query.maxPrice) } : {}),
     ...(query.minFloat ? { minFloat: parseFloat(query.minFloat) } : {}),
     ...(query.maxFloat ? { maxFloat: parseFloat(query.maxFloat) } : {}),
+    ...(query.weapon ? { weapon: query.weapon } : {}),
+    ...(query.rarity ? { rarity: query.rarity } : {}),
   };
 }
 
+/**
+ * Only used when textual search merges several product pages into one
+ * complete result set. Never used to re-sort a single GET /listings page.
+ */
 export function sortMarketListings(
   items: Listing[],
   sort: MarketSort,
 ): Listing[] {
-  if (sort === "price-asc") {
+  if (sort === "price_asc") {
     return [...items].sort((a, b) => Number(a.price) - Number(b.price));
   }
-  if (sort === "price-desc") {
+  if (sort === "price_desc") {
     return [...items].sort((a, b) => Number(b.price) - Number(a.price));
   }
-  if (sort === "float-asc") {
+  if (sort === "float_asc") {
     return [...items].sort(
       (a, b) => Number(a.floatValue) - Number(b.floatValue),
     );
   }
-  if (sort === "float-desc") {
+  if (sort === "float_desc") {
     return [...items].sort(
       (a, b) => Number(b.floatValue) - Number(a.floatValue),
     );
@@ -67,22 +76,24 @@ function paginate(
  * Storefront catalog. `GET /listings` has no `search`; resolve `q` through
  * `GET /products?search=` (weapon / skin / collection / marketHashName), then
  * load ACTIVE listings for those product ids.
+ *
+ * Sort is sent to GET /listings. The current page is not re-sorted.
  */
 export async function fetchMarketListings(
   query: MarketQuery,
 ): Promise<ListListingsResponse> {
+  if (!isValidMarketRange(query)) {
+    return emptyPage(query.page);
+  }
+
   const filters = listingFilters(query);
 
   if (!query.q) {
-    const result = await listListings({
+    return listListings({
       ...filters,
       page: query.page,
       limit: MARKET_PAGE_SIZE,
     });
-    return {
-      ...result,
-      items: sortMarketListings(result.items, query.sort),
-    };
   }
 
   const products = await listProducts({
@@ -96,16 +107,12 @@ export async function fetchMarketListings(
   if (ids.length === 0) return emptyPage(query.page);
 
   if (ids.length === 1) {
-    const result = await listListings({
+    return listListings({
       ...filters,
       productId: ids[0],
       page: query.page,
       limit: MARKET_PAGE_SIZE,
     });
-    return {
-      ...result,
-      items: sortMarketListings(result.items, query.sort),
-    };
   }
 
   const pages = await Promise.all(

--- a/src/lib/marketQuery.ts
+++ b/src/lib/marketQuery.ts
@@ -1,5 +1,8 @@
 /** Market catalog query: URL is the source of truth. */
 
+import { MARKET_RARITIES } from "@/lib/catalogTaxonomy";
+import type { ListingSort } from "@/api/listings";
+
 export const MARKET_EXTERIORS = [
   "",
   "Factory New",
@@ -9,17 +12,34 @@ export const MARKET_EXTERIORS = [
   "Battle-Scarred",
 ] as const;
 
+/** URL + UI values match the GET /listings sort whitelist. */
 export const MARKET_SORTS = [
   { value: "", label: "Padrão" },
-  { value: "price-asc", label: "Menor Preço" },
-  { value: "price-desc", label: "Maior Preço" },
-  { value: "float-asc", label: "Menor Float" },
-  { value: "float-desc", label: "Maior Float" },
+  { value: "price_asc", label: "Menor Preço" },
+  { value: "price_desc", label: "Maior Preço" },
+  { value: "float_asc", label: "Menor Float" },
+  { value: "float_desc", label: "Maior Float" },
 ] as const;
+
+const LEGACY_SORT: Record<string, MarketSort> = {
+  "price-asc": "price_asc",
+  "price-desc": "price_desc",
+  "float-asc": "float_asc",
+  "float-desc": "float_desc",
+  createdAt_desc: "",
+  newest: "",
+};
 
 export const MARKET_PAGE_SIZE = 20;
 export const MARKET_SEARCH_DEBOUNCE_MS = 300;
 export const MARKET_SEARCH_PRODUCT_LIMIT = 100;
+export const MARKET_SORT_DEFAULT_COPY = "mais recentes";
+export const MARKET_FLOAT_HINT = "0.00–1.00";
+export const MARKET_FLOAT_RANGE_ERROR =
+  "O float mínimo não pode ser maior que o máximo.";
+export const MARKET_FILTERS_EMPTY_TITLE = "Nenhum listing com estes filtros";
+export const MARKET_CATALOG_EMPTY_TITLE = "Nenhum item encontrado";
+export const MARKET_CATALOG_EMPTY_DESCRIPTION = "Tente ajustar os filtros";
 
 export type MarketExterior = (typeof MARKET_EXTERIORS)[number];
 export type MarketSort = (typeof MARKET_SORTS)[number]["value"];
@@ -27,18 +47,21 @@ export type MarketSort = (typeof MARKET_SORTS)[number]["value"];
 export interface MarketQuery {
   q: string;
   productId?: string;
-  exterior: MarketExterior;
+  exterior: string;
   isStattrak: boolean | undefined;
   minPrice: string;
   maxPrice: string;
   minFloat: string;
   maxFloat: string;
+  weapon: string;
+  rarity: string;
   sort: MarketSort;
   page: number;
 }
 
 const EXTERIOR_SET = new Set<string>(MARKET_EXTERIORS.filter(Boolean));
 const SORT_SET = new Set<string>(MARKET_SORTS.map((item) => item.value));
+const RARITY_SET = new Set<string>(MARKET_RARITIES);
 
 function readTrimmed(params: URLSearchParams, key: string): string {
   return params.get(key)?.trim() ?? "";
@@ -77,7 +100,16 @@ function parseExterior(value: string): MarketExterior {
 }
 
 function parseSort(value: string): MarketSort {
+  if (LEGACY_SORT[value] !== undefined) return LEGACY_SORT[value];
   return SORT_SET.has(value) ? (value as MarketSort) : "";
+}
+
+function parseWeapon(value: string): string {
+  return value;
+}
+
+function parseRarity(value: string): string {
+  return RARITY_SET.has(value) ? value : "";
 }
 
 /** `q` wins over `search`. Empty / invalid values become defaults. */
@@ -93,6 +125,8 @@ export function parseMarketQuery(params: URLSearchParams): MarketQuery {
     maxPrice: parseMoney(readTrimmed(params, "maxPrice")),
     minFloat: parseFloatRange(readTrimmed(params, "minFloat")),
     maxFloat: parseFloatRange(readTrimmed(params, "maxFloat")),
+    weapon: parseWeapon(readTrimmed(params, "weapon")),
+    rarity: parseRarity(readTrimmed(params, "rarity")),
     sort: parseSort(readTrimmed(params, "sort")),
     page: parsePage(params.get("page")),
   };
@@ -110,13 +144,15 @@ export function serializeMarketQuery(query: MarketQuery): URLSearchParams {
   if (query.maxPrice) params.set("maxPrice", query.maxPrice);
   if (query.minFloat) params.set("minFloat", query.minFloat);
   if (query.maxFloat) params.set("maxFloat", query.maxFloat);
+  if (query.weapon) params.set("weapon", query.weapon);
+  if (query.rarity) params.set("rarity", query.rarity);
   if (query.sort) params.set("sort", query.sort);
   if (query.page > 1) params.set("page", String(query.page));
   return params;
 }
 
-export function marketPath(query: Partial<MarketQuery> = {}): string {
-  const params = serializeMarketQuery({
+export function emptyMarketQuery(): MarketQuery {
+  return {
     q: "",
     exterior: "",
     isStattrak: undefined,
@@ -124,8 +160,16 @@ export function marketPath(query: Partial<MarketQuery> = {}): string {
     maxPrice: "",
     minFloat: "",
     maxFloat: "",
+    weapon: "",
+    rarity: "",
     sort: "",
     page: 1,
+  };
+}
+
+export function marketPath(query: Partial<MarketQuery> = {}): string {
+  const params = serializeMarketQuery({
+    ...emptyMarketQuery(),
     ...query,
   });
   const qs = params.toString();
@@ -149,8 +193,66 @@ export function hasMarketFilters(query: MarketQuery): boolean {
     query.maxPrice ||
     query.minFloat ||
     query.maxFloat ||
+    query.weapon ||
+    query.rarity ||
     query.sort,
   );
+}
+
+/** Filters that can zero the catalog (sort alone does not). */
+export function hasActiveMarketConstraints(query: MarketQuery): boolean {
+  return Boolean(
+    query.q ||
+    query.productId ||
+    query.exterior ||
+    query.isStattrak !== undefined ||
+    query.minPrice ||
+    query.maxPrice ||
+    query.minFloat ||
+    query.maxFloat ||
+    query.weapon ||
+    query.rarity,
+  );
+}
+
+export function isValidNumericRange(min: string, max: string): boolean {
+  if (!min || !max) return true;
+  const low = Number(min);
+  const high = Number(max);
+  if (!Number.isFinite(low) || !Number.isFinite(high)) return true;
+  return low <= high;
+}
+
+export function isValidMarketRange(query: MarketQuery): boolean {
+  return (
+    isValidNumericRange(query.minFloat, query.maxFloat) &&
+    isValidNumericRange(query.minPrice, query.maxPrice)
+  );
+}
+
+export function toListingSort(sort: MarketSort): ListingSort {
+  if (sort === "price_asc") return "price_asc";
+  if (sort === "price_desc") return "price_desc";
+  if (sort === "float_asc") return "float_asc";
+  if (sort === "float_desc") return "float_desc";
+  return "createdAt_desc";
+}
+
+export function describeMarketFilters(query: MarketQuery): string[] {
+  const parts: string[] = [];
+  if (query.q) parts.push(`busca “${query.q}”`);
+  if (query.weapon) parts.push(`arma ${query.weapon}`);
+  if (query.rarity) parts.push(`raridade ${query.rarity}`);
+  if (query.exterior) parts.push(`exterior ${query.exterior}`);
+  if (query.isStattrak === true) parts.push("StatTrak™");
+  if (query.isStattrak === false) parts.push("sem StatTrak");
+  if (query.minPrice || query.maxPrice) {
+    parts.push(`preço ${query.minPrice || "0"}–${query.maxPrice || "∞"}`);
+  }
+  if (query.minFloat || query.maxFloat) {
+    parts.push(`float ${query.minFloat || "0"}–${query.maxFloat || "1"}`);
+  }
+  return parts;
 }
 
 export function marketSearchEmptyTitle(term: string): string {

--- a/src/lib/pendingFavorite.ts
+++ b/src/lib/pendingFavorite.ts
@@ -1,0 +1,19 @@
+const STORAGE_KEY = "pendingFavoriteListingId";
+
+export function setPendingFavoriteListingId(listingId: string): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, listingId);
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+export function consumePendingFavoriteListingId(): string | null {
+  try {
+    const value = sessionStorage.getItem(STORAGE_KEY);
+    if (value) sessionStorage.removeItem(STORAGE_KEY);
+    return value;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/prefetchListing.ts
+++ b/src/lib/prefetchListing.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { getListing } from "@/api/listings";
+
+const lastPrefetchAt = new Map<string, number>();
+export const LISTING_PREFETCH_TTL_MS = 60_000;
+
+/** At most one GET /listings/:id per listing per TTL (hover/focus). */
+export function prefetchListingDetail(
+  queryClient: QueryClient,
+  listingId: string,
+): void {
+  if (!listingId) return;
+  const now = Date.now();
+  const last = lastPrefetchAt.get(listingId) ?? 0;
+  if (now - last < LISTING_PREFETCH_TTL_MS) return;
+  lastPrefetchAt.set(listingId, now);
+  void queryClient.prefetchQuery({
+    queryKey: ["listing", listingId],
+    queryFn: () => getListing(listingId),
+  });
+}
+
+export function resetListingPrefetchForTests(): void {
+  lastPrefetchAt.clear();
+}

--- a/src/lib/priceHistoryView.ts
+++ b/src/lib/priceHistoryView.ts
@@ -1,0 +1,28 @@
+import type { PriceHistory } from "@/types/api";
+
+export const PRICE_HISTORY_EMPTY = "Sem alterações de preço ainda";
+export const PRICE_HISTORY_HEADING = "Histórico de preços deste listing";
+export const PRICE_HISTORY_COPY =
+  "Alterações feitas pelo vendedor neste listing. Não é um índice de mercado Steam.";
+
+export function sparklinePoints(
+  entries: PriceHistory[],
+  width = 160,
+  height = 36,
+): string {
+  if (entries.length === 0) return "";
+  const prices = entries.map((entry) => Number(entry.newPrice));
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+  const span = max - min || 1;
+  return prices
+    .map((price, index) => {
+      const x =
+        entries.length === 1
+          ? width / 2
+          : (index / (entries.length - 1)) * width;
+      const y = height - ((price - min) / span) * (height - 4) - 2;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,27 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Storefront QueryClient defaults (#118 / #119):
+ * - GET queries retry once (transient 5xx / network), not the React Query 3x default.
+ * - Mutations never retry (avoids duplicate POSTs).
+ * - Listings staleTime is modest so Market feels fresh without a refetch storm.
+ * - throwOnError stays false so page queries render ErrorState instead of crashing.
+ */
+export const QUERY_GET_RETRY = 1;
+export const QUERY_MUTATION_RETRY = 0;
+export const LISTINGS_STALE_TIME_MS = 30_000;
+
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: QUERY_GET_RETRY,
+        staleTime: LISTINGS_STALE_TIME_MS,
+        throwOnError: false,
+      },
+      mutations: {
+        retry: QUERY_MUTATION_RETRY,
+      },
+    },
+  });
+}

--- a/src/lib/relatedListings.ts
+++ b/src/lib/relatedListings.ts
@@ -1,0 +1,40 @@
+import type { Listing } from "@/types/api";
+
+export function excludeListingIds(
+  items: Listing[],
+  excludeIds: ReadonlySet<string>,
+): Listing[] {
+  return items.filter((item) => !excludeIds.has(item.id));
+}
+
+export function takeUniqueListings(
+  items: Listing[],
+  excludeIds: ReadonlySet<string>,
+  limit: number,
+): Listing[] {
+  const seen = new Set(excludeIds);
+  const result: Listing[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    result.push(item);
+    if (result.length >= limit) break;
+  }
+  return result;
+}
+
+export function relatedSkinHeading(count: number): string {
+  return count > 0
+    ? "Outros listings desta skin"
+    : "Outros listings desta skin";
+}
+
+export function relatedFallbackHeading(kind: "weapon" | "collection"): string {
+  return kind === "collection"
+    ? "Outros listings desta coleção"
+    : "Outros listings desta arma";
+}
+
+export function moreFromSellerHeading(storeName: string): string {
+  return `Mais de ${storeName}`;
+}

--- a/src/lib/storePath.ts
+++ b/src/lib/storePath.ts
@@ -1,0 +1,6 @@
+export function storePath(sellerId: string): string {
+  return `/stores/${sellerId}`;
+}
+
+export const SELLER_RATING_COPY =
+  "Nota da loja (campo do vendedor, não média de avaliações)";

--- a/src/lib/userFacingApiError.ts
+++ b/src/lib/userFacingApiError.ts
@@ -68,6 +68,14 @@ export class ApiClientError extends Error {
   }
 }
 
+/** Typed HTTP failure from `api` (`res.ok === false` includes `status`). */
+export class ApiError extends ApiClientError {
+  constructor(message: string, options?: { status?: number; code?: string }) {
+    super(message, options);
+    this.name = "ApiError";
+  }
+}
+
 const LISTING_STATUS_LABELS: Record<string, string> = {
   ACTIVE: "Disponível",
   RESERVED: "Reservado",
@@ -246,6 +254,9 @@ export function userFacingApiError(error: unknown): string {
 
   return leaksTechnicalDetail(copy) ? USER_FACING_GENERIC : copy;
 }
+
+/** Page-facing mapper — callers should not parse `Failed to fetch` themselves. */
+export const toUserMessage = userFacingApiError;
 
 export function logTechnicalError(error: unknown): void {
   if (import.meta.env.DEV) {

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -4,6 +4,7 @@ import { Eye, EyeOff } from "lucide-react";
 import { getMe } from "@/api/users";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
+import { ApplySellerCard } from "@/components/account/ApplySellerCard";
 import { ErrorState } from "@/components/page-state";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -293,12 +294,21 @@ export default function AccountPage() {
         </Button>
       </form>
 
+      <div className="mt-10">
+        <ApplySellerCard role={user?.role ?? loaded.role} />
+      </div>
+
       <div className="mt-10 space-y-3">
         <h2 className="text-lg font-semibold tracking-tight">Atalhos</h2>
         <div className="flex flex-wrap gap-2">
           {isCustomer ? (
             <Button asChild variant="outline">
               <Link to="/account/orders">Meus pedidos</Link>
+            </Button>
+          ) : null}
+          {isCustomer ? (
+            <Button asChild variant="outline">
+              <Link to="/account/favorites">Favoritos</Link>
             </Button>
           ) : null}
           {sellerAdminPath ? (

--- a/src/pages/AccountFavorites.tsx
+++ b/src/pages/AccountFavorites.tsx
@@ -1,0 +1,104 @@
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { listFavorites } from "@/api/favorites";
+import { ListingCard } from "@/components/ProductCard";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { similarItemsMarketPath } from "@/lib/listingCartCta";
+
+export default function AccountFavoritesPage() {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["favorites"],
+    queryFn: listFavorites,
+  });
+
+  if (isLoading) {
+    return (
+      <div
+        className="container space-y-4 py-8"
+        role="status"
+        aria-label="Carregando"
+      >
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="container py-8">
+        <ErrorState
+          title="Erro ao carregar favoritos"
+          error={error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void refetch()}
+            >
+              Tentar novamente
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  const items = data ?? [];
+
+  return (
+    <div className="container py-8">
+      <h1 className="text-2xl font-semibold tracking-tight">Favoritos</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Itens salvos na sua conta. Sobrevivem ao recarregar a página.
+      </p>
+
+      {items.length === 0 ? (
+        <EmptyState
+          title="Nenhum favorito"
+          description="Salve um listing no Market para voltar depois."
+          action={
+            <Button asChild>
+              <Link to="/products">Explorar Market</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <ul className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((favorite) => {
+            const listing = favorite.listing;
+            if (!listing) {
+              return (
+                <li
+                  key={favorite.id}
+                  className="rounded-md border border-border p-4 text-sm text-muted-foreground"
+                >
+                  Listing {favorite.listingId}
+                </li>
+              );
+            }
+            return (
+              <li key={favorite.id} className="space-y-2">
+                {listing.status === "SOLD" ? (
+                  <div className="flex items-center justify-between gap-2">
+                    <Badge variant="secondary">Vendido</Badge>
+                    <Link
+                      to={similarItemsMarketPath(listing.productId)}
+                      className="text-sm underline-offset-2 hover:underline"
+                    >
+                      Ver relacionados
+                    </Link>
+                  </div>
+                ) : null}
+                <ListingCard listing={listing} source="related" />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { adminApproveSeller, listAdminOrders } from "@/api/admin";
 import { listProducts } from "@/api/products";
@@ -152,6 +153,11 @@ export default function AdminDashboard() {
               <EmptyState
                 title="Nenhum vendedor pendente de aprovação"
                 description="Todos os cadastros já foram revisados."
+                action={
+                  <Button asChild variant="outline">
+                    <Link to="/admin/sellers">Ver vendedores</Link>
+                  </Button>
+                }
               />
             ) : (
               <PendingSellersTable
@@ -172,7 +178,14 @@ export default function AdminDashboard() {
               Todos os vendedores
             </h2>
             {sellers.length === 0 ? (
-              <EmptyState title="Nenhum vendedor cadastrado" />
+              <EmptyState
+                title="Nenhum vendedor cadastrado"
+                action={
+                  <Button asChild>
+                    <Link to="/admin/users">Ver usuários</Link>
+                  </Button>
+                }
+              />
             ) : (
               <SellersOverviewTable sellers={sellers} />
             )}
@@ -183,7 +196,15 @@ export default function AdminDashboard() {
               Pedidos recentes
             </h2>
             {recentOrders.length === 0 ? (
-              <EmptyState title="Nenhum pedido encontrado" />
+              <EmptyState
+                title="Nenhum pedido encontrado"
+                description="Enquanto isso, revise vendedores ou o catálogo."
+                action={
+                  <Button asChild>
+                    <Link to="/admin/sellers">Aprovar vendedores</Link>
+                  </Button>
+                }
+              />
             ) : (
               <RecentOrdersTable orders={recentOrders} />
             )}

--- a/src/pages/ListingDetail.tsx
+++ b/src/pages/ListingDetail.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
-import { useParams, Link, useNavigate, useLocation } from "react-router-dom";
+import { useParams, Link, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft } from "lucide-react";
 import { ListingCard, SkinVisual } from "@/components/ProductCard";
 import { ListingCartCta } from "@/components/ListingCartCta";
+import { FavoriteButton } from "@/components/FavoriteButton";
+import { PriceHistorySection } from "@/components/PriceHistorySection";
 import { ProductReviews } from "@/components/ProductReviews";
 import { RecentlyViewedRail } from "@/components/RecentlyViewedRail";
 import { ErrorState } from "@/components/page-state";
@@ -11,9 +12,24 @@ import { getListing, listListings } from "@/api/listings";
 import { getPriceHistory } from "@/api/price-history";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { useRecentlyViewedListings } from "@/hooks/useRecentlyViewedListings";
 import { recordRecentlyViewedId } from "@/lib/recentlyViewed";
 import { analyticsPrice, readAnalyticsSource, track } from "@/lib/analytics";
+import { marketPath } from "@/lib/marketQuery";
+import {
+  moreFromSellerHeading,
+  relatedFallbackHeading,
+  takeUniqueListings,
+} from "@/lib/relatedListings";
+import { SELLER_RATING_COPY, storePath } from "@/lib/storePath";
 import {
   isNotFoundApiError,
   isRetryableReadError,
@@ -22,7 +38,6 @@ import {
 
 export default function ListingDetail() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const location = useLocation();
   const source = readAnalyticsSource(location.state);
 
@@ -44,20 +59,74 @@ export default function ListingDetail() {
     enabled: !!id,
   });
 
-  const { data: relatedData } = useQuery({
-    queryKey: ["listings", { productId: listing?.productId, limit: 4 }],
+  const { data: relatedSkinData } = useQuery({
+    queryKey: ["listings", { productId: listing?.productId, limit: 5 }],
     queryFn: () =>
       listListings({
         productId: listing?.productId,
         status: "ACTIVE",
-        limit: 4,
+        limit: 5,
       }),
     enabled: !!listing?.productId,
   });
 
-  const related = (relatedData?.items ?? [])
-    .filter((item) => item.id !== id)
-    .slice(0, 4);
+  const sameSkin = takeUniqueListings(
+    relatedSkinData?.items ?? [],
+    new Set(id ? [id] : []),
+    4,
+  );
+  const usedIds = new Set([id ?? "", ...sameSkin.map((item) => item.id)]);
+
+  const needFallback = sameSkin.length < 3;
+  const { data: fallbackData } = useQuery({
+    queryKey: [
+      "listings",
+      {
+        weapon: listing?.product.weapon,
+        collection: listing?.product.collection,
+        limit: 8,
+      },
+    ],
+    queryFn: () =>
+      listListings({
+        weapon: listing?.product.weapon,
+        status: "ACTIVE",
+        limit: 8,
+      }),
+    enabled: Boolean(needFallback && listing?.product.weapon),
+  });
+
+  const fallbackKind: "weapon" | "collection" = listing?.product.collection
+    ? "collection"
+    : "weapon";
+  const fallbackItems = takeUniqueListings(
+    (fallbackData?.items ?? []).filter((item) => {
+      if (fallbackKind === "collection" && listing?.product.collection) {
+        return item.product.collection === listing.product.collection;
+      }
+      return item.product.weapon === listing?.product.weapon;
+    }),
+    usedIds,
+    4,
+  );
+  fallbackItems.forEach((item) => usedIds.add(item.id));
+
+  const { data: sellerListingsData } = useQuery({
+    queryKey: ["listings", { sellerId: listing?.sellerId, status: "ACTIVE" }],
+    queryFn: () =>
+      listListings({
+        sellerId: listing?.sellerId,
+        status: "ACTIVE",
+        limit: 5,
+      }),
+    enabled: !!listing?.sellerId,
+  });
+
+  const sellerItems = takeUniqueListings(
+    sellerListingsData?.items ?? [],
+    usedIds,
+    4,
+  );
   const recentlyViewed = useRecentlyViewedListings(id);
 
   useEffect(() => {
@@ -129,17 +198,37 @@ export default function ListingDetail() {
   const sellerName =
     listing.seller?.user?.name ?? listing.seller?.storeName ?? "";
   const latestHistory = priceHistory?.[0];
+  const storeHref = storePath(listing.sellerId);
 
   return (
     <div className="container py-8">
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => navigate(-1)}
-        className="mb-6"
-      >
-        <ArrowLeft className="mr-1 h-4 w-4" /> Voltar
-      </Button>
+      <Breadcrumb className="mb-6">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/">Home</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/products">Market</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to={marketPath({ weapon: listing.product.weapon })}>
+                {listing.product.weapon}
+              </Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{productName}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       <div className="grid gap-8 md:grid-cols-2">
         <div className="relative flex aspect-[4/3] items-center justify-center overflow-hidden rounded-md border border-border bg-muted">
@@ -152,40 +241,83 @@ export default function ListingDetail() {
         </div>
 
         <div className="space-y-6">
-          <div>
-            <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-              {productName}
-            </h1>
-            <dl className="mt-4 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
-              <div>
-                <dt className="text-foreground">Raridade</dt>
-                <dd>{listing.product.rarity}</dd>
-              </div>
-              <div>
-                <dt className="text-foreground">Coleção</dt>
-                <dd>{listing.product.collection || "N/A"}</dd>
-              </div>
-              <div>
-                <dt className="text-foreground">Float</dt>
-                <dd className="tabular-nums">
-                  {Number(listing.floatValue).toFixed(8)}
-                </dd>
-              </div>
-              {listing.pattern != null ? (
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+                {productName}
+              </h1>
+              <dl className="mt-4 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2">
                 <div>
-                  <dt className="text-foreground">Pattern</dt>
-                  <dd className="tabular-nums">{listing.pattern}</dd>
-                </div>
-              ) : null}
-              {listing.tradeLockUntil ? (
-                <div className="sm:col-span-2">
-                  <dt className="text-foreground">Trade Lock até</dt>
+                  <dt className="text-foreground">Raridade</dt>
                   <dd>
-                    {new Date(listing.tradeLockUntil).toLocaleDateString()}
+                    <Link
+                      to={marketPath({ rarity: listing.product.rarity })}
+                      className="underline-offset-2 hover:underline"
+                    >
+                      {listing.product.rarity}
+                    </Link>
                   </dd>
                 </div>
-              ) : null}
-            </dl>
+                <div>
+                  <dt className="text-foreground">Coleção</dt>
+                  <dd>
+                    {listing.product.collection ? (
+                      <Link
+                        to={marketPath({ q: listing.product.collection })}
+                        className="underline-offset-2 hover:underline"
+                      >
+                        {listing.product.collection}
+                      </Link>
+                    ) : (
+                      "N/A"
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-foreground">Arma</dt>
+                  <dd>
+                    <Link
+                      to={marketPath({ weapon: listing.product.weapon })}
+                      className="underline-offset-2 hover:underline"
+                    >
+                      {listing.product.weapon}
+                    </Link>
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-foreground">Exterior</dt>
+                  <dd>
+                    <Link
+                      to={marketPath({ exterior: listing.product.exterior })}
+                      className="underline-offset-2 hover:underline"
+                    >
+                      {listing.product.exterior}
+                    </Link>
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-foreground">Float</dt>
+                  <dd className="tabular-nums">
+                    {Number(listing.floatValue).toFixed(8)}
+                  </dd>
+                </div>
+                {listing.pattern != null ? (
+                  <div>
+                    <dt className="text-foreground">Pattern</dt>
+                    <dd className="tabular-nums">{listing.pattern}</dd>
+                  </div>
+                ) : null}
+                {listing.tradeLockUntil ? (
+                  <div className="sm:col-span-2">
+                    <dt className="text-foreground">Trade Lock até</dt>
+                    <dd>
+                      {new Date(listing.tradeLockUntil).toLocaleDateString()}
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+            </div>
+            <FavoriteButton listingId={listing.id} />
           </div>
 
           {sellerName ? (
@@ -195,11 +327,17 @@ export default function ListingDetail() {
               </div>
               <div>
                 <p className="text-sm font-medium text-foreground">
-                  {sellerName}
+                  <Link
+                    to={storeHref}
+                    className="underline-offset-2 hover:underline"
+                  >
+                    {sellerName}
+                  </Link>
                 </p>
                 {listing.seller.rating != null ? (
                   <p className="text-xs text-muted-foreground">
-                    Nota da loja: {Number(listing.seller.rating).toFixed(1)}
+                    {SELLER_RATING_COPY}:{" "}
+                    {Number(listing.seller.rating).toFixed(1)}
                   </p>
                 ) : null}
               </div>
@@ -230,38 +368,52 @@ export default function ListingDetail() {
             />
           </div>
 
-          {priceHistory && priceHistory.length > 0 ? (
-            <div className="rounded-md border border-border bg-card p-4">
-              <h2 className="mb-3 text-sm font-semibold tracking-tight text-foreground">
-                Histórico de Preços
-              </h2>
-              <ul className="space-y-2 text-sm text-muted-foreground">
-                {priceHistory.slice(0, 5).map((entry) => (
-                  <li key={entry.id} className="flex justify-between gap-3">
-                    <span>
-                      {new Date(entry.changedAt).toLocaleDateString()}
-                    </span>
-                    <span className="tabular-nums">
-                      ${Number(entry.oldPrice).toFixed(2)} → $
-                      {Number(entry.newPrice).toFixed(2)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
+          <PriceHistorySection entries={priceHistory} />
         </div>
       </div>
 
       <ProductReviews productId={listing.productId} />
 
-      {related.length > 0 ? (
+      {sameSkin.length > 0 ? (
         <section className="mt-12 border-t border-border pt-10">
           <h2 className="mb-4 text-xl font-semibold tracking-tight text-foreground">
             Outros listings desta skin
           </h2>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {related.map((item) => (
+            {sameSkin.map((item) => (
+              <ListingCard key={item.id} listing={item} source="related" />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {fallbackItems.length > 0 ? (
+        <section className="mt-12 border-t border-border pt-10">
+          <h2 className="mb-4 text-xl font-semibold tracking-tight text-foreground">
+            {relatedFallbackHeading(fallbackKind)}
+          </h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {fallbackItems.map((item) => (
+              <ListingCard key={item.id} listing={item} source="related" />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {sellerItems.length > 0 ? (
+        <section className="mt-12 border-t border-border pt-10">
+          <div className="mb-4 flex items-end justify-between gap-3">
+            <h2 className="text-xl font-semibold tracking-tight text-foreground">
+              {moreFromSellerHeading(
+                listing.seller.storeName || sellerName || "esta loja",
+              )}
+            </h2>
+            <Button asChild variant="outline" size="sm">
+              <Link to={storeHref}>Ver loja</Link>
+            </Button>
+          </div>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {sellerItems.map((item) => (
               <ListingCard key={item.id} listing={item} source="related" />
             ))}
           </div>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -10,12 +10,22 @@ import {
   MARKET_VIEW_CTA,
 } from "@/lib/listingCartCta";
 import { fetchMarketListings } from "@/lib/marketListings";
+import { MARKET_RARITIES, MARKET_WEAPONS } from "@/lib/catalogTaxonomy";
 import {
+  MARKET_CATALOG_EMPTY_DESCRIPTION,
+  MARKET_CATALOG_EMPTY_TITLE,
   MARKET_EXTERIORS,
+  MARKET_FILTERS_EMPTY_TITLE,
+  MARKET_FLOAT_HINT,
+  MARKET_FLOAT_RANGE_ERROR,
   MARKET_PAGE_SIZE,
   MARKET_SEARCH_DEBOUNCE_MS,
   MARKET_SORTS,
+  MARKET_SORT_DEFAULT_COPY,
+  describeMarketFilters,
+  hasActiveMarketConstraints,
   hasMarketFilters,
+  isValidNumericRange,
   marketPath,
   marketSearchEmptyTitle,
   parseMarketQuery,
@@ -26,6 +36,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { marketSearchQuery, track } from "@/lib/analytics";
 
 function Chip({
@@ -79,6 +97,7 @@ export default function Products() {
   const [maxPriceDraft, setMaxPriceDraft] = useState(query.maxPrice);
   const [minFloatDraft, setMinFloatDraft] = useState(query.minFloat);
   const [maxFloatDraft, setMaxFloatDraft] = useState(query.maxFloat);
+  const [floatRangeError, setFloatRangeError] = useState<string | null>(null);
 
   useEffect(() => {
     setSearchDraft(query.q);
@@ -116,9 +135,11 @@ export default function Products() {
     );
   };
 
+  const rangeValid = isValidNumericRange(query.minFloat, query.maxFloat);
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["listings", "market", query],
     queryFn: () => fetchMarketListings(query),
+    enabled: rangeValid,
   });
 
   const items = data?.items ?? [];
@@ -133,22 +154,29 @@ export default function Products() {
   });
 
   useEffect(() => {
-    if (!searchQuery || isLoading || isError) return;
+    if (!searchQuery || isLoading || isError || !rangeValid) return;
     track("search", {
       query: searchQuery,
       productId: query.productId,
       source: "market",
       resultCount: total,
     });
-  }, [searchQuery, query.productId, isLoading, isError, total]);
+  }, [searchQuery, query.productId, isLoading, isError, total, rangeValid]);
 
   const applyPriceFloat = () => {
+    const minF = minFloatDraft.trim();
+    const maxF = maxFloatDraft.trim();
+    if (!isValidNumericRange(minF, maxF)) {
+      setFloatRangeError(MARKET_FLOAT_RANGE_ERROR);
+      return;
+    }
+    setFloatRangeError(null);
     writeQuery(
       {
         minPrice: minPriceDraft.trim(),
         maxPrice: maxPriceDraft.trim(),
-        minFloat: minFloatDraft.trim(),
-        maxFloat: maxFloatDraft.trim(),
+        minFloat: minF,
+        maxFloat: maxF,
         page: 1,
       },
       { replace: true },
@@ -156,6 +184,7 @@ export default function Products() {
   };
 
   const clearFilters = () => {
+    setFloatRangeError(null);
     setSearchParams(new URLSearchParams());
   };
 
@@ -163,8 +192,39 @@ export default function Products() {
     writeQuery({ q: "", page: 1 }, { replace: true });
   };
 
+  const filterSummary = describeMarketFilters(query);
+  const filteredEmpty = hasActiveMarketConstraints(query);
+
   return (
     <div className="container py-8">
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/">Home</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            {query.q ? (
+              <BreadcrumbLink asChild>
+                <Link to="/products">Market</Link>
+              </BreadcrumbLink>
+            ) : (
+              <BreadcrumbPage>Market</BreadcrumbPage>
+            )}
+          </BreadcrumbItem>
+          {query.q ? (
+            <>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbPage>{query.q}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </>
+          ) : null}
+        </BreadcrumbList>
+      </Breadcrumb>
+
       <div className="mb-6 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Market</h1>
@@ -174,7 +234,7 @@ export default function Products() {
               : "Listings ativos · item único"}
           </p>
         </div>
-        {!isLoading && !isError ? (
+        {!isLoading && !isError && rangeValid ? (
           <p className="text-sm tabular-nums text-muted-foreground">
             {query.q
               ? `${total} resultado${total !== 1 ? "s" : ""} para ${query.q}`
@@ -196,6 +256,48 @@ export default function Products() {
             aria-label="Buscar no Market"
           />
         </div>
+
+        <fieldset className="space-y-1.5">
+          <legend className="text-xs text-muted-foreground">Arma</legend>
+          <div className="flex flex-wrap gap-1.5">
+            <Chip
+              active={!query.weapon}
+              onClick={() => writeQuery({ weapon: "", page: 1 })}
+            >
+              Todas
+            </Chip>
+            {MARKET_WEAPONS.map((weapon) => (
+              <Chip
+                key={weapon}
+                active={query.weapon === weapon}
+                onClick={() => writeQuery({ weapon, page: 1 })}
+              >
+                {weapon}
+              </Chip>
+            ))}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-1.5">
+          <legend className="text-xs text-muted-foreground">Raridade</legend>
+          <div className="flex flex-wrap gap-1.5">
+            <Chip
+              active={!query.rarity}
+              onClick={() => writeQuery({ rarity: "", page: 1 })}
+            >
+              Todas
+            </Chip>
+            {MARKET_RARITIES.map((rarity) => (
+              <Chip
+                key={rarity}
+                active={query.rarity === rarity}
+                onClick={() => writeQuery({ rarity, page: 1 })}
+              >
+                {rarity}
+              </Chip>
+            ))}
+          </div>
+        </fieldset>
 
         <fieldset className="space-y-1.5">
           <legend className="text-xs text-muted-foreground">Exterior</legend>
@@ -274,7 +376,9 @@ export default function Products() {
           </fieldset>
 
           <fieldset className="space-y-1.5">
-            <legend className="text-xs text-muted-foreground">Float</legend>
+            <legend className="text-xs text-muted-foreground">
+              Float ({MARKET_FLOAT_HINT})
+            </legend>
             <div className="flex items-center gap-2">
               <Label htmlFor="minFloat" className="sr-only">
                 Float mínimo
@@ -287,8 +391,13 @@ export default function Products() {
                 max="1"
                 placeholder="0.00"
                 value={minFloatDraft}
-                onChange={(e) => setMinFloatDraft(e.target.value)}
+                onChange={(e) => {
+                  setMinFloatDraft(e.target.value);
+                  setFloatRangeError(null);
+                }}
                 className="w-24"
+                aria-invalid={floatRangeError ? true : undefined}
+                aria-describedby="float-hint"
               />
               <span className="text-sm text-muted-foreground">–</span>
               <Label htmlFor="maxFloat" className="sr-only">
@@ -302,8 +411,12 @@ export default function Products() {
                 max="1"
                 placeholder="1.00"
                 value={maxFloatDraft}
-                onChange={(e) => setMaxFloatDraft(e.target.value)}
+                onChange={(e) => {
+                  setMaxFloatDraft(e.target.value);
+                  setFloatRangeError(null);
+                }}
                 className="w-24"
+                aria-invalid={floatRangeError ? true : undefined}
               />
               <Button
                 size="sm"
@@ -315,11 +428,21 @@ export default function Products() {
                 Filtrar
               </Button>
             </div>
+            <p id="float-hint" className="text-xs text-muted-foreground">
+              {MARKET_FLOAT_HINT}
+            </p>
+            {floatRangeError || !rangeValid ? (
+              <p className="text-sm text-destructive" role="alert">
+                {floatRangeError ?? MARKET_FLOAT_RANGE_ERROR}
+              </p>
+            ) : null}
           </fieldset>
         </div>
 
         <fieldset className="space-y-1.5">
-          <legend className="text-xs text-muted-foreground">Ordenar</legend>
+          <legend className="text-xs text-muted-foreground">
+            Ordenar ({MARKET_SORT_DEFAULT_COPY} no servidor)
+          </legend>
           <div className="flex flex-wrap gap-1.5">
             {MARKET_SORTS.map(({ value, label }) => (
               <Chip
@@ -345,7 +468,7 @@ export default function Products() {
         ) : null}
       </div>
 
-      {isLoading && (
+      {isLoading && rangeValid && (
         <div
           className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
           role="status"
@@ -371,6 +494,7 @@ export default function Products() {
 
       {!isLoading &&
         !isError &&
+        rangeValid &&
         items.length === 0 &&
         (query.q ? (
           <EmptyState
@@ -400,28 +524,31 @@ export default function Products() {
               </Button>
             }
           />
+        ) : filteredEmpty ? (
+          <EmptyState
+            title={MARKET_FILTERS_EMPTY_TITLE}
+            description={
+              filterSummary.length > 0
+                ? `Nenhum listing para ${filterSummary.join(", ")}.`
+                : "Nenhum listing combina com os filtros ativos."
+            }
+            action={
+              <div className="flex flex-col items-center gap-3">
+                <Button type="button" variant="outline" onClick={clearFilters}>
+                  Limpar filtros
+                </Button>
+                <ExteriorShortcuts />
+              </div>
+            }
+          />
         ) : (
           <EmptyState
-            title="Nenhum item encontrado"
-            description="Tente ajustar os filtros"
-            action={
-              hasMarketFilters(query) ? (
-                <div className="flex flex-col items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={clearFilters}
-                  >
-                    Limpar filtros
-                  </Button>
-                  <ExteriorShortcuts />
-                </div>
-              ) : undefined
-            }
+            title={MARKET_CATALOG_EMPTY_TITLE}
+            description={MARKET_CATALOG_EMPTY_DESCRIPTION}
           />
         ))}
 
-      {!isLoading && !isError && items.length > 0 && (
+      {!isLoading && !isError && rangeValid && items.length > 0 && (
         <>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {items.map((listing) => (

--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -177,7 +177,9 @@ export default function SellerDashboard() {
             description="Quando houver vendas, elas aparecem aqui."
             action={
               <Button asChild>
-                <Link to="/seller/listings">Ver listings</Link>
+                <Link to="/seller/listings">
+                  {activeListings === 0 ? "Criar listing" : "Ver listings"}
+                </Link>
               </Button>
             }
           />

--- a/src/pages/StorePage.tsx
+++ b/src/pages/StorePage.tsx
@@ -1,0 +1,125 @@
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getSellerById } from "@/api/sellers";
+import { listListings } from "@/api/listings";
+import { ListingCard } from "@/components/ProductCard";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SELLER_RATING_COPY } from "@/lib/storePath";
+import { isNotFoundApiError } from "@/lib/userFacingApiError";
+
+export default function StorePage() {
+  const { sellerId } = useParams<{ sellerId: string }>();
+
+  const sellerQuery = useQuery({
+    queryKey: ["seller", sellerId],
+    queryFn: () => getSellerById(sellerId!),
+    enabled: !!sellerId,
+  });
+  const listingsQuery = useQuery({
+    queryKey: ["listings", { sellerId, status: "ACTIVE" }],
+    queryFn: () =>
+      listListings({ sellerId, status: "ACTIVE", page: 1, limit: 40 }),
+    enabled: !!sellerId && sellerQuery.isSuccess,
+  });
+
+  if (sellerQuery.isLoading) {
+    return (
+      <div
+        className="container space-y-4 py-10"
+        role="status"
+        aria-label="Carregando"
+      >
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-4 w-80 max-w-full" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (sellerQuery.isError || !sellerQuery.data) {
+    return (
+      <div className="container py-10">
+        <ErrorState
+          title={
+            isNotFoundApiError(sellerQuery.error)
+              ? "Loja não encontrada"
+              : "Erro ao carregar a loja"
+          }
+          error={sellerQuery.error}
+          action={
+            <Button asChild>
+              <Link to="/products">Voltar ao Market</Link>
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  const seller = sellerQuery.data;
+  const items = listingsQuery.data?.items ?? [];
+
+  return (
+    <div className="container py-8">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {seller.storeName}
+        </h1>
+        {seller.user?.name ? (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {seller.user.name}
+          </p>
+        ) : null}
+        <p className="mt-2 text-sm text-muted-foreground">
+          {SELLER_RATING_COPY}: {Number(seller.rating).toFixed(1)}
+        </p>
+      </div>
+
+      {listingsQuery.isLoading ? (
+        <div
+          className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+          role="status"
+          aria-label="Carregando"
+        >
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-64 w-full" />
+          ))}
+        </div>
+      ) : listingsQuery.isError ? (
+        <ErrorState
+          title="Erro ao carregar listings da loja"
+          error={listingsQuery.error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void listingsQuery.refetch()}
+            >
+              Tentar novamente
+            </Button>
+          }
+        />
+      ) : items.length === 0 ? (
+        <EmptyState
+          title="Nenhum listing ativo nesta loja."
+          action={
+            <Button asChild>
+              <Link to="/products">Explorar Market</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {items.map((listing) => (
+            <ListingCard key={listing.id} listing={listing} source="seller" />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/__tests__/Account.test.tsx
+++ b/src/pages/__tests__/Account.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AccountPage from "../Account";
 import type { Role, User } from "@/types/api";
 import { USER_FACING_NETWORK } from "@/lib/userFacingApiError";
@@ -21,9 +22,17 @@ const authState = {
   logout: (...args: unknown[]) => logout(...args),
 };
 
+const getSellerMe = vi.fn();
+const applySeller = vi.fn();
+
 vi.mock("@/api/users", () => ({
   getMe: (...args: unknown[]) => getMe(...args),
   updateMe: vi.fn(),
+}));
+
+vi.mock("@/api/sellers", () => ({
+  getSellerMe: (...args: unknown[]) => getSellerMe(...args),
+  applySeller: (...args: unknown[]) => applySeller(...args),
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -54,15 +63,24 @@ function setRole(role: Role) {
 }
 
 function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter initialEntries={["/account"]}>
-      <Routes>
-        <Route path="/account" element={<AccountPage />} />
-        <Route path="/account/orders" element={<div>orders-page</div>} />
-        <Route path="/seller" element={<div>seller-dash</div>} />
-        <Route path="/admin" element={<div>admin-dash</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/account"]}>
+        <Routes>
+          <Route path="/account" element={<AccountPage />} />
+          <Route path="/account/orders" element={<div>orders-page</div>} />
+          <Route
+            path="/account/favorites"
+            element={<div>favorites-page</div>}
+          />
+          <Route path="/seller" element={<div>seller-dash</div>} />
+          <Route path="/admin" element={<div>admin-dash</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -72,6 +90,9 @@ describe("AccountPage", () => {
     updateProfile.mockReset();
     logout.mockReset();
     toast.mockReset();
+    getSellerMe.mockReset();
+    applySeller.mockReset();
+    getSellerMe.mockRejectedValue(new Error("not a seller"));
     setRole("CUSTOMER");
     getMe.mockResolvedValue(profile());
     updateProfile.mockImplementation(async (input: { name?: string }) => {
@@ -185,6 +206,42 @@ describe("AccountPage", () => {
       await screen.findByRole("link", { name: "Dashboard" }),
     ).toHaveAttribute("href", "/admin");
     expect(screen.queryByRole("link", { name: "Meus pedidos" })).toBeNull();
+  });
+
+  it("lets a CUSTOMER apply as seller via POST /sellers/apply", async () => {
+    applySeller.mockResolvedValue({
+      id: "seller-new",
+      userId: "customer-1",
+      storeName: "Loja Nova",
+      balance: 0,
+      rating: 0,
+      isApproved: false,
+    });
+    getSellerMe
+      .mockRejectedValueOnce(new Error("not a seller"))
+      .mockResolvedValue({
+        id: "seller-new",
+        userId: "customer-1",
+        storeName: "Loja Nova",
+        balance: 0,
+        rating: 0,
+        isApproved: false,
+      });
+
+    renderPage();
+    expect(await screen.findByText("Quero vender")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Nome da loja"), {
+      target: { value: "Loja Nova" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Enviar candidatura" }));
+
+    await waitFor(() => {
+      expect(applySeller).toHaveBeenCalledWith({ storeName: "Loja Nova" });
+    });
+    expect(
+      await screen.findByText(/Aguardando aprovação de um admin/),
+    ).toBeTruthy();
+    expect(screen.queryByText(/e-mail de aprovação/i)).toBeNull();
   });
 
   it("logout from the account page uses AuthContext.logout", async () => {

--- a/src/pages/__tests__/AccountFavorites.test.tsx
+++ b/src/pages/__tests__/AccountFavorites.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AccountFavoritesPage from "../AccountFavorites";
+import { CartProvider } from "@/contexts/CartContext";
+import type { Favorite, Listing } from "@/types/api";
+
+const listFavorites = vi.fn();
+
+vi.mock("@/api/favorites", () => ({
+  listFavorites: (...args: unknown[]) => listFavorites(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function soldFavorite(): Favorite {
+  const listing: Listing = {
+    id: "listing-sold",
+    productId: "prod-1",
+    sellerId: "seller-1",
+    price: 40,
+    currency: "USD",
+    status: "SOLD",
+    floatValue: 0.1,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AWP",
+      skinName: "Asiimov",
+      rarity: "Covert",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      imageUrl: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+    seller: { id: "seller-1", storeName: "Store" },
+  };
+  return {
+    id: "fav-1",
+    userId: "u1",
+    listingId: "listing-sold",
+    listing,
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CartProvider>
+          <AccountFavoritesPage />
+        </CartProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AccountFavoritesPage", () => {
+  beforeEach(() => {
+    listFavorites.mockReset();
+  });
+
+  it("shows a Market CTA when the list is empty", async () => {
+    listFavorites.mockResolvedValue([]);
+    renderPage();
+    expect(await screen.findByText("Nenhum favorito")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Explorar Market" }),
+    ).toHaveAttribute("href", "/products");
+  });
+
+  it("keeps a SOLD favorite with a badge and related link", async () => {
+    listFavorites.mockResolvedValue([soldFavorite()]);
+    renderPage();
+    expect(await screen.findByText("Vendido")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Ver relacionados" }),
+    ).toHaveAttribute("href", "/products?productId=prod-1");
+  });
+});

--- a/src/pages/__tests__/AccountFavorites.test.tsx
+++ b/src/pages/__tests__/AccountFavorites.test.tsx
@@ -82,7 +82,7 @@ describe("AccountFavoritesPage", () => {
   it("keeps a SOLD favorite with a badge and related link", async () => {
     listFavorites.mockResolvedValue([soldFavorite()]);
     renderPage();
-    expect(await screen.findByText("Vendido")).toBeTruthy();
+    expect(await screen.findAllByText("Vendido")).toHaveLength(2);
     expect(
       screen.getByRole("link", { name: "Ver relacionados" }),
     ).toHaveAttribute("href", "/products?productId=prod-1");

--- a/src/pages/__tests__/AdminDashboard.test.tsx
+++ b/src/pages/__tests__/AdminDashboard.test.tsx
@@ -131,6 +131,30 @@ describe("AdminDashboard", () => {
     });
   });
 
+  it("gives each empty admin section one real CTA", async () => {
+    listSellers.mockResolvedValue([]);
+    listAdminOrders.mockResolvedValue([]);
+    listProducts.mockResolvedValue({ items: [], total: 0, page: 1, limit: 1 });
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText("Nenhum vendedor pendente de aprovação"),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Ver vendedores" }),
+    ).toHaveAttribute("href", "/admin/sellers");
+    expect(screen.getByText("Nenhum vendedor cadastrado")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Ver usuários" })).toHaveAttribute(
+      "href",
+      "/admin/users",
+    );
+    expect(screen.getByText("Nenhum pedido encontrado")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Aprovar vendedores" }),
+    ).toHaveAttribute("href", "/admin/sellers");
+  });
+
   it("keeps Importar catálogo when other admin lists fail", async () => {
     listAdminOrders.mockRejectedValue(new Error("boom"));
     listSellers.mockRejectedValue(new Error("boom"));

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -76,6 +76,7 @@ vi.mock("@/hooks/use-toast", () => ({
 
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => authState,
+  useOptionalAuth: () => authState,
 }));
 
 vi.mock("@/api/reviews", () => ({
@@ -83,6 +84,12 @@ vi.mock("@/api/reviews", () => ({
   createReview: (...args: unknown[]) => createReview(...args),
   updateReview: (...args: unknown[]) => updateReview(...args),
   deleteReview: (...args: unknown[]) => deleteReview(...args),
+}));
+
+vi.mock("@/api/favorites", () => ({
+  listFavorites: () => Promise.resolve([]),
+  addFavorite: vi.fn(),
+  removeFavorite: vi.fn(),
 }));
 
 function makeListing(overrides: Partial<Listing> = {}): Listing {
@@ -194,6 +201,7 @@ describe("ListingDetail", () => {
     authState.isLoading = false;
     localStorage.removeItem(CART_STORAGE_KEY);
     localStorage.removeItem(RECENTLY_VIEWED_STORAGE_KEY);
+    sessionStorage.clear();
     listListings.mockResolvedValue({ items: [], total: 0, page: 1, limit: 4 });
     getPriceHistory.mockResolvedValue([]);
     listProductReviews.mockResolvedValue([]);
@@ -231,7 +239,7 @@ describe("ListingDetail", () => {
     expect(screen.getAllByText("NeonTrader").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$22.00").length).toBeGreaterThan(0);
     expect(screen.getByText(/Última alteração: \$22\.00/)).toBeTruthy();
-    expect(screen.getByText("Histórico de Preços")).toBeTruthy();
+    expect(screen.getByText("Histórico de preços deste listing")).toBeTruthy();
     expect(screen.getByText("Outros listings desta skin")).toBeTruthy();
 
     const addButton = screen.getAllByRole("button", {
@@ -249,6 +257,71 @@ describe("ListingDetail", () => {
     expect(reserveListing).not.toHaveBeenCalled();
     expect(screen.queryByText(/Reservado para você/)).toBeNull();
     expect(screen.queryByText(/15:00/)).toBeNull();
+    expect(screen.queryByText(/preço de mercado Steam/i)).toBeNull();
+  });
+
+  it("shows an explicit empty price history", async () => {
+    getListing.mockResolvedValue(makeListing());
+    getPriceHistory.mockResolvedValue([]);
+    renderDetail();
+    expect(
+      await screen.findByText("Sem alterações de preço ainda"),
+    ).toBeTruthy();
+  });
+
+  it("falls back to same-weapon listings and a seller rail with honest headings", async () => {
+    getListing.mockResolvedValue(makeListing());
+    const otherWeapon = makeListing({
+      id: "listing-weapon",
+      productId: "ak-other",
+      product: {
+        ...makeListing().product,
+        id: "ak-other",
+        skinName: "Slate",
+      },
+    });
+    const sellerOther = makeListing({
+      id: "listing-seller",
+      productId: "m4",
+      sellerId: "seller-1",
+      product: {
+        ...makeListing().product,
+        id: "m4",
+        weapon: "M4A4",
+        skinName: "Howl",
+        collection: "Other",
+      },
+    });
+    listListings.mockImplementation(
+      async (params: {
+        productId?: string;
+        sellerId?: string;
+        weapon?: string;
+      }) => {
+        if (params.productId) {
+          return { items: [makeListing()], total: 1, page: 1, limit: 5 };
+        }
+        if (params.sellerId) {
+          return { items: [sellerOther], total: 1, page: 1, limit: 5 };
+        }
+        if (params.weapon) {
+          return { items: [otherWeapon], total: 1, page: 1, limit: 8 };
+        }
+        return { items: [], total: 0, page: 1, limit: 4 };
+      },
+    );
+
+    renderDetail();
+
+    expect(
+      await screen.findByText("Outros listings desta coleção"),
+    ).toBeTruthy();
+    expect(screen.getByText("Mais de NeonTrader Store")).toBeTruthy();
+    expect(screen.queryByText(/recomendado para você/i)).toBeNull();
+    expect(screen.getByRole("link", { name: "Ver loja" })).toHaveAttribute(
+      "href",
+      "/stores/seller-1",
+    );
   });
 
   it("replaces the add CTA on a SOLD listing with Vendido and similar items", async () => {
@@ -334,7 +407,11 @@ describe("ListingDetail", () => {
     expect(screen.getByText(PRODUCT_REVIEWS_SCOPE)).toBeTruthy();
     expect(screen.getByText("Ana")).toBeTruthy();
     expect(screen.getByText("Float honesto, entrega rápida.")).toBeTruthy();
-    expect(screen.getByText("Nota da loja: 4.5")).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Nota da loja \(campo do vendedor, não média de avaliações\): 4\.5/,
+      ),
+    ).toBeTruthy();
     expect(screen.queryByText(/média das avaliações/i)).toBeNull();
     expect(listProductReviews).toHaveBeenCalledWith("ak-redline-ft");
   });

--- a/src/pages/__tests__/ListingDetail.test.tsx
+++ b/src/pages/__tests__/ListingDetail.test.tsx
@@ -43,6 +43,7 @@ import {
   PRODUCT_REVIEWS_SCOPE,
   PRODUCT_REVIEWS_SUBMIT,
 } from "@/components/ProductReviews";
+import { marketPath } from "@/lib/marketQuery";
 
 const getListing = vi.fn();
 const listListings = vi.fn();
@@ -267,6 +268,46 @@ describe("ListingDetail", () => {
     expect(
       await screen.findByText("Sem alterações de preço ainda"),
     ).toBeTruthy();
+  });
+
+  it("links breadcrumbs and attributes to existing Market query routes", async () => {
+    const listing = makeListing();
+    getListing.mockResolvedValue(listing);
+    renderDetail();
+
+    const crumbs = await screen.findByRole("navigation", {
+      name: "breadcrumb",
+    });
+    expect(within(crumbs).getByRole("link", { name: "Home" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+    expect(
+      within(crumbs).getByRole("link", { name: "Market" }),
+    ).toHaveAttribute("href", "/products");
+    expect(within(crumbs).getByRole("link", { name: "AK-47" })).toHaveAttribute(
+      "href",
+      marketPath({ weapon: "AK-47" }),
+    );
+    expect(
+      within(crumbs).getByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByRole("link", { name: "The Huntsman Collection" }),
+    ).toHaveAttribute("href", marketPath({ q: "The Huntsman Collection" }));
+    expect(screen.getByRole("link", { name: "Classified" })).toHaveAttribute(
+      "href",
+      marketPath({ rarity: "Classified" }),
+    );
+    expect(
+      screen
+        .getAllByRole("link", { name: "AK-47" })
+        .every(
+          (link) =>
+            link.getAttribute("href") === marketPath({ weapon: "AK-47" }),
+        ),
+    ).toBe(true);
   });
 
   it("falls back to same-weapon listings and a seller rail with honest headings", async () => {

--- a/src/pages/__tests__/Products.test.tsx
+++ b/src/pages/__tests__/Products.test.tsx
@@ -141,6 +141,7 @@ describe("Products", () => {
       page: 1,
       limit: 20,
       status: "ACTIVE",
+      sort: "createdAt_desc",
     });
     expect(screen.queryByText(MARKET_SIMILAR_EMPTY_TITLE)).toBeNull();
   });
@@ -163,6 +164,7 @@ describe("Products", () => {
       limit: 20,
       status: "ACTIVE",
       productId: "ak-redline-ft",
+      sort: "createdAt_desc",
     });
   });
 
@@ -189,6 +191,7 @@ describe("Products", () => {
       limit: 20,
       status: "ACTIVE",
       productId: "ak-redline-ft",
+      sort: "createdAt_desc",
     });
   });
 
@@ -209,6 +212,7 @@ describe("Products", () => {
       page: 1,
       limit: 20,
       status: "ACTIVE",
+      sort: "createdAt_desc",
     });
   });
 
@@ -301,6 +305,7 @@ describe("Products", () => {
       limit: 20,
       status: "ACTIVE",
       exterior: "Minimal Wear",
+      sort: "price_asc",
     });
     expect(listProducts).not.toHaveBeenCalled();
   });
@@ -324,6 +329,7 @@ describe("Products", () => {
       page: 1,
       limit: 20,
       status: "ACTIVE",
+      sort: "createdAt_desc",
     });
     expect(screen.getAllByRole("button", { name: "Todos" })[0]).toHaveAttribute(
       "aria-pressed",
@@ -392,6 +398,7 @@ describe("Products", () => {
       limit: 20,
       status: "ACTIVE",
       productId: "talon-fade-fn",
+      sort: "createdAt_desc",
     });
   });
 
@@ -444,6 +451,68 @@ describe("Products", () => {
     );
   });
 
+  it("does not request listings when minFloat is greater than maxFloat", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+    renderMarket();
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    listListings.mockClear();
+
+    fireEvent.change(screen.getByLabelText("Float mínimo"), {
+      target: { value: "0.4" },
+    });
+    fireEvent.change(screen.getByLabelText("Float máximo"), {
+      target: { value: "0.1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Filtrar/ }));
+
+    expect(
+      await screen.findByText(
+        "O float mínimo não pode ser maior que o máximo.",
+      ),
+    ).toBeTruthy();
+    expect(listListings).not.toHaveBeenCalled();
+  });
+
+  it("puts weapon and rarity in the URL and listListings params", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket();
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "AK-47" }));
+    fireEvent.click(screen.getByRole("button", { name: "Covert" }));
+
+    expect(screen.getByTestId("market-query").textContent).toContain(
+      "weapon=AK-47",
+    );
+    expect(screen.getByTestId("market-query").textContent).toContain(
+      "rarity=Covert",
+    );
+    await waitFor(() => {
+      expect(listListings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          weapon: "AK-47",
+          rarity: "Covert",
+          status: "ACTIVE",
+        }),
+      );
+    });
+  });
+
   it("clears filters back to the default catalog URL", async () => {
     listListings.mockResolvedValue({
       items: [],
@@ -454,7 +523,9 @@ describe("Products", () => {
 
     renderMarket("/products?exterior=Field-Tested&stattrak=true");
 
-    expect(await screen.findByText("Nenhum item encontrado")).toBeTruthy();
+    expect(
+      await screen.findByText("Nenhum listing com estes filtros"),
+    ).toBeTruthy();
     fireEvent.click(
       screen.getAllByRole("button", { name: "Limpar filtros" })[0],
     );

--- a/src/pages/__tests__/SellerDashboard.test.tsx
+++ b/src/pages/__tests__/SellerDashboard.test.tsx
@@ -168,6 +168,21 @@ describe("SellerDashboard", () => {
     expect(getSellerMe).toHaveBeenCalled();
   });
 
+  it("shows a create-listing CTA when the seller has no recent orders", async () => {
+    getSellerListings.mockResolvedValue({ items: [], total: 0 });
+    listOrders.mockResolvedValue([]);
+    getCommissionBalance.mockResolvedValue({ balance: "0.00" });
+    getSellerMe.mockResolvedValue(sellerMe());
+
+    renderDashboard("SELLER");
+
+    expect(await screen.findByText("Nenhum pedido")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Criar listing" })).toHaveAttribute(
+      "href",
+      "/seller/listings",
+    );
+  });
+
   it("does not invent saldo by summing local order totals", async () => {
     getSellerListings.mockResolvedValue({ items: [], total: 0 });
     listOrders.mockResolvedValue([order("ord-1", 50), order("ord-2", 50)]);

--- a/src/pages/__tests__/StorePage.test.tsx
+++ b/src/pages/__tests__/StorePage.test.tsx
@@ -99,7 +99,7 @@ describe("StorePage", () => {
     renderStore();
 
     expect(await screen.findByText("RustKing")).toBeTruthy();
-    expect(screen.getByText(new RegExp(SELLER_RATING_COPY))).toBeTruthy();
+    expect(screen.getByText(SELLER_RATING_COPY, { exact: false })).toBeTruthy();
     expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
     expect(listListings).toHaveBeenCalledWith({
       sellerId: "seller-1",
@@ -107,7 +107,7 @@ describe("StorePage", () => {
       page: 1,
       limit: 40,
     });
-    expect(screen.queryByText(/média de avaliações/i)).toBeNull();
+    expect(screen.queryByText(/média das avaliações/i)).toBeNull();
   });
 
   it("shows 404 copy for a missing seller", async () => {

--- a/src/pages/__tests__/StorePage.test.tsx
+++ b/src/pages/__tests__/StorePage.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import StorePage from "../StorePage";
+import { CartProvider } from "@/contexts/CartContext";
+import { ApiClientError } from "@/lib/userFacingApiError";
+import { SELLER_RATING_COPY } from "@/lib/storePath";
+import type { Listing, Seller } from "@/types/api";
+
+const getSellerById = vi.fn();
+const listListings = vi.fn();
+
+vi.mock("@/api/sellers", () => ({
+  getSellerById: (...args: unknown[]) => getSellerById(...args),
+}));
+
+vi.mock("@/api/listings", () => ({
+  listListings: (...args: unknown[]) => listListings(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function seller(): Seller {
+  return {
+    id: "seller-1",
+    userId: "user-1",
+    storeName: "RustKing",
+    balance: 0,
+    rating: 4.2,
+    isApproved: true,
+    user: { id: "user-1", name: "Rust", email: "rust@test.com" },
+  };
+}
+
+function listing(): Listing {
+  return {
+    id: "listing-1",
+    productId: "prod-1",
+    sellerId: "seller-1",
+    price: 10,
+    currency: "USD",
+    status: "ACTIVE",
+    floatValue: 0.1,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    product: {
+      id: "prod-1",
+      game: "CS2",
+      weapon: "AK-47",
+      skinName: "Redline",
+      rarity: "Classified",
+      exterior: "Field-Tested",
+      isStattrak: false,
+      isSouvenir: false,
+      imageUrl: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+    seller: { id: "seller-1", storeName: "RustKing" },
+  };
+}
+
+function renderStore(id = "seller-1") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/stores/${id}`]}>
+        <CartProvider>
+          <Routes>
+            <Route path="/stores/:sellerId" element={<StorePage />} />
+            <Route path="/products" element={<div>market</div>} />
+          </Routes>
+        </CartProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("StorePage", () => {
+  beforeEach(() => {
+    getSellerById.mockReset();
+    listListings.mockReset();
+  });
+
+  it("loads the public store with ACTIVE listings only", async () => {
+    getSellerById.mockResolvedValue(seller());
+    listListings.mockResolvedValue({
+      items: [listing()],
+      total: 1,
+      page: 1,
+      limit: 40,
+    });
+
+    renderStore();
+
+    expect(await screen.findByText("RustKing")).toBeTruthy();
+    expect(screen.getByText(new RegExp(SELLER_RATING_COPY))).toBeTruthy();
+    expect(screen.getByText("AK-47 | Redline (Field-Tested)")).toBeTruthy();
+    expect(listListings).toHaveBeenCalledWith({
+      sellerId: "seller-1",
+      status: "ACTIVE",
+      page: 1,
+      limit: 40,
+    });
+    expect(screen.queryByText(/média de avaliações/i)).toBeNull();
+  });
+
+  it("shows 404 copy for a missing seller", async () => {
+    getSellerById.mockRejectedValue(
+      new ApiClientError("Not found", { status: 404 }),
+    );
+
+    renderStore("missing");
+
+    expect(await screen.findByText("Loja não encontrada")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Voltar ao Market" }),
+    ).toHaveAttribute("href", "/products");
+    expect(listListings).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/admin/AdminProducts.tsx
+++ b/src/pages/admin/AdminProducts.tsx
@@ -476,7 +476,7 @@ export default function AdminProducts() {
             <AlertDialogAction
               onClick={() => pendingDelete && remove.mutate(pendingDelete.id)}
             >
-              Excluir
+              Confirmar exclusão
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/admin/AdminProducts.tsx
+++ b/src/pages/admin/AdminProducts.tsx
@@ -1,0 +1,486 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createProduct,
+  deleteProduct,
+  listProducts,
+  updateProduct,
+} from "@/api/products";
+import { EmptyState, ErrorState } from "@/components/page-state";
+import { SkinThumb } from "@/components/ProductCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { MARKET_EXTERIORS } from "@/lib/marketQuery";
+import { MARKET_RARITIES } from "@/lib/catalogTaxonomy";
+import { useToast } from "@/hooks/use-toast";
+import { userFacingApiError } from "@/lib/userFacingApiError";
+import type { Product } from "@/types/api";
+
+const PAGE_SIZE = 20;
+
+interface ProductFormState {
+  game: string;
+  weapon: string;
+  skinName: string;
+  rarity: string;
+  exterior: string;
+  collection: string;
+  imageUrl: string;
+  isStattrak: boolean;
+  isSouvenir: boolean;
+}
+
+const emptyForm = (): ProductFormState => ({
+  game: "CS2",
+  weapon: "",
+  skinName: "",
+  rarity: "Classified",
+  exterior: "Field-Tested",
+  collection: "",
+  imageUrl: "",
+  isStattrak: false,
+  isSouvenir: false,
+});
+
+function formFromProduct(product: Product): ProductFormState {
+  return {
+    game: product.game,
+    weapon: product.weapon,
+    skinName: product.skinName,
+    rarity: product.rarity,
+    exterior: product.exterior,
+    collection: product.collection ?? "",
+    imageUrl: product.imageUrl ?? "",
+    isStattrak: product.isStattrak,
+    isSouvenir: product.isSouvenir,
+  };
+}
+
+export default function AdminProducts() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [page, setPage] = useState(1);
+  const [editor, setEditor] = useState<
+    { mode: "create" } | { mode: "edit"; product: Product } | null
+  >(null);
+  const [form, setForm] = useState<ProductFormState>(emptyForm);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<Product | null>(null);
+
+  const listQuery = useQuery({
+    queryKey: ["admin-products", page],
+    queryFn: () => listProducts({ page, limit: PAGE_SIZE }),
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["admin-products"] });
+  };
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const body = {
+        game: form.game.trim() || "CS2",
+        weapon: form.weapon.trim(),
+        skinName: form.skinName.trim(),
+        rarity: form.rarity,
+        exterior: form.exterior,
+        collection: form.collection.trim() || undefined,
+        imageUrl: form.imageUrl.trim() || undefined,
+        isStattrak: form.isStattrak,
+        isSouvenir: form.isSouvenir,
+      };
+      if (editor?.mode === "edit") {
+        return updateProduct(editor.product.id, body);
+      }
+      return createProduct(body);
+    },
+    onSuccess: () => {
+      toast({
+        title:
+          editor?.mode === "edit" ? "Produto atualizado" : "Produto criado",
+      });
+      setEditor(null);
+      invalidate();
+    },
+    onError: (error) => {
+      setFormError(userFacingApiError(error));
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => deleteProduct(id),
+    onSuccess: () => {
+      toast({ title: "Produto removido" });
+      setPendingDelete(null);
+      invalidate();
+    },
+    onError: (error) => {
+      toast({ title: userFacingApiError(error), variant: "destructive" });
+    },
+  });
+
+  const openCreate = () => {
+    setForm(emptyForm());
+    setFormError(null);
+    setEditor({ mode: "create" });
+  };
+
+  const openEdit = (product: Product) => {
+    setForm(formFromProduct(product));
+    setFormError(null);
+    setEditor({ mode: "edit", product });
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!form.weapon.trim() || !form.skinName.trim()) {
+      setFormError("Informe arma e nome da skin.");
+      return;
+    }
+    save.mutate();
+  };
+
+  if (listQuery.isLoading) {
+    return (
+      <div className="space-y-4" role="status" aria-label="Carregando">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (listQuery.isError) {
+    return (
+      <ErrorState
+        title="Erro ao carregar produtos"
+        error={listQuery.error}
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void listQuery.refetch()}
+          >
+            Tentar novamente
+          </Button>
+        }
+      />
+    );
+  }
+
+  const items = listQuery.data?.items ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Produtos</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Catálogo base. Sellers só leem; só admin cria, edita e remove.
+          </p>
+        </div>
+        <Button type="button" onClick={openCreate}>
+          Novo produto
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <EmptyState
+          title="Nenhum produto no catálogo"
+          description="Cadastre a primeira skin para os sellers anunciarem."
+          action={
+            <Button type="button" onClick={openCreate}>
+              Novo produto
+            </Button>
+          }
+        />
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Skin</TableHead>
+                <TableHead>Raridade</TableHead>
+                <TableHead className="hidden md:table-cell">Exterior</TableHead>
+                <TableHead className="text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {items.map((product) => (
+                <TableRow key={product.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <SkinThumb product={product} size="md" decorative />
+                      <span className="font-medium">
+                        {product.weapon} | {product.skinName}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>{product.rarity}</TableCell>
+                  <TableCell className="hidden text-muted-foreground md:table-cell">
+                    {product.exterior}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => openEdit(product)}
+                      >
+                        Editar
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setPendingDelete(product)}
+                      >
+                        Excluir
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {total > PAGE_SIZE ? (
+        <div className="flex justify-between text-sm text-muted-foreground">
+          <span className="tabular-nums">{total} produtos</span>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+            >
+              Anterior
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={page >= pageCount}
+              onClick={() => setPage((current) => current + 1)}
+            >
+              Próxima
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <Dialog
+        open={editor != null}
+        onOpenChange={(open) => !open && setEditor(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editor?.mode === "edit" ? "Editar produto" : "Novo produto"}
+            </DialogTitle>
+            <DialogDescription>
+              Campos do DTO de produto. Sellers não usam este formulário.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="product-weapon">Arma</Label>
+                <Input
+                  id="product-weapon"
+                  className="mt-1.5"
+                  value={form.weapon}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      weapon: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="product-skin">Skin</Label>
+                <Input
+                  id="product-skin"
+                  className="mt-1.5"
+                  value={form.skinName}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      skinName: event.target.value,
+                    }))
+                  }
+                  required
+                />
+              </div>
+              <div>
+                <Label htmlFor="product-rarity">Raridade</Label>
+                <select
+                  id="product-rarity"
+                  className="mt-1.5 flex h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  value={form.rarity}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      rarity: event.target.value,
+                    }))
+                  }
+                >
+                  {MARKET_RARITIES.map((rarity) => (
+                    <option key={rarity} value={rarity}>
+                      {rarity}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <Label htmlFor="product-exterior">Exterior</Label>
+                <select
+                  id="product-exterior"
+                  className="mt-1.5 flex h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  value={form.exterior}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      exterior: event.target.value,
+                    }))
+                  }
+                >
+                  {MARKET_EXTERIORS.filter(Boolean).map((exterior) => (
+                    <option key={exterior} value={exterior}>
+                      {exterior}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="product-collection">Coleção</Label>
+              <Input
+                id="product-collection"
+                className="mt-1.5"
+                value={form.collection}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    collection: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div>
+              <Label htmlFor="product-image">imageUrl</Label>
+              <Input
+                id="product-image"
+                className="mt-1.5"
+                value={form.imageUrl}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    imageUrl: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="flex gap-4 text-sm">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={form.isStattrak}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      isStattrak: event.target.checked,
+                    }))
+                  }
+                />
+                StatTrak™
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={form.isSouvenir}
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      isSouvenir: event.target.checked,
+                    }))
+                  }
+                />
+                Souvenir
+              </label>
+            </div>
+            {formError ? (
+              <p className="text-sm text-destructive" role="alert">
+                {formError}
+              </p>
+            ) : null}
+            <DialogFooter>
+              <Button type="submit" disabled={save.isPending}>
+                {save.isPending ? "Salvando..." : "Salvar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={pendingDelete != null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Excluir produto?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete
+                ? `${pendingDelete.weapon} | ${pendingDelete.skinName} será removido do catálogo.`
+                : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => pendingDelete && remove.mutate(pendingDelete.id)}
+            >
+              Excluir
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/admin/__tests__/AdminProducts.test.tsx
+++ b/src/pages/admin/__tests__/AdminProducts.test.tsx
@@ -95,7 +95,7 @@ describe("AdminProducts", () => {
     fireEvent.click(screen.getByRole("button", { name: "Excluir" }));
     expect(screen.getByText("Excluir produto?")).toBeTruthy();
     expect(deleteProduct).not.toHaveBeenCalled();
-    fireEvent.click(screen.getAllByRole("button", { name: "Excluir" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar exclusão" }));
     await waitFor(() => {
       expect(deleteProduct).toHaveBeenCalledWith("prod-1");
     });

--- a/src/pages/admin/__tests__/AdminProducts.test.tsx
+++ b/src/pages/admin/__tests__/AdminProducts.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AdminProducts from "../AdminProducts";
+import type { Product } from "@/types/api";
+
+const listProducts = vi.fn();
+const createProduct = vi.fn();
+const updateProduct = vi.fn();
+const deleteProduct = vi.fn();
+
+vi.mock("@/api/products", () => ({
+  listProducts: (...args: unknown[]) => listProducts(...args),
+  createProduct: (...args: unknown[]) => createProduct(...args),
+  updateProduct: (...args: unknown[]) => updateProduct(...args),
+  deleteProduct: (...args: unknown[]) => deleteProduct(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function product(): Product {
+  return {
+    id: "prod-1",
+    game: "CS2",
+    weapon: "AK-47",
+    skinName: "Redline",
+    rarity: "Classified",
+    exterior: "Field-Tested",
+    collection: "The Phoenix Collection",
+    imageUrl: null,
+    isStattrak: false,
+    isSouvenir: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminProducts />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminProducts", () => {
+  beforeEach(() => {
+    listProducts.mockReset();
+    createProduct.mockReset();
+    updateProduct.mockReset();
+    deleteProduct.mockReset();
+    listProducts.mockResolvedValue({
+      items: [product()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+    createProduct.mockResolvedValue(product());
+  });
+
+  it("creates a catalog product through the admin form", async () => {
+    renderPage();
+    expect(await screen.findByText("AK-47 | Redline")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Novo produto" }));
+    fireEvent.change(screen.getByLabelText("Arma"), {
+      target: { value: "M4A4" },
+    });
+    fireEvent.change(screen.getByLabelText("Skin"), {
+      target: { value: "Asiimov" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => {
+      expect(createProduct).toHaveBeenCalledWith(
+        expect.objectContaining({
+          weapon: "M4A4",
+          skinName: "Asiimov",
+        }),
+      );
+    });
+  });
+
+  it("asks for confirmation before deleting", async () => {
+    renderPage();
+    expect(await screen.findByText("AK-47 | Redline")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Excluir" }));
+    expect(screen.getByText("Excluir produto?")).toBeTruthy();
+    expect(deleteProduct).not.toHaveBeenCalled();
+    fireEvent.click(screen.getAllByRole("button", { name: "Excluir" })[1]);
+    await waitFor(() => {
+      expect(deleteProduct).toHaveBeenCalledWith("prod-1");
+    });
+  });
+});

--- a/src/pages/seller/SellerOrders.tsx
+++ b/src/pages/seller/SellerOrders.tsx
@@ -1,8 +1,10 @@
-import { Navigate } from "react-router-dom";
+import { useState } from "react";
+import { Link, Navigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { listOrders } from "@/api/orders";
 import { useAuth } from "@/contexts/AuthContext";
 import { EmptyState, ErrorState } from "@/components/page-state";
+import { OrderTrackingDialog } from "@/components/seller/OrderTrackingDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -24,6 +26,7 @@ function orderTotal(order: Order): number {
 export default function SellerOrdersPage() {
   const { user } = useAuth();
   const isAdmin = user?.role === "ADMIN";
+  const [trackingOrder, setTrackingOrder] = useState<Order | null>(null);
   const {
     data: orders = [],
     isLoading,
@@ -77,6 +80,11 @@ export default function SellerOrdersPage() {
         <EmptyState
           title="Nenhum pedido"
           description="Quando um listing for vendido, o pedido aparece aqui."
+          action={
+            <Button asChild>
+              <Link to="/seller/listings">Criar listing</Link>
+            </Button>
+          }
         />
       ) : (
         <ul className="space-y-2">
@@ -112,9 +120,17 @@ export default function SellerOrdersPage() {
                         {new Date(order.createdAt).toLocaleDateString()}
                       </span>
                     ) : null}
+                    {order.trackingCode ? (
+                      <span className="text-xs text-muted-foreground">
+                        {order.trackingCarrier
+                          ? `${order.trackingCarrier} · `
+                          : ""}
+                        {order.trackingCode}
+                      </span>
+                    ) : null}
                   </div>
                 </div>
-                <div className="text-left sm:text-right">
+                <div className="flex flex-col items-start gap-2 sm:items-end">
                   <p className="tabular-nums text-lg font-semibold">
                     ${orderTotal(order).toFixed(2)}
                   </p>
@@ -122,12 +138,28 @@ export default function SellerOrdersPage() {
                     {order.items?.length ?? 0}{" "}
                     {(order.items?.length ?? 0) === 1 ? "item" : "itens"}
                   </p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setTrackingOrder(order)}
+                  >
+                    Informar envio
+                  </Button>
                 </div>
               </li>
             );
           })}
         </ul>
       )}
+      <OrderTrackingDialog
+        key={trackingOrder?.id ?? "closed"}
+        order={trackingOrder}
+        open={trackingOrder != null}
+        onOpenChange={(open) => {
+          if (!open) setTrackingOrder(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/seller/SellerProducts.tsx
+++ b/src/pages/seller/SellerProducts.tsx
@@ -77,6 +77,11 @@ export default function SellerProductsPage() {
         <EmptyState
           title="Nenhum produto no catálogo"
           description="O catálogo é gerenciado pelo admin."
+          action={
+            <Button asChild>
+              <Link to="/seller/listings">Ir para listings</Link>
+            </Button>
+          }
         />
       ) : (
         <div className="overflow-hidden rounded-md border border-border">

--- a/src/pages/seller/__tests__/SellerOrders.test.tsx
+++ b/src/pages/seller/__tests__/SellerOrders.test.tsx
@@ -94,6 +94,18 @@ describe("SellerOrders", () => {
     setRole("SELLER");
   });
 
+  it("shows a create-listing CTA when there are no orders", async () => {
+    listOrders.mockResolvedValue([]);
+
+    renderOrders();
+
+    expect(await screen.findByText("Nenhum pedido")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Criar listing" })).toHaveAttribute(
+      "href",
+      "/seller/listings",
+    );
+  });
+
   it("renders the seller order list", async () => {
     listOrders.mockResolvedValue([order()]);
 

--- a/src/pages/seller/__tests__/SellerOrders.test.tsx
+++ b/src/pages/seller/__tests__/SellerOrders.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SellerOrdersPage from "../SellerOrders";
 import type { Order, Role, User } from "@/types/api";
 
 const listOrders = vi.fn();
+const updateOrderTracking = vi.fn();
+const updateOrderStatus = vi.fn();
+const toast = vi.fn();
 const authState = {
   user: {
     id: "seller-user",
@@ -17,6 +20,12 @@ const authState = {
 
 vi.mock("@/api/orders", () => ({
   listOrders: (...args: unknown[]) => listOrders(...args),
+  updateOrderTracking: (...args: unknown[]) => updateOrderTracking(...args),
+  updateOrderStatus: (...args: unknown[]) => updateOrderStatus(...args),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast }),
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -79,6 +88,9 @@ function renderOrders() {
 describe("SellerOrders", () => {
   beforeEach(() => {
     listOrders.mockReset();
+    updateOrderTracking.mockReset();
+    updateOrderStatus.mockReset();
+    toast.mockReset();
     setRole("SELLER");
   });
 
@@ -109,5 +121,33 @@ describe("SellerOrders", () => {
       screen.queryByText("Pedidos que incluem um listing da sua loja."),
     ).toBeNull();
     expect(listOrders).not.toHaveBeenCalled();
+  });
+
+  it("saves tracking through updateOrderTracking and never calls updateOrderStatus", async () => {
+    listOrders.mockResolvedValue([order()]);
+    updateOrderTracking.mockResolvedValue({
+      ...order(),
+      trackingCode: "TR-1",
+      trackingCarrier: "Trade",
+    });
+
+    renderOrders();
+    expect(await screen.findByText("Pedido ord-1")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Informar envio" }));
+    fireEvent.change(screen.getByLabelText("Código"), {
+      target: { value: "TR-1" },
+    });
+    fireEvent.change(screen.getByLabelText("Transportadora / método"), {
+      target: { value: "Trade" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => {
+      expect(updateOrderTracking).toHaveBeenCalledWith("ord-1", {
+        trackingCode: "TR-1",
+        trackingCarrier: "Trade",
+      });
+    });
+    expect(updateOrderStatus).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/seller/__tests__/SellerProducts.test.tsx
+++ b/src/pages/seller/__tests__/SellerProducts.test.tsx
@@ -72,6 +72,28 @@ describe("SellerProducts", () => {
     setRole("SELLER");
   });
 
+  it("shows a listings CTA when the catalog is empty", async () => {
+    listProducts.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+    });
+
+    renderProducts();
+
+    expect(await screen.findByText("Nenhum produto no catálogo")).toBeTruthy();
+    const listingCtas = screen.getAllByRole("link", {
+      name: "Ir para listings",
+    });
+    expect(listingCtas.length).toBeGreaterThan(0);
+    expect(
+      listingCtas.every(
+        (link) => link.getAttribute("href") === "/seller/listings",
+      ),
+    ).toBe(true);
+  });
+
   it("renders a read-only product catalog from listProducts", async () => {
     listProducts.mockResolvedValue({
       items: [product()],

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -212,3 +212,12 @@ export interface UpdateReviewBody {
   rating?: number;
   comment?: string;
 }
+
+/** GET /favorites — listing may be SOLD and still returned. */
+export interface Favorite {
+  id: string;
+  userId: string;
+  listingId: string;
+  createdAt?: string;
+  listing?: Listing;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

One frontend agent compiled the open storefront / dashboard / a11y issues and shipped them on a single branch. `server/` is untouched.

**Closes #94 #101 #104 #107 #108 #99 #114 #116 #112 #110 #109 #87 #117 #119 #118**

**Related (do not close — need the backend PR merged and live-API proof): #93 #103 #106**

| Issue | Status |
|---|---|
| #94 imageUrl lazy + onError monogram | DONE |
| #101 minFloat / maxFloat; min>max skips request | DONE |
| #104 `/stores/:sellerId` public store | DONE |
| #107 PDP related (weapon/collection + same seller) | DONE |
| #108 POST `/sellers/apply` from Account | DONE |
| #99 seller `updateOrderTracking` dialog | DONE (unit/integration; no auth browser) |
| #114 `/admin/products` CRUD | DONE (unit/integration; no auth browser) |
| #116 full price history + empty copy | DONE |
| #112 Market empty vs filtered empty | DONE |
| #110 seller/admin empty CTAs | DONE |
| #109 breadcrumbs → Market query | DONE |
| #87 one mobile hamburger on dashboards | DONE |
| #117 skip-link, `main#conteudo`, RouteFocus, reduced-motion | DONE |
| #119 `ApiError` + 400/401/500 client tests | DONE |
| #118 lazy + prefetch + QueryClient retry 1/0 | DONE |
| #93 server sort client | PARTIAL — UI wired; live API is the sibling backend PR |
| #103 weapon/rarity URL + params | PARTIAL — same |
| #106 favorites UI | PARTIAL — same |

## Verification

- Typecheck / lint pass
- Frontend tests: **75 files / 431 tests**
- Browser (Vite mock catalog): Market empty vs filtered empty + Limpar filtros; `/stores/missing-seller` 404

[Market catalog empty](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsweep_market_catalog_empty_ok.png)
[Market filters empty with clear-filters CTA](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsweep_market_filters_empty_ok.png)
[Public store 404](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsweep_store_not_found_ok.png)

## Merge note

Merge **after or with** `#93 #103 #106 — Listings sort, weapon/rarity filters, and favorites API` so Wave B (sort / weapon-rarity / favorites) hits the real API.

## Risks

- Authenticated seller/admin flows (#99, #114, #108) are covered by tests, not a logged-in browser session
- Favorites / sort / weapon filters stay PARTIAL until the backend PR is deployed and exercised against a live API


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

