### PR TITLE
#106 #103 — Favoritos persistidos e atalhos de arma no Market

### DIFF
--- a/src/api/__tests__/favorites.test.ts
+++ b/src/api/__tests__/favorites.test.ts
@@ -30,10 +30,21 @@ describe("favorites client", () => {
     expect(get).toHaveBeenCalledWith("/favorites");
   });
 
-  it("POSTs /favorites with listingId", async () => {
-    post.mockResolvedValue({ id: "f1", userId: "u1", listingId: "l1" });
-    await addFavorite("l1");
+  it("POSTs /favorites with listingId only and accepts duplicate 200", async () => {
+    post.mockResolvedValue({ listingId: "l1" });
+    await expect(addFavorite("l1")).resolves.toEqual({ listingId: "l1" });
     expect(post).toHaveBeenCalledWith("/favorites", { listingId: "l1" });
+    expect(post.mock.calls[0]?.[1]).toEqual({ listingId: "l1" });
+    expect(post.mock.calls[0]?.[1]).not.toHaveProperty("userId");
+  });
+
+  it("normalizes GET items that only include listingId and listing", async () => {
+    get.mockResolvedValue({
+      items: [{ listingId: "l1", listing: { id: "l1", status: "ACTIVE" } }],
+    });
+    await expect(listFavorites()).resolves.toEqual([
+      { listingId: "l1", listing: { id: "l1", status: "ACTIVE" } },
+    ]);
   });
 
   it("DELETEs /favorites/:listingId", async () => {

--- a/src/api/favorites.ts
+++ b/src/api/favorites.ts
@@ -1,19 +1,31 @@
 import { api } from "./client";
-import type { Favorite, Listing } from "@/types/api";
+import type { AddFavoriteResponse, Favorite, Listing } from "@/types/api";
 
 export interface ListFavoritesResponse {
   items: Favorite[];
 }
 
+function asFavorite(value: unknown): Favorite | null {
+  if (!value || typeof value !== "object") return null;
+  const listingId = favoriteListingId(value as Favorite);
+  if (!listingId) return null;
+  return value as Favorite;
+}
+
 function normalizeFavorites(payload: unknown): Favorite[] {
-  if (Array.isArray(payload)) return payload as Favorite[];
+  if (Array.isArray(payload)) {
+    return payload.flatMap((item) => {
+      const favorite = asFavorite(item);
+      return favorite ? [favorite] : [];
+    });
+  }
   if (
     payload &&
     typeof payload === "object" &&
     "items" in payload &&
     Array.isArray((payload as ListFavoritesResponse).items)
   ) {
-    return (payload as ListFavoritesResponse).items;
+    return normalizeFavorites((payload as ListFavoritesResponse).items);
   }
   return [];
 }
@@ -25,8 +37,8 @@ export async function listFavorites(): Promise<Favorite[]> {
   return normalizeFavorites(payload);
 }
 
-export function addFavorite(listingId: string): Promise<Favorite> {
-  return api.post<Favorite>("/favorites", { listingId });
+export function addFavorite(listingId: string): Promise<AddFavoriteResponse> {
+  return api.post<AddFavoriteResponse>("/favorites", { listingId });
 }
 
 export function removeFavorite(listingId: string): Promise<void> {

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -9,7 +9,11 @@ import {
   consumePendingFavoriteListingId,
   setPendingFavoriteListingId,
 } from "@/lib/pendingFavorite";
-import { userFacingApiError } from "@/lib/userFacingApiError";
+import { normalizeInternalPath } from "@/lib/postLoginPath";
+import {
+  USER_FACING_FORBIDDEN,
+  userFacingApiError,
+} from "@/lib/userFacingApiError";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +26,7 @@ export function FavoriteButton({
 }) {
   const auth = useOptionalAuth();
   const isAuthenticated = Boolean(auth?.isAuthenticated);
+  const isCustomer = auth?.user?.role === "CUSTOMER";
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -30,7 +35,7 @@ export function FavoriteButton({
   const favoritesQuery = useQuery({
     queryKey: ["favorites"],
     queryFn: listFavorites,
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && isCustomer,
   });
 
   const favorited = (favoritesQuery.data ?? []).some(
@@ -81,16 +86,33 @@ export function FavoriteButton({
   useEffect(() => {
     if (!isAuthenticated) return;
     const pending = consumePendingFavoriteListingId();
-    if (pending === listingId) toggle.mutate();
+    if (pending !== listingId) return;
+    if (!isCustomer) {
+      toast({
+        title: USER_FACING_FORBIDDEN,
+        variant: "destructive",
+      });
+      return;
+    }
+    toggle.mutate();
     // one-shot pending favorite after login
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated, listingId]);
+  }, [isAuthenticated, isCustomer, listingId]);
 
   const onClick = () => {
     if (!isAuthenticated) {
       setPendingFavoriteListingId(listingId);
       navigate("/login", {
-        state: { from: `${location.pathname}${location.search}` },
+        state: {
+          from: normalizeInternalPath(`${location.pathname}${location.search}`),
+        },
+      });
+      return;
+    }
+    if (!isCustomer) {
+      toast({
+        title: USER_FACING_FORBIDDEN,
+        variant: "destructive",
       });
       return;
     }

--- a/src/components/__tests__/FavoriteButton.test.tsx
+++ b/src/components/__tests__/FavoriteButton.test.tsx
@@ -56,6 +56,8 @@ describe("FavoriteButton", () => {
     toast.mockReset();
     authState.isAuthenticated = false;
     authState.user = null;
+    sessionStorage.clear();
+    localStorage.clear();
     listFavorites.mockResolvedValue([]);
     addFavorite.mockResolvedValue({
       id: "f1",
@@ -86,5 +88,70 @@ describe("FavoriteButton", () => {
     await waitFor(() => {
       expect(addFavorite).toHaveBeenCalledWith("listing-1");
     });
+  });
+
+  it("treats a duplicate POST 200 as success", async () => {
+    authState.isAuthenticated = true;
+    authState.user = { id: "u1", role: "CUSTOMER" };
+    addFavorite.mockResolvedValue({ listingId: "listing-1" });
+    renderButton();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Adicionar aos favoritos" }),
+    );
+    await waitFor(() => {
+      expect(addFavorite).toHaveBeenCalledWith("listing-1");
+    });
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("rolls back and toasts when the API fails", async () => {
+    authState.isAuthenticated = true;
+    authState.user = { id: "u1", role: "CUSTOMER" };
+    addFavorite.mockRejectedValue(new Error("listing missing"));
+    renderButton();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Adicionar aos favoritos" }),
+    );
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByRole("button", { name: "Adicionar aos favoritos" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("does not claim success when a seller would get 403", async () => {
+    authState.isAuthenticated = true;
+    authState.user = { id: "s1", role: "SELLER" };
+    renderButton();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Adicionar aos favoritos" }),
+    );
+    expect(addFavorite).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Adicionar aos favoritos" }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("posts the one-shot pending favorite after a customer logs in", async () => {
+    sessionStorage.setItem("pendingFavoriteListingId", "listing-1");
+    authState.isAuthenticated = true;
+    authState.user = { id: "u1", role: "CUSTOMER" };
+    renderButton();
+    await waitFor(() => {
+      expect(addFavorite).toHaveBeenCalledWith("listing-1");
+    });
+    expect(sessionStorage.getItem("pendingFavoriteListingId")).toBeNull();
+  });
+
+  it("does not present sessionStorage pending as a saved list", async () => {
+    sessionStorage.setItem("pendingFavoriteListingId", "listing-1");
+    renderButton();
+    expect(
+      screen.getByRole("button", { name: "Adicionar aos favoritos" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(listFavorites).not.toHaveBeenCalled();
+    expect(screen.queryByText("Nenhum favorito")).toBeNull();
   });
 });

--- a/src/lib/__tests__/homeDiscovery.test.ts
+++ b/src/lib/__tests__/homeDiscovery.test.ts
@@ -6,6 +6,7 @@ import {
   approvedSellersCountLabel,
   catalogDiscoveryLinks,
   HOME_EXTERIOR_LINKS,
+  HOME_WEAPON_LINKS,
   listingsCountLabel,
 } from "../homeDiscovery";
 
@@ -55,6 +56,19 @@ describe("catalogDiscoveryLinks", () => {
       },
     ]);
     expect(links.every((link) => !link.href.includes("#"))).toBe(true);
+  });
+});
+
+describe("HOME_WEAPON_LINKS", () => {
+  it("deep-links Market weapon filters", () => {
+    expect(HOME_WEAPON_LINKS[0]).toEqual({
+      weapon: "AK-47",
+      label: "AK-47",
+      href: marketPath({ weapon: "AK-47" }),
+    });
+    expect(HOME_WEAPON_LINKS.map((link) => link.href)).toContain(
+      "/products?weapon=AK-47",
+    );
   });
 });
 

--- a/src/lib/__tests__/marketQuery.test.ts
+++ b/src/lib/__tests__/marketQuery.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   hasMarketFilters,
   isValidNumericRange,
+  MARKET_TAXONOMY_EMPTY_HINT,
+  marketFiltersEmptyDescription,
   marketPath,
   marketSearchEmptyTitle,
   parseMarketQuery,
@@ -147,6 +149,14 @@ describe("weapon and rarity", () => {
     expect(query.rarity).toBe("Covert");
     expect(serializeMarketQuery(query).toString()).toBe(
       "weapon=AK-47&rarity=Covert",
+    );
+  });
+
+  it("suggests clearing weapon or rarity in the empty-filter copy", () => {
+    const query = parseMarketQuery(new URLSearchParams("weapon=AK-47"));
+    expect(marketFiltersEmptyDescription(query)).toContain("arma AK-47");
+    expect(marketFiltersEmptyDescription(query)).toContain(
+      MARKET_TAXONOMY_EMPTY_HINT,
     );
   });
 });

--- a/src/lib/__tests__/pendingFavorite.test.ts
+++ b/src/lib/__tests__/pendingFavorite.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  consumePendingFavoriteListingId,
+  setPendingFavoriteListingId,
+} from "../pendingFavorite";
+
+describe("pendingFavorite", () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  it("stores one listing in sessionStorage, not localStorage", () => {
+    setPendingFavoriteListingId("listing-1");
+    expect(sessionStorage.getItem("pendingFavoriteListingId")).toBe(
+      "listing-1",
+    );
+    expect(localStorage.getItem("pendingFavoriteListingId")).toBeNull();
+    expect(localStorage.getItem("favorites")).toBeNull();
+  });
+
+  it("consumes the pending listing once", () => {
+    setPendingFavoriteListingId("listing-1");
+    expect(consumePendingFavoriteListingId()).toBe("listing-1");
+    expect(consumePendingFavoriteListingId()).toBeNull();
+  });
+});

--- a/src/lib/homeDiscovery.ts
+++ b/src/lib/homeDiscovery.ts
@@ -1,4 +1,5 @@
 import type { Product } from "@/types/api";
+import { MARKET_WEAPONS } from "@/lib/catalogTaxonomy";
 import { similarItemsMarketPath } from "@/lib/listingCartCta";
 import { MARKET_EXTERIORS, marketPath } from "@/lib/marketQuery";
 
@@ -11,7 +12,7 @@ export const HOME_NEW_SORT_COPY =
 
 export const HOME_SHORTCUTS_HEADING = "Descobrir no Market";
 export const HOME_SHORTCUTS_COPY =
-  "Atalhos para skins do catálogo. Cada um abre o Market nessa skin.";
+  "Atalhos de arma e skins. Cada arma abre o Market com o filtro na URL.";
 
 export const HOME_TRUST_HEADING = "Como comprar";
 export const HOME_TRUST_ITEMS = [
@@ -36,6 +37,13 @@ export const HOME_EXTERIOR_LINKS = MARKET_EXTERIORS.filter(Boolean).map(
     href: marketPath({ exterior }),
   }),
 );
+
+/** Common CS2 weapons → Market `weapon=` query. Not a categories table. */
+export const HOME_WEAPON_LINKS = MARKET_WEAPONS.map((weapon) => ({
+  weapon,
+  label: weapon,
+  href: marketPath({ weapon }),
+}));
 
 export interface CatalogShortcut {
   productId: string;

--- a/src/lib/marketQuery.ts
+++ b/src/lib/marketQuery.ts
@@ -38,6 +38,8 @@ export const MARKET_FLOAT_HINT = "0.00–1.00";
 export const MARKET_FLOAT_RANGE_ERROR =
   "O float mínimo não pode ser maior que o máximo.";
 export const MARKET_FILTERS_EMPTY_TITLE = "Nenhum listing com estes filtros";
+export const MARKET_TAXONOMY_EMPTY_HINT =
+  "Limpe a arma ou a raridade para ver mais listings.";
 export const MARKET_CATALOG_EMPTY_TITLE = "Nenhum item encontrado";
 export const MARKET_CATALOG_EMPTY_DESCRIPTION = "Tente ajustar os filtros";
 
@@ -253,6 +255,18 @@ export function describeMarketFilters(query: MarketQuery): string[] {
     parts.push(`float ${query.minFloat || "0"}–${query.maxFloat || "1"}`);
   }
   return parts;
+}
+
+export function marketFiltersEmptyDescription(query: MarketQuery): string {
+  const summary = describeMarketFilters(query);
+  const base =
+    summary.length > 0
+      ? `Nenhum listing para ${summary.join(", ")}.`
+      : "Nenhum listing combina com os filtros ativos.";
+  if (query.weapon || query.rarity) {
+    return `${base} ${MARKET_TAXONOMY_EMPTY_HINT}`;
+  }
+  return base;
 }
 
 export function marketSearchEmptyTitle(term: string): string {

--- a/src/pages/AccountFavorites.tsx
+++ b/src/pages/AccountFavorites.tsx
@@ -1,10 +1,6 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import {
-  favoriteListing,
-  favoriteListingId,
-  listFavorites,
-} from "@/api/favorites";
+import { listFavorites } from "@/api/favorites";
 import { ListingCard } from "@/components/ProductCard";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
@@ -73,8 +69,8 @@ export default function AccountFavoritesPage() {
       ) : (
         <ul className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((favorite) => {
-            const listing = favoriteListing(favorite);
-            const id = favoriteListingId(favorite);
+            const listing = favorite.listing;
+            const id = favorite.listingId ?? favorite.listing?.id ?? "";
             if (!listing) {
               return (
                 <li

--- a/src/pages/AccountFavorites.tsx
+++ b/src/pages/AccountFavorites.tsx
@@ -1,6 +1,10 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { listFavorites } from "@/api/favorites";
+import {
+  favoriteListing,
+  favoriteListingId,
+  listFavorites,
+} from "@/api/favorites";
 import { ListingCard } from "@/components/ProductCard";
 import { EmptyState, ErrorState } from "@/components/page-state";
 import { Badge } from "@/components/ui/badge";
@@ -69,19 +73,20 @@ export default function AccountFavoritesPage() {
       ) : (
         <ul className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {items.map((favorite) => {
-            const listing = favorite.listing;
+            const listing = favoriteListing(favorite);
+            const id = favoriteListingId(favorite);
             if (!listing) {
               return (
                 <li
-                  key={favorite.id}
+                  key={id}
                   className="rounded-md border border-border p-4 text-sm text-muted-foreground"
                 >
-                  Listing {favorite.listingId}
+                  Listing {id}
                 </li>
               );
             }
             return (
-              <li key={favorite.id} className="space-y-2">
+              <li key={id} className="space-y-2">
                 {listing.status === "SOLD" ? (
                   <div className="flex items-center justify-between gap-2">
                     <Badge variant="secondary">Vendido</Badge>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -26,6 +26,7 @@ import {
   HOME_VALUE_PROP,
   approvedSellersCountLabel,
   catalogDiscoveryLinks,
+  HOME_WEAPON_LINKS,
   listingsCountLabel,
 } from "@/lib/homeDiscovery";
 
@@ -106,6 +107,26 @@ export default function IndexPage() {
             <Button asChild variant="outline" size="sm">
               <Link to="/products">{MARKET_VIEW_CTA}</Link>
             </Button>
+            {HOME_WEAPON_LINKS.map((shortcut) => (
+              <Button
+                key={`weapon-${shortcut.weapon}`}
+                asChild
+                variant="outline"
+                size="sm"
+              >
+                <Link
+                  to={shortcut.href}
+                  onClick={() =>
+                    track("category_view", {
+                      category: shortcut.weapon,
+                      source: "home",
+                    })
+                  }
+                >
+                  {shortcut.label}
+                </Link>
+              </Button>
+            ))}
             {HOME_EXTERIOR_LINKS.map((shortcut) => (
               <Button
                 key={shortcut.exterior}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -198,9 +198,7 @@ export default function Products() {
 
   const focusOtherWeaponsSearch = () => {
     writeQuery({ weapon: "", page: 1 }, { replace: true });
-    window.requestAnimationFrame(() => {
-      searchInputRef.current?.focus();
-    });
+    searchInputRef.current?.focus();
   };
 
   return (

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Filter } from "lucide-react";
@@ -22,7 +22,7 @@ import {
   MARKET_SEARCH_DEBOUNCE_MS,
   MARKET_SORTS,
   MARKET_SORT_DEFAULT_COPY,
-  describeMarketFilters,
+  marketFiltersEmptyDescription,
   hasActiveMarketConstraints,
   hasMarketFilters,
   isValidNumericRange,
@@ -92,6 +92,7 @@ function ExteriorShortcuts({
 export default function Products() {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = parseMarketQuery(searchParams);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchDraft, setSearchDraft] = useState(query.q);
   const [minPriceDraft, setMinPriceDraft] = useState(query.minPrice);
   const [maxPriceDraft, setMaxPriceDraft] = useState(query.maxPrice);
@@ -192,8 +193,15 @@ export default function Products() {
     writeQuery({ q: "", page: 1 }, { replace: true });
   };
 
-  const filterSummary = describeMarketFilters(query);
   const filteredEmpty = hasActiveMarketConstraints(query);
+  const emptyFilterDescription = marketFiltersEmptyDescription(query);
+
+  const focusOtherWeaponsSearch = () => {
+    writeQuery({ weapon: "", page: 1 }, { replace: true });
+    window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+  };
 
   return (
     <div className="container py-8">
@@ -248,6 +256,7 @@ export default function Products() {
           <Label htmlFor="market-search">Buscar</Label>
           <Input
             id="market-search"
+            ref={searchInputRef}
             type="search"
             value={searchDraft}
             onChange={(event) => setSearchDraft(event.target.value)}
@@ -255,6 +264,9 @@ export default function Products() {
             autoComplete="off"
             aria-label="Buscar no Market"
           />
+          <p className="text-xs text-muted-foreground">
+            Armas fora da lista: use Outras e a busca.
+          </p>
         </div>
 
         <fieldset className="space-y-1.5">
@@ -275,6 +287,9 @@ export default function Products() {
                 {weapon}
               </Chip>
             ))}
+            <Chip active={false} onClick={focusOtherWeaponsSearch}>
+              Outras
+            </Chip>
           </div>
         </fieldset>
 
@@ -527,11 +542,7 @@ export default function Products() {
         ) : filteredEmpty ? (
           <EmptyState
             title={MARKET_FILTERS_EMPTY_TITLE}
-            description={
-              filterSummary.length > 0
-                ? `Nenhum listing para ${filterSummary.join(", ")}.`
-                : "Nenhum listing combina com os filtros ativos."
-            }
+            description={emptyFilterDescription}
             action={
               <div className="flex flex-col items-center gap-3">
                 <Button type="button" variant="outline" onClick={clearFilters}>

--- a/src/pages/__tests__/AccountFavorites.test.tsx
+++ b/src/pages/__tests__/AccountFavorites.test.tsx
@@ -87,4 +87,20 @@ describe("AccountFavoritesPage", () => {
       screen.getByRole("link", { name: "Ver relacionados" }),
     ).toHaveAttribute("href", "/products?productId=prod-1");
   });
+
+  it("renders GET /favorites items that only include listingId", async () => {
+    const sold = soldFavorite();
+    listFavorites.mockResolvedValue([
+      { listingId: sold.listingId, listing: sold.listing },
+    ]);
+    renderPage();
+    expect(await screen.findAllByText("Vendido")).toHaveLength(2);
+  });
+
+  it("shows an error state without claiming a saved list", async () => {
+    listFavorites.mockRejectedValue(new Error("forbidden"));
+    renderPage();
+    expect(await screen.findByText("Erro ao carregar favoritos")).toBeTruthy();
+    expect(screen.queryByText("Nenhum favorito")).toBeNull();
+  });
 });

--- a/src/pages/__tests__/Index.test.tsx
+++ b/src/pages/__tests__/Index.test.tsx
@@ -195,6 +195,10 @@ describe("Index", () => {
     expect(marketLinks.length).toBeGreaterThan(1);
     expect(marketLinks[0]).toHaveAttribute("href", "/products");
 
+    expect(screen.getByRole("link", { name: /^AK-47$/ })).toHaveAttribute(
+      "href",
+      "/products?weapon=AK-47",
+    );
     expect(screen.getByRole("link", { name: "Factory New" })).toHaveAttribute(
       "href",
       "/products?exterior=Factory+New",

--- a/src/pages/__tests__/Login.test.tsx
+++ b/src/pages/__tests__/Login.test.tsx
@@ -29,11 +29,14 @@ function authedUser(role: Role): User {
   };
 }
 
-function renderLogin(from?: string) {
+function renderLogin(from?: string, asString = false) {
   const entry =
     from === undefined
       ? "/login"
-      : { pathname: "/login", state: { from: { pathname: from } } };
+      : {
+          pathname: "/login",
+          state: { from: asString ? from : { pathname: from } },
+        };
 
   return render(
     <MemoryRouter initialEntries={[entry]}>
@@ -44,6 +47,7 @@ function renderLogin(from?: string) {
         <Route path="/admin" element={<div>landed-admin</div>} />
         <Route path="/checkout" element={<div>landed-checkout</div>} />
         <Route path="/seller/listings" element={<div>landed-listings</div>} />
+        <Route path="/listing/:id" element={<div>landed-listing</div>} />
       </Routes>
     </MemoryRouter>,
   );
@@ -98,6 +102,18 @@ describe("Login", () => {
     renderLogin();
     await submitAs("SELLER");
     expect(await screen.findByText("landed-seller")).toBeTruthy();
+  });
+
+  it("returns a customer to a safe listing path from a string from", async () => {
+    renderLogin("/listing/listing-1", true);
+    await submitAs("CUSTOMER");
+    expect(await screen.findByText("landed-listing")).toBeTruthy();
+  });
+
+  it("rejects an external from string", async () => {
+    renderLogin("https://evil.example", true);
+    await submitAs("CUSTOMER");
+    expect(await screen.findByText("landed-home")).toBeTruthy();
   });
 
   it("sends customer with from=/checkout to /checkout", async () => {

--- a/src/pages/__tests__/Products.test.tsx
+++ b/src/pages/__tests__/Products.test.tsx
@@ -10,6 +10,7 @@ import {
   MARKET_SIMILAR_EMPTY_TITLE,
   MARKET_VIEW_CTA,
 } from "@/lib/listingCartCta";
+import { MARKET_TAXONOMY_EMPTY_HINT } from "@/lib/marketQuery";
 import { CART_STORAGE_KEY } from "@/lib/cartStorage";
 import {
   setAnalyticsCollector,
@@ -478,6 +479,99 @@ describe("Products", () => {
       ),
     ).toBeTruthy();
     expect(listListings).not.toHaveBeenCalled();
+  });
+
+  it("marks the weapon chip from the URL as pressed", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?weapon=AK-47");
+
+    expect(
+      await screen.findByRole("button", { name: "AK-47" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await waitFor(() => {
+      expect(listListings).toHaveBeenCalledWith(
+        expect.objectContaining({ weapon: "AK-47", status: "ACTIVE" }),
+      );
+    });
+  });
+
+  it("combines weapon with exterior, StatTrak, and search in the URL", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?weapon=AK-47&exterior=Field-Tested&stattrak=true");
+    expect(
+      await screen.findByText("AK-47 | Redline (Field-Tested)"),
+    ).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Buscar no Market"), {
+      target: { value: "redline" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-query").textContent).toContain(
+        "weapon=AK-47",
+      );
+      expect(screen.getByTestId("market-query").textContent).toContain(
+        "exterior=Field-Tested",
+      );
+      expect(screen.getByTestId("market-query").textContent).toContain(
+        "stattrak=true",
+      );
+      expect(screen.getByTestId("market-query").textContent).toContain(
+        "q=redline",
+      );
+    });
+  });
+
+  it("uses Outras to focus search instead of inventing a weapon param", async () => {
+    listListings.mockResolvedValue({
+      items: [makeListing()],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?weapon=AK-47");
+    expect(
+      await screen.findByRole("button", { name: "AK-47" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Outras" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("market-query").textContent).not.toContain(
+        "weapon=",
+      );
+    });
+    expect(screen.getByLabelText("Buscar no Market")).toHaveFocus();
+  });
+
+  it("suggests clearing weapon or rarity when those filters empty the grid", async () => {
+    listListings.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+    });
+
+    renderMarket("/products?weapon=AK-47&rarity=Covert");
+
+    expect(
+      await screen.findByText("Nenhum listing com estes filtros"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(new RegExp(MARKET_TAXONOMY_EMPTY_HINT)),
+    ).toBeTruthy();
   });
 
   it("puts weapon and rarity in the URL and listListings params", async () => {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -215,9 +215,14 @@ export interface UpdateReviewBody {
 
 /** GET /favorites — listing may be SOLD and still returned. */
 export interface Favorite {
-  id: string;
-  userId: string;
   listingId: string;
-  createdAt?: string;
   listing?: Listing;
+  id?: string;
+  userId?: string;
+  createdAt?: string;
+}
+
+/** POST /favorites 200 — create and duplicate are both `{ listingId }`. */
+export interface AddFavoriteResponse {
+  listingId: string;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fecha o backlog de frontend que ficou PARTIAL no sweep anterior, agora contra a API já mergeada (#204).

**Closes #106 #103**

Não toca `server/`. Contrato de favorites / `weapon` / `rarity` já está na `main`.

### #106 — Favoritos
- Coração na PDP e no card; `/account/favorites`
- Guest → login com `from` sanitizado (`normalizeInternalPath`); pending em `sessionStorage` (não é lista da conta)
- Só CUSTOMER muta; seller/admin vê 403 e não marca sucesso
- POST `{ listingId }` only; GET aceita items sem `id`
- Prova live: CUSTOMER JWT — GET vazio → POST 200 → POST duplicado 200 → dois GETs ainda com o mesmo `listingId` (F5). Guest 401. Seller 403.

### #103 — Arma / raridade
- Home: chips `HOME_WEAPON_LINKS` → `/products?weapon=AK-47` (antes só exterior + skin/productId)
- Market: chip ativo reflete a URL; **Outras** foca a busca (sem inventar param)
- Empty copy pede para limpar arma/raridade
- Prova live: `GET /listings?weapon=AK-47` total 23 todos AK-47 vs 122 sem filtro; AWP 16; Covert 73. Contagens iguais no Postgres.

## Verification

- `npm run typecheck` → pass
- `npm run lint` → 0 errors
- `npm test` → **76 files / 449 tests**
- API worktree `:3002` (o processo em `:3001` era um binário antigo que ignorava `weapon=` / `rarity=`)

[Home weapon shortcuts](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffe_weapon_home.png)
[Market AK-47 chip and Outras](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffe_weapon_market_ak47.png)
[Market AK-47 + Contraband filters](https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffe_weapon_empty_filter.png)

## Risks

- Screenshots do Vite `:5179` mostram a UI (chips/Outras) mas a grade falhou por CORS (`FRONTEND_URL=http://localhost:5173`). Persistência e filtro estão provados por curl na API `:3002`, não por F5 no browser da lista.
- Clique interativo de favorito no browser não foi gravado (sem computerUse neste agente).

## Backend

Nenhum. `BACKEND_NEEDED: none`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0775b-f2cd-77ff-9880-0a9b78f3fe71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

