### PR TITLE
fix(ci): permitir build da API no workflow k6

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -34,7 +34,6 @@ jobs:
     env:
       BASE_URL: http://127.0.0.1:3001
       DATABASE_URL: postgresql://neon:ci_password@localhost:5432/neon_arsenal_loadtest
-      NODE_ENV: production
       PORT: "3001"
       SEED_DEMO_DATA: "true"
       JWT_SECRET: ephemeral-load-test-access-secret
@@ -81,7 +80,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts/k6
-          (cd server && npm start > ../artifacts/k6/api.log 2>&1 & echo $! > ../artifacts/k6/api.pid)
+          (cd server && NODE_ENV=production npm start > ../artifacts/k6/api.log 2>&1 & echo $! > ../artifacts/k6/api.pid)
 
       - name: Wait for API readiness
         shell: bash


### PR DESCRIPTION
Corrige a falha de `catalog`/`smoke` antes do k6 iniciar.

`NODE_ENV=production` era definido no job inteiro, então `npm ci` omitia dependências de desenvolvimento (`typescript`, `vitest`, `@types/node`) e o build da API falhava. O ambiente de produção agora é aplicado apenas ao comando que inicia a API.

Verificado:

- `env -u NODE_ENV npm ci --prefix server`
- `npm run build --prefix server`
- validação YAML

Relates to #55.