### PR TITLE
feat(ai-factory): define the direct agent harness

### DIFF
--- a/.cursor/rules/01-task-execution.mdc
+++ b/.cursor/rules/01-task-execution.mdc
@@ -1,15 +1,15 @@
 ---
-description: Issue-driven task planning and execution
+description: Repository-artifact-driven task planning and execution
 alwaysApply: true
 ---
 
 # Task Execution
 
-When the user names a GitHub issue, feature, bug, roadmap item, or says `next` / `orquestrador`, treat it as an engineering task and follow the repository's agent protocol. Unqualified `next` means: run `python3 scripts/orchestrator/next.py` and spawn the printed subagents.
+When the user names a Task, Plan, Specification, external Issue, feature, bug, or roadmap item, resolve it through `docs/agents/harness.md`. Unqualified `next` means validate the repository graph and choose an unambiguously eligible `Ready` Task. Do not invoke the legacy orchestrator unless the user explicitly requests the legacy command.
 
 ## Before coding
 
-- Identify the exact issue/task.
+- Identify the exact authoritative artifact or shape the request into one.
 - Read its acceptance criteria and constraints.
 - Check the relevant roadmap item.
 - Classify the task by risk and domain.
@@ -21,7 +21,7 @@ For non-trivial work, present a concise plan before making broad changes. Do not
 
 ## During coding
 
-- Keep changes scoped to the issue.
+- Keep changes scoped to the Task.
 - Preserve existing public behavior unless the task requires a change.
 - Prefer the smallest correct design.
 - Do not refactor unrelated code.
@@ -34,11 +34,11 @@ For non-trivial work, present a concise plan before making broad changes. Do not
 
 Use a dedicated branch/worktree when the environment supports it. Do not rewrite shared history. Do not force-push unless explicitly authorized.
 
-If the user asks for a commit, commit only the scoped changes after verification. Use a clear conventional commit message and include the issue number when appropriate.
+If the user asks for a commit, commit only the scoped changes after verification. Use a clear conventional commit message and include an external Issue number only when one exists.
 
 Do not claim that a commit, test, deployment, or CI run happened unless you actually performed or observed it.
 
-## Issue completion
+## Task completion
 
 A task is not complete until:
 
@@ -49,4 +49,4 @@ A task is not complete until:
 - remaining risks are known;
 - completion evidence is reported.
 
-If the issue is ambiguous in a way that affects correctness, stop and ask for clarification. If the ambiguity is safely resolvable from existing repository conventions, resolve it without unnecessary interruption.
+If authority or required behavior is ambiguous in a way that affects correctness, stop and ask for clarification. If the ambiguity is safely resolvable from existing repository conventions, resolve it without unnecessary interruption.

--- a/.cursor/rules/06-orchestrator.mdc
+++ b/.cursor/rules/06-orchestrator.mdc
@@ -1,21 +1,23 @@
 ---
-description: Unified GitHub-issue orchestrator that spawns role-assigned subagents
-alwaysApply: true
+description: Deprecated compatibility rule for the legacy GitHub-issue orchestrator
+alwaysApply: false
 ---
 
-# Orchestrator
+# Legacy Orchestrator Compatibility
 
-There is **one** engineering orchestrator. It reads **GitHub issues**, not `scripts/p-front/activities.json` or `scripts/p-back/activities.json`.
+ADR 0020 and `docs/agents/harness.md` define direct repository execution as the default. This rule exists only until the legacy scripts are physically removed.
 
-## When the user says `next`, `orquestrador`, or `orchestrator`
+## When the user explicitly requests the legacy command
 
-The parent agent must:
+Only an explicit request such as “run the legacy orchestrator command” activates this compatibility path. Plain `next`, a Task ID, a Plan ID, a feature, or a bug follows the direct harness.
+
+When explicitly activated, the parent agent may:
 
 1. Run `python3 scripts/orchestrator/next.py --json` (add `--prompt` when spawning).
 2. Treat `spawn[]` as the work set. Each entry already has `role`, `requiredRoles`, `subagentType`, `branch`, and `prompt`.
-3. Launch **one Task subagent per `spawn` entry** (`subagentType`, usually `generalPurpose`) with that prompt. Do not implement those issues in the parent.
+3. Treat the output as advisory intake, then reconcile it with authoritative repository Specifications, Plans, and Tasks before implementation.
 4. Parallelize only when tracks are disjoint (`src/` vs `server/`). Default is one backend issue and one frontend issue.
-5. After a subagent returns, do not mark the GitHub issue closed (`gh` is read-only). Do not merge.
+5. Preserve all normal Task scope, verification, and human-approval boundaries.
 
 `--track backend` or `--track frontend` narrows the set. `--issue N` forces a single issue.
 
@@ -27,7 +29,7 @@ Follow `docs/agents/roles.md` and `.cursor/rules/00`–`05`. Verification must c
 
 ## Intake
 
-Source of truth: open GitHub issues.
+Legacy intake: open GitHub issues. These are not the source of truth.
 
 - Done: closed issue, or high-confidence match against `origin/main` commit subjects (listed as `likelyDone`).
 - Busy: open PR that references the issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,17 @@ Do not invent missing requirements to make artifacts agree. When artifacts confl
 
 Templates live under `docs/templates/`. Canonical artifact IDs and file naming are defined by the factory authority document at `docs/architecture/ai-engineering-authority.md`.
 
+### Direct agent entry
+
+The canonical execution protocol is `docs/agents/harness.md`. Agents operate directly from repository artifacts:
+
+- a named `TASK-*` authorizes bounded execution when its lifecycle and dependencies permit it;
+- a named `PLAN-*` is continued through its next eligible Task;
+- a described problem is classified by materiality and shaped into the required artifacts before implementation;
+- unqualified `next` means validate the repository graph and select an unambiguously eligible `Ready` Task, not query GitHub or invoke the legacy orchestrator.
+
+If multiple eligible Tasks represent materially different priorities that the repository does not resolve, ask the human to choose. External trackers are optional context only.
+
 ## Before Changing Code
 
 1. Identify the Specification, Plan, or Task that authorizes the work; an external Issue may provide context but is optional.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -12,14 +12,12 @@ Read in this order:
 
 1. `AGENTS.md` — global engineering rules.
 2. `docs/agents/README.md` — team operating model.
-3. `docs/agents/roles.md` — responsibilities and boundaries.
-4. `docs/architecture/current-state.md` — known architectural reality and gaps.
-5. `docs/domain/invariants.md` — canonical invariant ID catalog and enforcement map.
-6. `docs/architecture/domain-invariants.md` — narrative invariant contract (must stay in sync with the catalog).
-7. `docs/roadmap.md` — prioritized backlog.
-8. The relevant source code, schema, migrations, and tests.
-9. The relevant ADRs and operational documentation.
-10. `docs/observability.md` when the task touches logs, traces, metrics or request correlation.
+3. `docs/agents/harness.md` — direct entry, context, execution, and evidence protocol.
+4. The named Specification, Plan, or Task.
+5. `docs/agents/roles.md` — responsibilities and boundaries.
+6. Relevant architecture and invariant documents.
+7. The relevant source code, schema, migrations, and tests.
+8. Relevant ADRs, provider, and operational documentation.
 
 If code and documentation disagree, the agent must inspect the code and flag the documentation as stale. It must not silently invent behavior.
 
@@ -28,6 +26,8 @@ If code and documentation disagree, the agent must inspect the code and flag the
 The team is intentionally **sequential by default**. Parallel agents are used only when their work has no overlapping files or semantic dependencies.
 
 The repository artifact graph is the control plane. An agent selects a `Ready` Task whose dependencies are `Done`, loads its bounded context, and applies the minimum relevant roles.
+
+Canonical entry modes and `next` semantics are defined in [`harness.md`](harness.md). No Python command or external tracker is required to start an agent.
 
 The previous Issue-based orchestrator remains as a temporary migration adapter:
 

--- a/docs/agents/context-policy.md
+++ b/docs/agents/context-policy.md
@@ -8,7 +8,7 @@ Give each agent the minimum context required to make a correct decision. Context
 2. `docs/agents/README.md`
 3. The role file or role section relevant to the task
 4. The specific architecture/invariant document named by the task
-5. The GitHub issue
+5. The optional external Issue, when one was supplied
 6. Directly relevant source files
 7. Relevant tests, schema and migrations
 8. ADRs or operational docs only when the task touches those concerns
@@ -40,7 +40,7 @@ Use filename/symbol/term search before opening large files. Prefer targeted rang
 
 ## Context tiers
 ### Tier 0 — always
-`AGENTS.md`, `docs/agents/README.md`, GitHub issue.
+`AGENTS.md` and the named Specification, Plan, or Task. Load an external Issue only when it exists and adds relevant context.
 
 ### Tier 1 — task-local
 Relevant role, architecture, invariants, source, tests, schema/migrations.
@@ -63,7 +63,7 @@ If those answers are known, implement or review instead of continuing to explore
 
 ## Handoff compression
 Every handoff should fit comfortably in a short message and contain:
-- task/issue;
+- Task and optional external Issue;
 - files changed or inspected;
 - invariant protected;
 - decision made;

--- a/docs/agents/execution-protocol.md
+++ b/docs/agents/execution-protocol.md
@@ -20,15 +20,15 @@ VERIFYING
 ```
 
 ## READY
-Run `python3 scripts/orchestrator/next.py`. Spawn one subagent per selected GitHub issue, with the role set from `docs/agents/roles.md`. Prefer the highest-priority unblocked issues. Do not start multiple dependent roadmap items concurrently. Default wave: at most one backend issue and one frontend issue.
+Resolve the user request through `docs/agents/harness.md`. For a named Task, validate its status and dependencies. For a Plan, identify its next eligible Task. For unqualified `next`, validate the repository graph and choose only an unambiguously eligible `Ready` Task. Do not query GitHub or invoke the legacy orchestrator by default.
 
 ## PLANNING
 Planner reads the mandatory context, identifies the invariant, affected boundaries, acceptance criteria and verification plan. Output is a compact implementation brief.
 
-If the issue is ambiguous, contradictory or materially larger than documented, transition to `HUMAN` rather than inventing requirements.
+If the authoritative artifacts are ambiguous, contradictory, or materially smaller than the requested behavior, transition to `HUMAN` rather than inventing requirements.
 
 ## IMPLEMENTING
-Primary agent works in an isolated branch/worktree. It changes only files within the issue scope unless a directly required dependency is discovered.
+Primary agent works in an isolated branch/worktree. It changes only files within the Task scope unless a directly required dependency is discovered and the Task is replanned.
 
 Do not mix unrelated cleanup, dependency upgrades or architectural experiments into the task.
 
@@ -54,10 +54,10 @@ Only after:
 - handoff is complete.
 
 ## HUMAN
-Use when the decision policy requires approval or when evidence is insufficient. The orchestrator must preserve the blocker and resume from the same task after the decision.
+Use when the decision policy requires approval or when evidence is insufficient. Preserve the blocker in the Task or handoff and resume from the same artifact after the decision.
 
 ## Agent invocation policy
-Do not invoke every role for every issue.
+Do not invoke every role for every Task.
 
 - Simple bug: Primary + Verification.
 - API behavior: Primary + Test + Security when relevant + Verification.

--- a/docs/agents/harness.md
+++ b/docs/agents/harness.md
@@ -1,0 +1,115 @@
+# Direct Agent Harness
+
+## Purpose
+
+This repository is the agent harness. Any coding agent with repository access can work safely by reading the same durable artifacts and running the same deterministic checks. No agent vendor, GitHub Issue, prompt generator, model API, or parent orchestrator is required.
+
+## Entry modes
+
+An agent enters through one of four explicit modes:
+
+1. **Execute a Task** — the user names a `TASK-*`; execute only when it is `Ready` or continue it when `InProgress`.
+2. **Continue a Plan** — the user names a `PLAN-*`; identify the next declared Task whose dependencies are `Done`.
+3. **Shape requested work** — the user describes a problem; apply the materiality rule and create or update the required Specification, Plan, and Task before implementation.
+4. **Choose next work** — the user says `next`; validate artifacts and inspect repository Tasks directly. Execute one unambiguously eligible `Ready` Task. If several materially different Tasks are eligible and repository priorities do not decide between them, ask the human to choose. If none is eligible, report that fact instead of consulting GitHub automatically.
+
+An external Issue may be supplied in any mode as context. It never replaces repository authority.
+
+## Artifact resolution
+
+Resolve authority in this order for material work:
+
+```text
+Accepted SPEC → Ready PLAN → Ready/InProgress TASK → code and tests → verification evidence
+```
+
+- Specification decides required behavior and acceptance.
+- ADR and invariant catalogs decide durable architecture and correctness constraints.
+- Plan decides implementation strategy and graph structure.
+- Task decides the bounded objective, owner, allowed files, dependencies, and verification command.
+- Code describes current executable behavior; disagreement with an authoritative artifact is a defect to resolve.
+
+Never manufacture a missing link just to begin coding. Small reversible work may be Task-only when the materiality rule permits it.
+
+## Bootstrap
+
+For an executable Task:
+
+1. Read `AGENTS.md`.
+2. Read the named Task and its source Plan and Specification.
+3. Read only the architecture, invariant, role, provider, and operational documents referenced by those artifacts or implicated by the risk.
+4. Search for the owning implementation and closest tests before opening broad directories.
+5. Run `python scripts/ai-factory/validate.py` before broad edits when artifact state may have changed.
+6. Confirm Task status, source versions, dependencies, baseline, and allowed-file boundary.
+
+Do not load every document by default.
+
+## Context budget
+
+Use progressive disclosure:
+
+- Tier 0: `AGENTS.md` and the named artifact.
+- Tier 1: its direct source artifacts, owning code, and closest tests.
+- Tier 2: affected architecture, invariants, security, reliability, provider, or operational documents.
+- Tier 3: repository-wide inspection only for broad architecture work or unresolved conflicting evidence.
+
+Stop expanding context when the invariant, required behavior, owner files, proof, and verification command are known. Summaries and handoffs are navigation aids, not authority.
+
+## Execution loop
+
+```text
+RESOLVE → VALIDATE → PLAN → IMPLEMENT → TEST → REVIEW → VERIFY → RECORD
+```
+
+- **Resolve:** bind work to the authoritative artifact and exact versions.
+- **Validate:** confirm graph eligibility, preconditions, and baseline assumptions.
+- **Plan:** state a concise sequence and failure model proportional to risk.
+- **Implement:** make the smallest coherent change within allowed files.
+- **Test:** prove acceptance criteria and relevant failure/invariant behavior.
+- **Review:** inspect the diff using the selected role lenses.
+- **Verify:** run the exact Task command plus broader checks justified by risk.
+- **Record:** update status and durable verification/handoff evidence truthfully.
+
+A failed check returns to implementation with the exact evidence. Two failures from the same unresolved root cause stop the loop for human direction.
+
+## Role lenses
+
+Roles in `docs/agents/roles.md` are review perspectives, not mandatory processes or separate agents. Select the minimum set required by the risk. A single agent may apply them sequentially; genuinely independent work may use separate agents when the environment supports it.
+
+Verification must remain adversarial to the implementation claim. The same agent may verify, but it must inspect acceptance criteria, invariants, failure paths, and the final diff rather than merely summarize its own work.
+
+## Parallelism
+
+Sequential execution is the default. Parallel work is allowed only when Tasks are dependency-independent, allowed files are disjoint, and they do not mutate the same invariant, contract, schema state, or generated artifact. Each Task keeps one owner and produces its own evidence.
+
+The static graph validator proves reference and lifecycle ordering. It does not prove semantic independence; that judgment remains in the Plan and review.
+
+## Evidence and handoff
+
+Completion records:
+
+- artifact IDs and exact versions;
+- files changed;
+- invariants and contracts affected;
+- exact commands and results;
+- acceptance mapping;
+- unresolved risks and unverified surfaces;
+- next eligible Task, when known.
+
+Use `docs/agents/handoff-template.md`. Never claim a check ran when it did not, and never treat a chat summary as durable evidence.
+
+## Portability
+
+The canonical harness uses Markdown, Git, repository code/tests, and dependency-free validation. Provider-specific rules such as `.cursor/rules/` adapt the same contract but cannot override `AGENTS.md`, Specifications, ADRs, invariants, Plans, or Tasks.
+
+Agents may be invoked interactively in Codex, Cursor, or another repository-capable environment. The harness does not call an LLM, own tokens, store credentials, schedule work, or require network access.
+
+## Legacy compatibility
+
+The existing `scripts/orchestrator/` command and its shims are deprecated adapters during migration. They may still be invoked only when a human explicitly requests the legacy path. Normal `next`, feature, bug, Specification, Plan, and Task requests follow this direct harness.
+
+External Issues remain optional references for coordination and historical lookup.
+
+## Stop conditions
+
+Stop and request human direction when authority conflicts materially, required behavior is undefined, a destructive or security-sensitive decision lacks approval, a Task would exceed allowed files, source artifact versions drift, or multiple eligible Tasks represent materially different priorities that the repository does not resolve.

--- a/docs/plans/PLAN-0007-direct-agent-harness.md
+++ b/docs/plans/PLAN-0007-direct-agent-harness.md
@@ -1,0 +1,111 @@
+---
+id: PLAN-0007
+status: Ready
+version: 1
+source_spec: SPEC-0009
+source_spec_version: 1
+baseline_revision: a40539921540417b88c56eddf2eee0eee6575565
+owner: "Neon Arsenal Engineering"
+created: 2026-09-08
+updated: 2026-09-08
+---
+
+# [PLAN-0007] — Define the direct agent harness
+
+## Status
+
+`Ready`
+
+## Source
+
+- Specification: `SPEC-0009` v1
+- ADR: `ADR 0020`
+- External tracker: None
+- Baseline: `a40539921540417b88c56eddf2eee0eee6575565`
+
+## Current State
+
+The repository artifact chain and Task graph are authoritative and validated. Active execution and context documents still contain mandatory orchestrator and GitHub intake instructions, so an agent can receive contradictory guidance despite ADR 0020.
+
+## Goal
+
+Publish one provider-neutral direct harness and align active agent instructions so repository-capable agents can resolve, execute, verify, and hand off work without the orchestrator.
+
+## Affected Areas
+
+- `docs/agents/harness.md`, README, context and execution protocols
+- Root `AGENTS.md` direct-entry guidance
+- Cursor task/orchestrator compatibility rules
+- Factory validation and tests for the harness document contract
+- Plan, Task, and verification evidence for this change
+
+## Architecture
+
+The harness is documentation plus deterministic validation, not a runtime service. `AGENTS.md` is the portable root entry point; provider-specific rules adapt it without gaining authority.
+
+## Database
+
+None. No product runtime, schema, migration, transaction, or persistence change.
+
+## Implementation Sequence
+
+1. Define direct entry modes, artifact resolution, context budget, execution loop, roles, parallelism, evidence, portability, and stop conditions.
+2. Replace active Issue/orchestrator-first instructions with direct Task/Plan/Specification resolution.
+3. Demote the Cursor orchestrator rule to explicit legacy compatibility.
+4. Validate the harness shape and repository artifacts, then record evidence.
+
+## Task Graph
+
+```text
+TASK-AI-001 → TASK-AI-002
+```
+
+`TASK-AI-002` begins after the project-local contract is Done.
+
+## Testing Strategy
+
+Add dependency-free checks for required harness headings, direct-mode language, and the absence of mandatory orchestrator invocation from active execution instructions.
+
+## Verification Strategy
+
+Run Python compilation, artifact validation, validator tests, focused searches for stale active instructions, and Git diff checks. Commit hooks provide client/server type checks.
+
+## Risks
+
+- Ambiguous `next` could silently choose the wrong work; the harness chooses only when eligibility and priority are unambiguous.
+- Provider-specific rules could contradict portable authority; their scope is explicitly subordinate.
+- Removing legacy files here would mix behavioral migration with deletion; physical removal remains PR3.
+
+## Dependencies
+
+- `SPEC-0009` Accepted: satisfied.
+- `TASK-AI-001` Done: satisfied.
+- ADR 0020 Accepted: satisfied.
+
+## Stop Conditions
+
+- Stop if the harness requires a model API, network service, credential, scheduler, or new dependency.
+- Stop before deleting legacy orchestrator files.
+- Stop if an active instruction cannot be reconciled without changing product behavior.
+
+## Definition of Done
+
+The direct harness is canonical, active instructions no longer require Issues or the orchestrator, portability and context budgets are explicit, deterministic checks pass, and no product runtime paths change.
+
+## Traceability
+
+```text
+SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+```
+
+- Specification: `SPEC-0009` v1
+- Plan: `PLAN-0007` v1
+- Task: `TASK-AI-002`
+- PR: pending
+- Verification/Convergence: `docs/verification/direct-agent-harness-v1.md`
+- Evaluation: pending
+- Memory: pending
+
+## Change History
+
+- `v1` — Ready plan for a provider-neutral direct harness — 2026-09-08

--- a/docs/tasks/TASK-AI-002-direct-agent-harness.md
+++ b/docs/tasks/TASK-AI-002-direct-agent-harness.md
@@ -1,0 +1,95 @@
+---
+id: TASK-AI-002
+status: Done
+version: 1
+source_spec: SPEC-0009
+source_spec_version: 1
+source_plan: PLAN-0007
+source_plan_version: 1
+baseline_revision: a40539921540417b88c56eddf2eee0eee6575565
+owner: Neon Arsenal Engineering
+created: 2026-09-08
+updated: 2026-09-08
+---
+
+# [TASK-AI-002] — Publish and enforce the direct agent harness
+
+## Status
+
+`Done`.
+
+## Source
+
+- Specification: `SPEC-0009` v1
+- Plan: `PLAN-0007` v1
+- ADR: `ADR 0020`
+- External tracker: None
+
+## Objective
+
+Make the direct repository harness the unambiguous default workflow for any compatible coding agent.
+
+## Scope
+
+Create the harness contract, align active agent guidance, retain legacy orchestration only as explicitly requested compatibility, and add deterministic harness validation. Do not remove legacy files or change product code.
+
+## Allowed Files
+
+- `AGENTS.md`
+- `.cursor/rules/01-task-execution.mdc`
+- `.cursor/rules/06-orchestrator.mdc`
+- `docs/agents/README.md`
+- `docs/agents/context-policy.md`
+- `docs/agents/execution-protocol.md`
+- `docs/agents/harness.md`
+- `docs/plans/PLAN-0007-direct-agent-harness.md`
+- `docs/tasks/TASK-AI-002-direct-agent-harness.md`
+- `docs/verification/direct-agent-harness-v1.md`
+- `scripts/ai-factory/validate.py`
+- `scripts/ai-factory/test_validate.py`
+
+## Preconditions
+
+`SPEC-0009` is Accepted, `PLAN-0007` is Ready, `TASK-AI-001` is Done, and the baseline resolves locally.
+
+## Acceptance Criteria
+
+- [x] `AC-01` The harness defines direct Task, Plan, request-shaping, and `next` entry modes. **Evidence:** static check
+- [x] `AC-02` Active execution and context guidance no longer requires a GitHub Issue or orchestrator command. **Evidence:** test
+- [x] `AC-03` Context loading, role selection, parallelism, verification, evidence, and stop conditions are provider-neutral and explicit. **Evidence:** manual review
+- [x] `AC-04` The Cursor orchestrator rule is inactive by default and limited to explicitly requested legacy compatibility. **Evidence:** static check
+- [x] `AC-05` Repository artifact validation and unit tests pass without product changes. **Evidence:** integration
+
+## Dependencies
+
+`TASK-AI-001`.
+
+## Risks
+
+Changing the meaning of `next` could surprise users accustomed to GitHub selection. The harness documents the direct semantics and retains explicit legacy invocation until PR3.
+
+## Verification Command
+
+```powershell
+python -m py_compile scripts/ai-factory/validate.py scripts/ai-factory/test_validate.py; python scripts/ai-factory/validate.py; python scripts/ai-factory/test_validate.py; git diff --check
+```
+
+## Expected Evidence
+
+- Direct harness headings and active-instruction constraints pass deterministic tests.
+- Repository artifacts and Task graph validate.
+- Changed paths exclude product runtime, database, migrations, and deployment.
+
+## Stop Conditions
+
+- Stop if direct execution requires a vendor API, secret, network call, or new dependency.
+- Stop before deleting `scripts/orchestrator/`, shims, or historical documentation.
+- Stop if product behavior would change.
+
+## Traceability
+
+`SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY`
+
+## Change History
+
+- 2026-09-08 — v1 — Direct harness implemented and verified.

--- a/docs/verification/direct-agent-harness-v1.md
+++ b/docs/verification/direct-agent-harness-v1.md
@@ -1,0 +1,26 @@
+# Verification — Direct agent harness v1
+
+## Scope
+
+Verification of `PLAN-0007` and `TASK-AI-002` under `SPEC-0009`. The change establishes the provider-neutral repository harness and aligns active agent instructions without removing legacy files.
+
+## Evidence
+
+- `python -m py_compile scripts/ai-factory/validate.py scripts/ai-factory/test_validate.py` — passed with exit code 0.
+- `python scripts/ai-factory/validate.py` — passed, including the direct harness, artifact contracts, Task graph, and internal references.
+- `python scripts/ai-factory/test_validate.py` — 18 tests passed.
+- `git diff --check` — passed with exit code 0 using the managed checkout's per-command safe-directory override.
+- Focused instruction search — active Task execution, context, and execution-protocol files contain no mandatory `scripts/orchestrator/next.py` invocation. Remaining command references are explicitly marked legacy compatibility for PR3 removal.
+- Changed-path review — no `src/`, `server/`, schema, migration, dependency, deployment, or infrastructure path changed.
+
+## Acceptance mapping
+
+- `TASK-AI-002 AC-01`: `docs/agents/harness.md` defines all four direct entry modes.
+- `TASK-AI-002 AC-02`: deterministic harness validation rejects a legacy command in active execution guidance.
+- `TASK-AI-002 AC-03`: manual review confirmed progressive context, role lenses, semantic parallelism, adversarial verification, evidence, portability, and stop conditions.
+- `TASK-AI-002 AC-04`: deterministic validation requires `.cursor/rules/06-orchestrator.mdc` to have `alwaysApply: false`.
+- `TASK-AI-002 AC-05`: all repository artifact and unit checks pass with documentation/tooling-only paths.
+
+## Result
+
+`PASS`. A repository-capable agent can now begin from a Task, Plan, described problem, or `next` without GitHub intake or a Python prompt generator. The legacy runtime remains isolated for physical deletion in the next PR.

--- a/scripts/ai-factory/test_validate.py
+++ b/scripts/ai-factory/test_validate.py
@@ -10,11 +10,13 @@ from pathlib import Path
 
 from validate import (
     ID_PATTERNS,
+    HARNESS_HEADINGS,
     TEMPLATES,
     TRACEABILITY_CHAIN,
     artifact_references,
     has_markdown_heading,
     validate_plan,
+    validate_harness,
     validate_spec,
     validate_task,
     validate_task_graph,
@@ -121,6 +123,36 @@ class ValidatorTests(unittest.TestCase):
             content = path.read_text(encoding="utf-8")
             for heading in headings:
                 self.assertIn(heading, content)
+
+    def test_direct_harness_contract_is_enforced(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "docs" / "agents").mkdir(parents=True)
+            (root / ".cursor" / "rules").mkdir(parents=True)
+            harness = "# Direct Agent Harness\n\n" + "\n\n".join(
+                f"{heading}\n\nContent." for heading in HARNESS_HEADINGS
+            )
+            (root / "docs" / "agents" / "harness.md").write_text(harness, encoding="utf-8")
+            (root / "AGENTS.md").write_text("docs/agents/harness.md\n", encoding="utf-8")
+            (root / "docs" / "agents" / "README.md").write_text("harness.md\n", encoding="utf-8")
+            (root / "docs" / "agents" / "execution-protocol.md").write_text("Direct.\n", encoding="utf-8")
+            (root / "docs" / "agents" / "context-policy.md").write_text("Direct.\n", encoding="utf-8")
+            (root / ".cursor" / "rules" / "01-task-execution.mdc").write_text("Direct.\n", encoding="utf-8")
+            legacy_rule = root / ".cursor" / "rules" / "06-orchestrator.mdc"
+            legacy_rule.write_text("---\nalwaysApply: false\n---\n", encoding="utf-8")
+
+            errors: list[str] = []
+            validate_harness(errors, root)
+            self.assertEqual(errors, [])
+
+            (root / "docs" / "agents" / "execution-protocol.md").write_text(
+                "Run scripts/orchestrator/next.py.\n", encoding="utf-8"
+            )
+            legacy_rule.write_text("---\nalwaysApply: true\n---\n", encoding="utf-8")
+            errors = []
+            validate_harness(errors, root)
+            self.assertTrue(any("must not require the legacy orchestrator" in error for error in errors))
+            self.assertIn(".cursor/rules/06-orchestrator.mdc must be inactive by default", errors)
 
     def test_valid_ready_plan_matches_accepted_source_version(self) -> None:
         errors: list[str] = []

--- a/scripts/ai-factory/validate.py
+++ b/scripts/ai-factory/validate.py
@@ -62,6 +62,12 @@ SPEC_REF = re.compile(r"^SPEC-[A-Z0-9](?:[A-Z0-9._-]*[A-Z0-9])?$")
 PLAN_REF = re.compile(r"^PLAN-[A-Z0-9](?:[A-Z0-9._-]*[A-Z0-9])?$")
 GIT_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 TRACEABILITY_CHAIN = "SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY"
+HARNESS_HEADINGS = (
+    "## Purpose", "## Entry modes", "## Artifact resolution", "## Bootstrap",
+    "## Context budget", "## Execution loop", "## Role lenses", "## Parallelism",
+    "## Evidence and handoff", "## Portability", "## Legacy compatibility",
+    "## Stop conditions",
+)
 
 
 def has_markdown_heading(content: str, heading: str) -> bool:
@@ -94,6 +100,41 @@ def validate_templates(errors: list[str]) -> None:
         for heading in headings:
             if not has_markdown_heading(content, heading):
                 errors.append(f"{path.relative_to(ROOT)} missing required heading: {heading}")
+
+
+def validate_harness(errors: list[str], root: Path = ROOT) -> None:
+    harness = root / "docs" / "agents" / "harness.md"
+    if not harness.is_file():
+        errors.append("missing direct agent harness: docs/agents/harness.md")
+        return
+
+    content = harness.read_text(encoding="utf-8")
+    for heading in HARNESS_HEADINGS:
+        if not has_markdown_heading(content, heading):
+            errors.append(f"docs/agents/harness.md missing required heading: {heading}")
+
+    required_links = (
+        (root / "AGENTS.md", "docs/agents/harness.md"),
+        (root / "docs" / "agents" / "README.md", "harness.md"),
+    )
+    for path, reference in required_links:
+        if not path.is_file() or reference not in path.read_text(encoding="utf-8"):
+            errors.append(f"{path.relative_to(root)} must reference the direct agent harness")
+
+    legacy_command = "scripts/orchestrator/next.py"
+    active_paths = (
+        root / ".cursor" / "rules" / "01-task-execution.mdc",
+        root / "docs" / "agents" / "execution-protocol.md",
+        root / "docs" / "agents" / "context-policy.md",
+    )
+    for path in active_paths:
+        if path.is_file() and legacy_command in path.read_text(encoding="utf-8"):
+            errors.append(f"{path.relative_to(root)} must not require the legacy orchestrator")
+
+    legacy_rule = root / ".cursor" / "rules" / "06-orchestrator.mdc"
+    metadata = parse_frontmatter(legacy_rule.read_text(encoding="utf-8")) if legacy_rule.is_file() else None
+    if metadata is None or metadata.get("alwaysApply", "").lower() != "false":
+        errors.append(".cursor/rules/06-orchestrator.mdc must be inactive by default")
 
 
 def parse_frontmatter(content: str) -> dict[str, str] | None:
@@ -454,6 +495,7 @@ def artifact_references(content: str, prefix: str) -> list[str]:
 def main() -> int:
     errors: list[str] = []
     validate_templates(errors)
+    validate_harness(errors)
     validate_references(errors)
     if errors:
         print("AI Factory artifact validation: FAILED")
@@ -461,7 +503,7 @@ def main() -> int:
         return 1
 
     print("AI Factory artifact validation: PASS")
-    print("- canonical templates: valid\n- artifact IDs: valid\n- specification contracts: valid\n- plan contracts: valid\n- task contracts: valid\n- task graph: valid\n- internal references: valid")
+    print("- canonical templates: valid\n- direct agent harness: valid\n- artifact IDs: valid\n- specification contracts: valid\n- plan contracts: valid\n- task contracts: valid\n- task graph: valid\n- internal references: valid")
     return 0
 
 


### PR DESCRIPTION
## Summary

- adds a provider-neutral direct agent harness for Task, Plan, problem-shaping, and `next` entry modes
- defines progressive context loading, artifact authority, execution loop, role lenses, semantic parallelism, evidence, and stop conditions
- removes mandatory GitHub Issue and orchestrator invocation from active execution/context guidance
- demotes the Cursor orchestrator rule to inactive, explicitly requested legacy compatibility
- extends deterministic validation so active guidance cannot regress to requiring the legacy command

## Verification

- `python -m py_compile scripts/ai-factory/validate.py scripts/ai-factory/test_validate.py`
- `python scripts/ai-factory/validate.py`
- `python scripts/ai-factory/test_validate.py` — 18 tests passed
- `git diff --check`
- client and server TypeScript checks passed in the commit hook

## Scope

Documentation and deterministic AI Factory validation only. No product runtime, database, schema, migration, dependency, infrastructure, or deployment behavior changed.

## Follow-up

The next PR will physically remove the deprecated orchestrator, its shims, tests, workflow references, and legacy documentation.