### PR TITLE
fix(docs): repair k6 artifact contracts

### DIFF
--- a/docs/plans/PLAN-0006-k6-load-testing.md
+++ b/docs/plans/PLAN-0006-k6-load-testing.md
@@ -1,13 +1,13 @@
 ---
 id: PLAN-0006
 status: Ready
-version: 1
+version: 2
 source_spec: SPEC-0009
-source_spec_version: 1
-baseline_revision: 624f14a0ed3bbd8a2671e1fcace0f70866ab9106
+source_spec_version: 2
+baseline_revision: bb829f41e320be915d9633e637071011701e4dc1
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-07
+updated: 2026-09-08
 ---
 
 # [PLAN-0006] — k6 load testing and capacity evidence
@@ -18,10 +18,10 @@ updated: 2026-09-07
 
 ## Source
 
-- Specification: `SPEC-0009` v1
-- Issue: `#55`
+- Specification: `SPEC-0009` v2
+- External tracker: `#55` (optional)
 - Planning task: performance evidence before infrastructure expansion
-- Baseline: `624f14a0ed3bbd8a2671e1fcace0f70866ab9106`
+- Baseline: `bb829f41e320be915d9633e637071011701e4dc1`
 
 ## Current State
 
@@ -52,7 +52,7 @@ No schema change. The opt-in orders profile mutates disposable fixture rows thro
 1. Accept `SPEC-0009` and bind this Ready Plan to the exact baseline.
 2. Implement profiles, checks, thresholds, input gates and JSON summary.
 3. Document environment/resource capture and reporting.
-4. Validate static factory rules and k6 script inspection when the binary is available.
+4. Validate documentation contracts and inspect the k6 script when the binary is available.
 5. Deploy/provision an isolated production-like target and run all profiles three times.
 6. Update capacity evidence and evaluate whether an ADR 0018/0019 review is triggered.
 
@@ -71,7 +71,8 @@ The sequence is intentionally serial because architecture conclusions depend on 
 ## Verification Strategy
 
 ```bash
-python3 scripts/ai-factory/validate.py
+python scripts/docs/validate_contracts.py
+python tests/tooling/test_docs_contracts.py
 k6 inspect load-tests/k6/neon-arsenal.js
 k6 run load-tests/k6/neon-arsenal.js
 ```
@@ -103,18 +104,17 @@ Harness/docs are reviewed and inspect successfully; all five profiles run agains
 ## Traceability
 
 ```text
-GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+SPEC → PLAN → TASK(S) → PR → EVIDENCE
 ```
 
-- Issue: `#55`
-- Specification: `SPEC-0009` v1
-- Plan: `PLAN-0006` v1
-- Tasks: `TASK-0010`
+- External tracker: `#55` (optional)
+- Specification: `SPEC-0009` v2
+- Plan: `PLAN-0006` v2
+- Tasks: `TASK-0010` v2
 - PR: pending
-- Verification/Convergence: pending isolated runtime
-- Evaluation: pending
-- Memory: pending
+- Evidence: pending isolated runtime
 
 ## Change History
 
+- `v2` — Migrated validation commands, baseline and traceability to the direct-agent documentation contract — 2026-09-08
 - `v1` — Ready plan for SPEC-0009 — 2026-09-07

--- a/docs/specs/SPEC-0009-load-testing-and-capacity-evidence.md
+++ b/docs/specs/SPEC-0009-load-testing-and-capacity-evidence.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0009
 status: Accepted
-version: 1
+version: 2
 source_issue: "#55"
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
@@ -109,7 +109,8 @@ No runtime, API, schema, deploy or client behavior changes. This adds an operato
 
 - `k6 inspect load-tests/k6/neon-arsenal.js`
 - `k6 run` for each profile against an isolated production-like deployment.
-- `python3 scripts/ai-factory/validate.py`
+- `python scripts/docs/validate_contracts.py`
+- `python tests/tooling/test_docs_contracts.py`
 - Existing backend typecheck/unit/integration suite; diff review proves no runtime change.
 - Provider/API/PG charts and SQL snapshots over the same UTC window.
 
@@ -121,18 +122,17 @@ No runtime, API, schema, deploy or client behavior changes. This adds an operato
 ## Traceability
 
 ```text
-GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+SPEC → PLAN → TASK(S) → PR → EVIDENCE
 ```
 
-- Issue: `#55`
+- External tracker: `#55` (optional)
 - Spec: `SPEC-0009`
-- Plan: `PLAN-0006`
-- Tasks: `TASK-0010`
+- Plan: `PLAN-0006` v2
+- Tasks: `TASK-0010` v2
 - PR: pending
-- Verification/Convergence: pending runtime evidence
-- Evaluation: pending
-- Memory: pending
+- Evidence: pending runtime evidence
 
 ## Change History
 
+- `v2` — Migrated validation commands and traceability to the direct-agent documentation contract — 2026-09-08
 - `v1` — Accepted harness and evidence contract — 2026-09-07

--- a/docs/tasks/TASK-0010-k6-harness.md
+++ b/docs/tasks/TASK-0010-k6-harness.md
@@ -1,13 +1,13 @@
 ---
 id: TASK-0010
 status: Ready
-version: 1
+version: 2
 source_issue: "#55"
 source_spec: SPEC-0009
-source_spec_version: 1
+source_spec_version: 2
 source_plan: PLAN-0006
-source_plan_version: 1
-baseline_revision: 624f14a0ed3bbd8a2671e1fcace0f70866ab9106
+source_plan_version: 2
+baseline_revision: bb829f41e320be915d9633e637071011701e4dc1
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
 updated: 2026-09-08
@@ -21,9 +21,9 @@ updated: 2026-09-08
 
 ## Source
 
-- Specification: `SPEC-0009`
-- Plan: `PLAN-0006`
-- Issue: #55
+- Specification: `SPEC-0009` v2
+- Plan: `PLAN-0006` v2
+- External tracker: #55 (optional)
 
 ## Objective
 
@@ -52,7 +52,7 @@ Deliver safe k6 profiles plus correlated capacity evidence from an isolated prod
 
 ## Dependencies
 
-None for the harness. Isolated runtime environment is required for final evidence.
+None
 
 ## Risks
 
@@ -61,14 +61,15 @@ Accidental mutation of shared data; external PayPal side effects; mistaking clie
 ## Verification Command
 
 ```bash
-python3 scripts/ai-factory/validate.py
+python scripts/docs/validate_contracts.py
+python tests/tooling/test_docs_contracts.py
 k6 inspect load-tests/k6/neon-arsenal.js
 k6 run load-tests/k6/neon-arsenal.js
 ```
 
 ## Expected Evidence
 
-Factory validation exits 0; k6 inspection succeeds; each profile has a JSON summary and synchronized API/PostgreSQL evidence; post-run invariants remain valid.
+Documentation contract validation exits 0; k6 inspection succeeds; each profile has a JSON summary and synchronized API/PostgreSQL evidence; post-run invariants remain valid.
 
 ## Stop Conditions
 
@@ -76,8 +77,9 @@ Stop if the target is not disposable, writes could reach shared data, PayPal cap
 
 ## Traceability
 
-GitHub Issue → SPEC → PLAN → TASK(S) → PR → VERIFICATION/CONVERGENCE → EVALUATION → MEMORY
+SPEC → PLAN → TASK(S) → PR → EVIDENCE
 
 ## Change History
 
-- 2026-09-08 — Migrated to the task artifact contract.
+- 2026-09-08 — v2 — Migrated dependencies, validation commands, baseline and traceability to the direct-agent documentation contract.
+- 2026-09-08 — v1 — Migrated to the task artifact contract.


### PR DESCRIPTION
## Context

Roadmap PR 01 restores the documentation contract gate before product work resumes. The k6 Specification, Plan and Task still referenced the removed AI Factory validator and the former long traceability chain; TASK-0010 also declared dependencies in a format rejected by the canonical validator.

## Change

- migrate SPEC-0009, PLAN-0006 and TASK-0010 to version 2
- point verification to `scripts/docs/validate_contracts.py` and its test suite
- use the canonical `SPEC → PLAN → TASK(S) → PR → EVIDENCE` chain
- make GitHub issue #55 explicit optional tracker metadata
- declare TASK-0010 dependencies canonically as `None`
- rebind Plan and Task to the current main baseline

## Risk

Documentation-only. The k6 workflow/runtime is intentionally unchanged and remains a separate roadmap PR.

## Verification

- `python scripts/docs/validate_contracts.py`
- `python tests/tooling/test_docs_contracts.py` — 19 passed
- frontend typecheck — commit hook
- backend typecheck — commit hook
- `git diff --check`

## Remaining risk

The load-test workflow has not been repaired or executed by this PR. Runtime evidence remains pending under the dedicated k6 roadmap item.