### PR TITLE
feat(payments): reconcile unresolved refunds

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -49,11 +49,12 @@ Step-by-step incident walk: [`docs/operations/runbook.md`](./operations/runbook.
 | `payments.confirm` | Payment confirmation |
 | `payments.confirm.transaction` | Claim order, sell listings, write seller transactions |
 | `payments.reconcile` | PayPal GET reconciliation batch |
+| `refund.reconcile.sweep` / `refund.reconcile` | Bounded refund scan and one claimed refund decision |
 | `seller.ledger.reconcile` | Seller.balance vs PAID ledger SUM |
 | `outbox.dispatch` | Claim and publish transactional outbox rows |
 | `paypal.webhook.verify` | Webhook signature verification |
 | `paypal.webhook.handle` | Event claim, ignore, confirm or fail |
-| `paypal.orders_create` / `orders_get` / `orders_capture` / `oauth_token` | PayPal HTTP |
+| `paypal.orders_create` / `orders_get` / `orders_capture` / `captures_refund` / `refunds_get` / `oauth_token` | PayPal HTTP |
 | `db.prisma` | Prisma operation (`db.operation` + `db.collection` only) |
 
 `app.outcome` distinguishes expected business results from operational failures:
@@ -78,7 +79,7 @@ Database: `db.client.operation.duration`, `db.client.errors`
 Attributes: `db.system=postgresql`, `db.operation`, `db.collection`
 
 PayPal: `paypal.client.request.count`, `paypal.client.errors`, `paypal.client.timeouts`, `paypal.client.request.duration`  
-Attribute: `paypal.operation` (`orders_create`, `orders_get`, `orders_capture`, `oauth_token`)
+Attribute: `paypal.operation` (`orders_create`, `orders_get`, `orders_capture`, `captures_refund`, `refunds_get`, `oauth_token`)
 
 Business counters (no labels):
 
@@ -87,7 +88,14 @@ Business counters (no labels):
 - `payments.confirmed`, `payments.failed`
 - `paypal.webhooks.received`, `paypal.webhooks.duplicate`, `paypal.webhooks.ignored`, `paypal.webhooks.failed`
 - `seller.ledger.drift_detected`, `seller.ledger.corrected`
+- `refund.reconciliation.scanned`, `refund.reconciliation.attempted`, `refund.reconciliation.converged`
+- `refund.reconciliation.still_pending`, `refund.reconciliation.retryable_failure`, `refund.reconciliation.terminal_failure`, `refund.reconciliation.operator_required`
 - `outbox.published`, `outbox.retry`, `outbox.failed`
+
+Refund reconciliation counters have no labels. Refund, order, capture, and refund IDs appear only in the
+safe per-item trace/log context; they are intentionally excluded from metric dimensions. The sweep span
+records bounded aggregate counts. `operator_required` means either a trusted terminal provider failure or
+an unresolved refund older than 24 hours; it does not mutate the refund into a guessed terminal outcome.
 
 There is no `orders.pending` gauge. That would scrape PostgreSQL on a timer; query `Order` where `paymentStatus = PENDING` when you need the count.
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -10,7 +10,7 @@ API service: `neon-arsenal-api` (Docker, `server/Dockerfile`, context `server/`)
 2. `server/entrypoint.sh` runs `prisma migrate deploy`.
 3. If `SEED_DEMO_DATA=true`, the entrypoint also runs `npm run db:seed`.
 4. `node dist/index.js` starts. It binds **`0.0.0.0:$PORT`** (`PORT` is `3001` in the Blueprint). If `SEED_DEMO_DATA=true`, `index.ts` seeds again. Both passes upsert; they do not overwrite existing rows. If `CS2SH_IMPORT=true` and `CS2SH_API_KEY` is set, `index.ts` schedules the cs2.sh catalog import **after** `app.listen` so Render `GET /ready` is not blocked. Missing key logs and skips; a failed import does not prevent listen.
-5. In-process jobs start after listen: reservation expiry (30s), PayPal GET reconciliation (60s), and seller ledger reconciliation (60s).
+5. In-process jobs start after listen: reservation expiry (30s), PayPal order/refund reconciliation (60s), and seller ledger reconciliation (60s).
 
 The Blueprint also defines static `neon-arsenal-web`. The public demo often uses Vercel for the Vite client and Render only for the API; set `FRONTEND_URL` on the API and `API_URL` on the frontend. Do not invent env vars.
 
@@ -85,6 +85,8 @@ These are investigation triggers for a human. This repository does not add a pag
 | `paypal.client.timeouts` | Any point in 15 minutes | 504 path. Do not retry `OrdersCreate` / `OrdersCapture`. |
 | `paypal.client.errors` ratio | &gt; 5% of `paypal.client.request.count` | SLO-ERR-PAYPAL. Check `PAYPAL_CLIENT_AUTH_FAILED` in logs. |
 | `seller.ledger.drift_detected` | Any increment | Ledger span + `SellerTransaction` SUM. Correction should follow (`seller.ledger.corrected`). |
+| `refund.reconciliation.terminal_failure` | Any increment | Compare the local refund row with the PayPal refund by `providerRefundId`; do not issue another refund. |
+| `refund.reconciliation.operator_required` | Any increment | A trusted terminal failure or unresolved state older than 24h needs human investigation. |
 | `outbox.failed` | Any increment | `outbox.dispatch` retries exhausted. Rows stay in PostgreSQL. |
 | `db.client.errors` | Any increment | Prisma exceptions. No SQL text in spans — use Render logs. |
 | `paypal.webhooks.failed` | Rising while `app.outcome` is not `reservation_expired` | Verify `PAYPAL_WEBHOOK_ID`, signature, `order_not_resolved` (503). |
@@ -169,68 +171,86 @@ LIMIT 50;
 
 Logs (no secrets): `paypal webhook received`, `paypal capture webhook processed`, `paypal webhook duplicate ignored`, `paypal webhook not applied: reservation expired`, `paypal reconciliation skipped: reservation expired`, `seller ledger projection drifted; corrected to PAID SUM`, `graceful shutdown started`.
 
-Capture after the reservation TTL is a split-brain with PayPal. Procedure: **Capture after reservation expiry** below.
+Capture after the reservation TTL creates a durable full technical-refund obligation. Procedure: **Refund reconciliation** below.
 
 ---
 
-## Capture after reservation expiry
+## Refund reconciliation
 
-PayPal can capture funds after the local reservation TTL has elapsed. The marketplace **must not** mark the listing `SOLD` or pay the seller. That invariant is already implemented (`confirmPayment` 409 + webhook HTTP 200). Returning the money is **not** implemented in this repository.
+PayPal can capture funds after the local reservation has become unfulfillable. The application preserves
+listing ownership, creates one durable full-BRL `Refund`, and uses PayPal's refund identity as trusted
+evidence. PayPal HTTP is outside PostgreSQL transactions; local `Refund`, `Order.paymentStatus`, append-only
+seller compensation, and `Seller.balance` changes commit atomically after provider completion is observed.
 
-### Code inspection (do not invent an API)
+### State meanings and selection
 
-Inspected:
+- `PENDING`: obligation exists; no trusted provider refund result is durable yet. Eligible after 2 minutes.
+- `PROCESSING`: an attempt is ambiguous, provider work is pending, or local completion remains. Eligible after 5 minutes.
+- `FAILED`: PayPal returned trusted `FAILED`/`CANCELLED`. It remains visible and is read again after 30 minutes so a later trusted `COMPLETED` observation can win; never replay POST when `providerRefundId` is known.
+- `COMPLETED`: trusted PayPal completion and all local financial effects committed. Later sweeps and stale observations are no-ops.
 
-- `server/src/shared/utils/paypal.ts` — `createPayPalOrder`, `capturePayPalOrder`, `getPayPalOrder`. No refund/void function.
-- `server/src/types/paypal.d.ts` — only OrdersCreate and OrdersCapture types.
-- `server/src/modules/payments/payments.service.ts` — expired capture → webhook event `FAILED` / `reservation_expired`; reconciliation skips the same 409.
-- No `PAYPAL_*` refund environment variable exists.
+The existing 60-second PayPal sweep selects at most 20 rows ordered by oldest `updatedAt`. A conditional
+`status + updatedAt` claim prevents duplicate work by overlapping API replicas. With a known
+`providerRefundId`, reconciliation calls Payments v2 RefundsGet. Without one (for example, a prior POST
+timed out), it safely replays CapturesRefund with the same deterministic `PayPal-Request-Id`. HTTP timeout,
+429, 5xx, and `409`/`PREVIOUS_REQUEST_IN_PROGRESS` remain retryable ambiguity; they never prove economic
+failure or completion. There is no tight retry loop and no new queue or worker service.
 
-Do not add a PayPal refund client, capture-void helper, or new env var until a human selects a provider contract.
-
-### How to detect
-
-1. Logs: `paypal webhook not applied: reservation expired` or `paypal reconciliation skipped: reservation expired`.
-2. Database:
+### Identify unresolved refunds (read-only)
 
 ```sql
-SELECT e."externalEventId", e.status, e."failureReason", e."orderId",
-       o."paypalOrderId", o.status AS order_status, o."paymentStatus",
-       i."listingId"
-FROM "PaymentWebhookEvent" e
-JOIN "Order" o ON o.id = e."orderId"
-JOIN "OrderItem" i ON i."orderId" = o.id
-WHERE e."failureReason" = 'reservation_expired'
-ORDER BY e."receivedAt" DESC;
+SELECT r.id, r."orderId", r.status, r."providerCaptureId", r."providerRefundId",
+       r."failureReason", r."createdAt", r."updatedAt", o."paymentStatus"
+FROM "Refund" r
+JOIN "Order" o ON o.id = r."orderId"
+WHERE r.status <> 'COMPLETED'
+ORDER BY r."updatedAt" ASC
+LIMIT 100;
 ```
 
-3. Confirm the listing is **not** `SOLD` and there is **no** `SellerTransaction` for that `orderId`.
-4. In the PayPal account (sandbox or live, matching `PAYPAL_MODE`), open the captured payment for `Order.paypalOrderId`. If PayPal shows captured funds, local and remote ledgers disagree.
+Use logs `refund reconciliation remains unresolved`, `refund reconciliation retry deferred`, and
+`refund reconciliation requires operator investigation`. Correlate by safe `refundId`/`orderId`; never
+paste OAuth tokens, credentials, customer data, or complete PayPal payloads into logs or tickets.
 
-### What to do (manual, out of band)
+### Safe investigation and recovery
 
-Until the HUMAN decision below is answered:
+1. Read the local row above. If `providerRefundId` exists, inspect that exact refund in the PayPal account
+   matching `PAYPAL_MODE`; distinguish its current `PENDING`, `COMPLETED`, or terminal `FAILED`/`CANCELLED`
+   state from an HTTP timeout or service error.
+2. If the provider is `PENDING` or unavailable, leave the row unresolved. The persisted-time policy will
+   retry RefundsGet. Do not treat a previous HTTP 2xx/timeout or an operator's recollection as completion.
+3. For remote `COMPLETED` + local `PROCESSING`/`FAILED`, leave the durable IDs intact and restore ordinary
+   sweep execution. RefundsGet will re-observe completion and call the idempotent local transaction. If the
+   first local commit crashed, the same path safely retries it.
+4. If no `providerRefundId` exists, verify the capture identity and deterministic local refund row. Allow
+   the sweep to replay the existing request ID. Do not create a new refund row or request ID.
+5. Human intervention is required immediately for trusted terminal provider failure, and for any unresolved
+   refund older than 24 hours (`refund.reconciliation.operator_required`). Investigate PayPal/account health
+   and application/database errors; preserve the row for audit and engineering follow-up.
 
-1. Do **not** set `Listing.status = SOLD`.
-2. Do **not** set `Order.paymentStatus = PAID` or create a `SellerTransaction`.
-3. Do **not** call undocumented PayPal URLs from this app.
-4. If funds were captured, reverse them in the **PayPal account UI** for that capture / order id (the same dashboard used to inspect sandbox or live payments). This runbook does not specify a REST path or request body; that would be inventing a contract this repo does not implement.
-5. After a dashboard reversal, local rows stay `PENDING` / `CANCELLED` and `FAILED`. There is no local `REFUNDED` write path. Leave them; the listing is already eligible for another buyer once `ACTIVE`.
-6. If the listing is still `RESERVED` with `reservationExpiresAt` in the past, the in-process expiry sweep (30s) will release it. Do not force `SOLD`.
+After completion, `Order.paymentStatus = REFUNDED`. If the seller was credited, there is exactly one
+`PAYMENT_CREDIT` and one `REFUND_COMPENSATION` per seller/order; compensation amounts are exact signed
+inverses and the PAID `netAmount` sum equals `Seller.balance`. If no credit existed, no negative movement
+exists. Diagnose with read-only SQL:
 
-### What not to do
+```sql
+SELECT r.id AS refund_id, r.status, o."paymentStatus", st."sellerId", st."entryType",
+       st."grossAmount", st."commissionAmount", st."netAmount", s.balance
+FROM "Refund" r
+JOIN "Order" o ON o.id = r."orderId"
+LEFT JOIN "SellerTransaction" st ON st."orderId" = o.id
+LEFT JOIN "Seller" s ON s.id = st."sellerId"
+WHERE r.id = '<refund-id>'
+ORDER BY st."createdAt";
+```
 
-- Replay the webhook hoping it will sell the listing. It will 409 again and stay `FAILED`.
-- Rely on GET reconciliation to fix money. It will skip the 409 forever.
-- Implement `OrdersCapture` retries or a new refund helper as part of incident response.
+### Operators must not
 
-### HUMAN decision (required before any refund code)
+- mark `Refund`/`Order` complete with SQL or insert/update ledger rows manually;
+- send another refund with a different `PayPal-Request-Id` or create a second refund obligation;
+- replay CapturesRefund when `providerRefundId` is already known; use RefundsGet evidence;
+- set a stale order/listing to `PAID`, `CONFIRMED`, or `SOLD`, or reclaim another buyer's reservation;
+- delete/rewrite a `PAYMENT_CREDIT` to hide compensation history;
+- classify timeout, throttling, 5xx, or request-in-progress as terminal economic failure.
 
-1. **Decision:** Should capture-after-expiry stay dashboard-only, or should the API reverse funds automatically?
-2. **Options:**
-   - A. Dashboard only (current). Operators follow this runbook. No new PayPal contract in the repo.
-   - B. Automated reverse, but only after documenting the **existing** PayPal API the account actually supports (refund vs void vs other), with timeout/idempotency, in a new activity — not guessed here.
-3. **Consequences:** A leaves rare captured-but-unsold money as a manual process. B without an inspected contract risks calling the wrong PayPal operation (voiding an already-captured order, double-refund, or marking `SOLD` incorrectly).
-4. **Recommendation:** Keep **A** until someone inspects the live/sandbox PayPal account and names the exact API. R2 must not guess.
-
-See also `docs/architecture/failure-modes.md` and `docs/adr/0002-paypal-webhook-reliability.md`.
+See also `docs/architecture/failure-modes.md`, `docs/adr/0002-paypal-webhook-reliability.md`, and ADR 0023.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -115,6 +115,7 @@ Integration tests are not skipped when PostgreSQL is down. A missing or unreacha
 | `observability.integration.test.ts` | Order/reservation/payment/webhook spans and counters against real PostgreSQL. No secrets or high-cardinality labels. |
 | `seller.ledger.integration.test.ts` | Sequential/concurrent confirm; Decimal net identity; projection matches PAID SUM. |
 | `seller.ledger.reconcile.integration.test.ts` | Matching projection is a no-op; drifted projection is SET once + audited; concurrent confirmPayment cannot double-credit. |
+| `refund.reconciliation.integration.test.ts` | Persisted-time selection, RefundsGet vs stable-key replay, remote/local crash recovery, pending/transient/terminal outcomes, concurrent workers, exact compensation, ledger sweep idempotency, and batch bounds. |
 | `listings.cursor.integration.test.ts` | Keyset first/next/last page; concurrent insert does not duplicate/skip under cursor; offset `page`/`limit`/`total` still works; invalid cursor HTTP 400. |
 | `auth.security.integration.test.ts` | Refresh family rotation/reuse revocation; concurrent refresh; login throttle 429; password policy. |
 | `api.security.integration.test.ts` | HTTP IDOR (customer/seller), ADMIN escalation, seller listing ownership, status/payment tampering, invalid/replayed webhook, expired-reservation purchase, client price manipulation (#72). |

--- a/docs/verification/refund-reconciliation-operations.md
+++ b/docs/verification/refund-reconciliation-operations.md
@@ -1,0 +1,38 @@
+# TASK-0015 refund reconciliation and operations evidence
+
+## Authority and scope
+
+- `SPEC-0013` v1, `PLAN-0012` v1, `TASK-0015` v1, ADR 0023.
+- Baseline: post-PR #226 `main` at `454ad13` (TASK baseline ancestor `2ec7897`).
+- Scope remains the modular-monolith API, PostgreSQL, the existing in-process PayPal sweep, and full
+  technical refunds only. No migration, public API, queue, cache, new service, partial refund, or customer
+  refund workflow is introduced.
+
+## Implemented evidence
+
+- Bounded selection uses `Refund.status + updatedAt`: PENDING 2m, PROCESSING 5m, FAILED 30m; oldest 20.
+- A conditional `id + status + updatedAt` update is the lightweight replica-safe claim.
+- Known `providerRefundId` uses Payments v2 RefundsGet. Unknown prior POST outcome replays CapturesRefund
+  with `buildPayPalRefundRequestId(refund.id)`, preserving one provider economic identity.
+- COMPLETED reuses the existing atomic local completion and append-only compensation transaction.
+- PENDING stays PROCESSING; timeout/429/5xx/request-in-progress stays retryable; trusted FAILED/CANCELLED
+  becomes FAILED. No retry limit guesses provider outcome. Terminal outcomes and ambiguity older than 24h
+  emit operator-required evidence.
+- Per-item logs/traces carry safe local/provider IDs, transition, and reason. Seven no-label counters cover
+  scanned, attempted, converged, pending, retryable, terminal, and operator-required outcomes.
+
+## Acceptance mapping
+
+- AC-03/07/08: `refund.reconciliation.integration.test.ts` proves remote/local recovery, crash replay,
+  unknown-outcome stable-key replay, transient/pending/terminal classification, and no downgrade.
+- AC-06: the same suite proves exact one-time compensation and repeated refund/ledger sweep idempotency.
+- AC-09: metrics tests plus `docs/observability.md` and the refund runbook section document safe evidence,
+  investigation, escalation, and forbidden operator actions.
+- AC-10: exact local and remote CI results are recorded in the PR description; no unexecuted check is
+  represented as passing here.
+
+## Evaluation
+
+Target rubric: specification fidelity 2, correctness/failure behavior 2, security/governance 2,
+architecture/scope 2, verification/operations 2. Final score is assigned only after the exact verification
+commands and diff review complete.

--- a/server/src/__tests__/paypal.refund.unit.test.ts
+++ b/server/src/__tests__/paypal.refund.unit.test.ts
@@ -6,6 +6,7 @@ import {
   refundPayPalCapture,
   resetPayPalTokenCacheForTests,
 } from "../shared/utils/paypal.js";
+import { getPayPalRefund } from "../modules/payments/paypal-refunds.client.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -113,5 +114,43 @@ describe("PayPal full capture refunds", () => {
       message: "PayPal CapturesRefund timed out",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads current refund state by encoded provider refund id without an immediate retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "token", expires_in: 300 }))
+      .mockResolvedValueOnce(jsonResponse(200, { id: "REFUND/1", status: "PENDING" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getPayPalRefund("REFUND/1")).resolves.toEqual({
+      id: "REFUND/1",
+      status: "PENDING",
+    });
+
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(url).toBe("https://api-m.sandbox.paypal.com/v2/payments/refunds/REFUND%2F1");
+    expect(init.method).toBeUndefined();
+    expect(init.headers).toMatchObject({ Authorization: "Bearer token" });
+  });
+
+  it("keeps RefundsGet timeout and 5xx outcomes retryable for the persisted sweep", async () => {
+    const timeout = new Error("The operation was aborted");
+    timeout.name = "TimeoutError";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "token", expires_in: 300 }))
+      .mockRejectedValueOnce(timeout);
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(getPayPalRefund("REFUND-TIMEOUT")).rejects.toMatchObject({ statusCode: 504 });
+
+    resetPayPalTokenCacheForTests();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "token-2", expires_in: 300 }))
+      .mockResolvedValueOnce(jsonResponse(503, { name: "INTERNAL_SERVER_ERROR" }));
+    await expect(getPayPalRefund("REFUND-503")).rejects.toMatchObject({
+      statusCode: 502,
+      message: "PayPal RefundsGet failed: 503",
+    });
   });
 });

--- a/server/src/__tests__/refund.reconciliation.integration.test.ts
+++ b/server/src/__tests__/refund.reconciliation.integration.test.ts
@@ -1,0 +1,310 @@
+import { Prisma, type RefundStatus } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const provider = vi.hoisted(() => ({
+  postCalls: [] as Array<{ captureId: string; requestId: string }>,
+  getCalls: [] as string[],
+  refundsByRequest: new Map<string, string>(),
+  statuses: new Map<string, "CANCELLED" | "FAILED" | "PENDING" | "COMPLETED">(),
+  postFailures: [] as Error[],
+  getFailures: [] as Error[],
+}));
+
+vi.mock("../shared/utils/paypal.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/utils/paypal.js")>();
+  return {
+    ...actual,
+    refundPayPalCapture: vi.fn(async (captureId: string, requestId: string) => {
+      provider.postCalls.push({ captureId, requestId });
+      const failure = provider.postFailures.shift();
+      if (failure) throw failure;
+      let providerRefundId = provider.refundsByRequest.get(requestId);
+      if (!providerRefundId) {
+        providerRefundId = `PROVIDER-${provider.refundsByRequest.size + 1}`;
+        provider.refundsByRequest.set(requestId, providerRefundId);
+        provider.statuses.set(providerRefundId, "COMPLETED");
+      }
+      return { id: providerRefundId, status: provider.statuses.get(providerRefundId) ?? "PENDING" };
+    }),
+  };
+});
+
+vi.mock("../modules/payments/paypal-refunds.client.js", () => ({
+  getPayPalRefund: vi.fn(async (providerRefundId: string) => {
+    provider.getCalls.push(providerRefundId);
+    const failure = provider.getFailures.shift();
+    if (failure) throw failure;
+    return { id: providerRefundId, status: provider.statuses.get(providerRefundId) ?? "PENDING" };
+  }),
+}));
+
+import { prisma } from "../shared/database/index.js";
+import { commissionsService } from "../modules/commissions/commissions.service.js";
+import { paymentsService } from "../modules/payments/payments.service.js";
+import {
+  buildPayPalRefundRequestId,
+  refundsService,
+} from "../modules/payments/refunds.service.js";
+import { createCheckoutGraph, createOrder, orderKey } from "./helpers/index.js";
+
+const NOW = new Date("2026-09-09T12:00:00.000Z");
+const OLD = new Date("2026-09-07T00:00:00.000Z");
+
+async function createRefund(options: {
+  label: string;
+  credited?: boolean;
+  status?: Exclude<RefundStatus, "COMPLETED">;
+  providerRefundId?: string;
+  createdAt?: Date;
+}) {
+  const fixture = await createCheckoutGraph();
+  const order = await createOrder(
+    fixture.customer.id,
+    [fixture.listings[0].id],
+    orderKey(options.label)
+  );
+  if (options.credited) await paymentsService.confirmPayment(order.id);
+  const refund = await refundsService.createObligation({
+    orderId: order.id,
+    providerCaptureId: `CAPTURE-${options.label}`,
+    amount: order.totalAmount,
+  });
+  return {
+    fixture,
+    order,
+    refund: await prisma.refund.update({
+      where: { id: refund.id },
+      data: {
+        status: options.status ?? "PROCESSING",
+        providerRefundId: options.providerRefundId,
+        createdAt: options.createdAt ?? OLD,
+        updatedAt: OLD,
+      },
+    }),
+  };
+}
+
+describe("TASK-0015 refund reconciliation (postgres)", () => {
+  beforeEach(() => {
+    provider.postCalls.length = 0;
+    provider.getCalls.length = 0;
+    provider.refundsByRequest.clear();
+    provider.statuses.clear();
+    provider.postFailures.length = 0;
+    provider.getFailures.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("converges remote COMPLETED plus local PROCESSING and repeats as a no-op", async () => {
+    const { refund, order } = await createRefund({
+      label: "remote-completed",
+      providerRefundId: "REFUND-REMOTE-COMPLETED",
+    });
+    provider.statuses.set("REFUND-REMOTE-COMPLETED", "COMPLETED");
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({
+      scanned: 1,
+      attempted: 1,
+      converged: 1,
+    });
+    expect((await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } })).status).toBe("COMPLETED");
+    expect((await prisma.order.findUniqueOrThrow({ where: { id: order.id } })).paymentStatus).toBe("REFUNDED");
+    expect(await refundsService.reconcileUnresolvedRefunds(new Date(NOW.getTime() + 3_600_000))).toMatchObject({
+      scanned: 0,
+      attempted: 0,
+      converged: 0,
+    });
+  });
+
+  it("recovers remote success after a local crash and applies ledger completion once", async () => {
+    const { refund, fixture, order } = await createRefund({
+      label: "local-crash",
+      credited: true,
+      status: "PENDING",
+    });
+    const completion = vi
+      .spyOn(refundsService, "recordProviderConfirmedCompletion")
+      .mockRejectedValueOnce(new Error("simulated local crash"));
+
+    await expect(refundsService.executeProviderRefund(refund.id)).rejects.toThrow("simulated local crash");
+    expect((await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } })).status).toBe("PROCESSING");
+    expect((await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } })).providerRefundId).toBeNull();
+    await prisma.refund.update({ where: { id: refund.id }, data: { updatedAt: OLD } });
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({ converged: 1 });
+
+    expect(completion).toHaveBeenCalledTimes(2);
+    expect(provider.postCalls.map((call) => call.requestId)).toEqual([
+      buildPayPalRefundRequestId(refund.id),
+      buildPayPalRefundRequestId(refund.id),
+    ]);
+    expect(await prisma.sellerTransaction.count({ where: { refundId: refund.id } })).toBe(1);
+    expect((await prisma.seller.findUniqueOrThrow({ where: { id: fixture.seller.id } })).balance.isZero()).toBe(true);
+    expect((await prisma.order.findUniqueOrThrow({ where: { id: order.id } })).paymentStatus).toBe("REFUNDED");
+  });
+
+  it("keeps provider PENDING unresolved without seller compensation", async () => {
+    const { refund, fixture } = await createRefund({
+      label: "pending",
+      credited: true,
+      providerRefundId: "REFUND-PENDING",
+    });
+    provider.statuses.set("REFUND-PENDING", "PENDING");
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({ stillPending: 1 });
+    expect((await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } })).status).toBe("PROCESSING");
+    expect(await prisma.sellerTransaction.count({ where: { refundId: refund.id } })).toBe(0);
+    expect((await prisma.seller.findUniqueOrThrow({ where: { id: fixture.seller.id } })).balance.equals(new Prisma.Decimal("90"))).toBe(true);
+  });
+
+  it.each([
+    Object.assign(new Error("PayPal RefundsGet timed out"), { statusCode: 504 }),
+    Object.assign(new Error("PayPal RefundsGet failed: 503"), { statusCode: 502 }),
+  ])("defers timeout and 5xx ambiguity without marking completion", async (failure) => {
+    const { refund } = await createRefund({
+      label: `transient-${failure.message}`,
+      providerRefundId: `REFUND-${failure.message}`,
+    });
+    provider.getFailures.push(failure);
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({ retryableFailures: 1, converged: 0 });
+    const unresolved = await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } });
+    expect(unresolved.status).toBe("PROCESSING");
+    expect(unresolved.completedAt).toBeNull();
+  });
+
+  it("records trusted provider terminal failure and operator evidence", async () => {
+    const { refund } = await createRefund({
+      label: "terminal",
+      providerRefundId: "REFUND-TERMINAL",
+    });
+    provider.statuses.set("REFUND-TERMINAL", "FAILED");
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({
+      terminalFailures: 1,
+      operatorRequired: 1,
+    });
+    const failed = await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } });
+    expect(failed.status).toBe("FAILED");
+    expect(failed.failureReason).toBe("paypal_refund_failed");
+  });
+
+  it("replays an unknown prior POST outcome with exactly the same PayPal-Request-Id", async () => {
+    const { refund } = await createRefund({ label: "unknown-post", status: "PENDING" });
+    const timeout = Object.assign(new Error("PayPal CapturesRefund timed out"), { statusCode: 504 });
+    provider.postFailures.push(timeout);
+    await expect(refundsService.executeProviderRefund(refund.id)).rejects.toBe(timeout);
+    const firstRequestId = provider.postCalls[0]!.requestId;
+    await prisma.refund.update({ where: { id: refund.id }, data: { updatedAt: OLD } });
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({ converged: 1 });
+    expect(provider.postCalls.map((call) => call.requestId)).toEqual([firstRequestId, firstRequestId]);
+    expect(firstRequestId).toBe(buildPayPalRefundRequestId(refund.id));
+    expect(new Set(provider.refundsByRequest.values()).size).toBe(1);
+  });
+
+  it("treats PREVIOUS_REQUEST_IN_PROGRESS-equivalent 409 as retryable ambiguity", async () => {
+    const { refund } = await createRefund({ label: "request-in-progress", status: "PENDING" });
+    provider.postFailures.push(
+      Object.assign(new Error("PayPal CapturesRefund failed: 409"), { statusCode: 502 })
+    );
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({
+      retryableFailures: 1,
+      terminalFailures: 0,
+      converged: 0,
+    });
+    const unresolved = await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } });
+    expect(unresolved.status).toBe("PROCESSING");
+    expect(unresolved.failureReason).toBe("paypal_request_in_progress");
+    expect(provider.postCalls[0]!.requestId).toBe(buildPayPalRefundRequestId(refund.id));
+
+    await prisma.refund.update({ where: { id: refund.id }, data: { updatedAt: OLD } });
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({ converged: 1 });
+    expect(new Set(provider.postCalls.map((call) => call.requestId))).toEqual(
+      new Set([buildPayPalRefundRequestId(refund.id)])
+    );
+  });
+
+  it("lets concurrent workers claim once and never double-debits a credited seller", async () => {
+    const { refund, fixture } = await createRefund({
+      label: "concurrent-workers",
+      credited: true,
+      status: "PENDING",
+    });
+
+    const results = await Promise.all([
+      refundsService.reconcileUnresolvedRefunds(NOW),
+      refundsService.reconcileUnresolvedRefunds(NOW),
+    ]);
+    expect(results.reduce((sum, result) => sum + result.attempted, 0)).toBe(1);
+    expect(new Set(provider.postCalls.map((call) => call.requestId))).toEqual(new Set([buildPayPalRefundRequestId(refund.id)]));
+    expect(await prisma.sellerTransaction.count({ where: { refundId: refund.id } })).toBe(1);
+    expect((await prisma.seller.findUniqueOrThrow({ where: { id: fixture.seller.id } })).balance.isZero()).toBe(true);
+  });
+
+  it("creates no negative movement when the original seller credit does not exist", async () => {
+    const { refund, fixture } = await createRefund({
+      label: "no-credit",
+      providerRefundId: "REFUND-NO-CREDIT",
+    });
+    provider.statuses.set("REFUND-NO-CREDIT", "COMPLETED");
+    await refundsService.reconcileUnresolvedRefunds(NOW);
+
+    expect(await prisma.sellerTransaction.count({ where: { refundId: refund.id } })).toBe(0);
+    expect((await prisma.seller.findUniqueOrThrow({ where: { id: fixture.seller.id } })).balance.isZero()).toBe(true);
+  });
+
+  it("cannot downgrade COMPLETED from an out-of-order PENDING observation", async () => {
+    const { refund } = await createRefund({
+      label: "out-of-order",
+      providerRefundId: "REFUND-OUT-OF-ORDER",
+    });
+    provider.statuses.set("REFUND-OUT-OF-ORDER", "COMPLETED");
+    await refundsService.reconcileUnresolvedRefunds(NOW);
+
+    await refundsService.recordProviderObservation({
+      refundId: refund.id,
+      providerRefundId: "REFUND-OUT-OF-ORDER",
+      status: "PENDING",
+    });
+    expect((await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } })).status).toBe("COMPLETED");
+  });
+
+  it("remains consistent across refund and seller-ledger reconciliation sweeps", async () => {
+    const { refund, fixture } = await createRefund({
+      label: "ledger-sweep",
+      credited: true,
+      providerRefundId: "REFUND-LEDGER-SWEEP",
+    });
+    provider.statuses.set("REFUND-LEDGER-SWEEP", "COMPLETED");
+    await refundsService.reconcileUnresolvedRefunds(NOW);
+
+    expect(await commissionsService.reconcileSellerLedger()).toMatchObject({ corrected: 0 });
+    expect(await commissionsService.reconcileSellerLedger()).toMatchObject({ corrected: 0 });
+    expect(await prisma.sellerTransaction.count({ where: { refundId: refund.id } })).toBe(1);
+    expect((await prisma.seller.findUniqueOrThrow({ where: { id: fixture.seller.id } })).balance.isZero()).toBe(true);
+  });
+
+  it("processes at most the configured batch and signals aged ambiguity", async () => {
+    const refunds = [];
+    for (let index = 0; index < 21; index += 1) {
+      refunds.push(await createRefund({
+        label: `batch-${index}`,
+        providerRefundId: `REFUND-BATCH-${index}`,
+        createdAt: OLD,
+      }));
+      provider.statuses.set(`REFUND-BATCH-${index}`, "PENDING");
+    }
+
+    expect(await refundsService.reconcileUnresolvedRefunds(NOW)).toMatchObject({
+      scanned: 20,
+      attempted: 20,
+      stillPending: 20,
+      operatorRequired: 20,
+    });
+    expect(await prisma.refund.count({ where: { id: { in: refunds.map(({ refund }) => refund.id) }, status: "PROCESSING" } })).toBe(21);
+  });
+});

--- a/server/src/modules/payments/__tests__/payments.service.test.ts
+++ b/server/src/modules/payments/__tests__/payments.service.test.ts
@@ -56,6 +56,15 @@ vi.mock("../refunds.service.js", () => ({
   refundsService: {
     createObligation: vi.fn(),
     executeProviderRefund: vi.fn(),
+    reconcileUnresolvedRefunds: vi.fn(async () => ({
+      scanned: 0,
+      attempted: 0,
+      converged: 0,
+      stillPending: 0,
+      retryableFailures: 0,
+      terminalFailures: 0,
+      operatorRequired: 0,
+    })),
   },
 }));
 

--- a/server/src/modules/payments/payments.service.ts
+++ b/server/src/modules/payments/payments.service.ts
@@ -439,6 +439,7 @@ export const paymentsService = {
     }
     span.setAttribute("app.reconcile_scanned", pending.length);
     span.setAttribute("app.reconcile_confirmed", confirmed);
+    await refundsService.reconcileUnresolvedRefunds();
     return { scanned: pending.length, confirmed };
     });
   },

--- a/server/src/modules/payments/paypal-refunds.client.ts
+++ b/server/src/modules/payments/paypal-refunds.client.ts
@@ -1,0 +1,38 @@
+import { AppError } from "../../shared/errors/AppError.js";
+import { getPayPalApiBaseUrl, getPayPalApiTimeoutMs } from "../../shared/config/paypal.js";
+import { withPaypalOperation } from "../../shared/observability/paypal.js";
+import { isTimeoutError } from "../../shared/resilience/retry.js";
+import {
+  getPayPalAccessToken,
+  mapPayPalHttpError,
+  parsePayPalRefundResource,
+  type ParsedPayPalRefund,
+} from "../../shared/utils/paypal.js";
+
+/**
+ * Minimum Payments v2 read used by reconciliation when a provider refund id is
+ * already durable. The GET is attempted once; persisted sweep backoff owns retry.
+ */
+export async function getPayPalRefund(providerRefundId: string): Promise<ParsedPayPalRefund> {
+  if (!providerRefundId.trim()) {
+    throw new AppError(400, "PayPal refund id is required");
+  }
+
+  return withPaypalOperation("refunds_get", async () => {
+    const token = await getPayPalAccessToken();
+    const url = `${getPayPalApiBaseUrl()}/v2/payments/refunds/${encodeURIComponent(providerRefundId)}`;
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(getPayPalApiTimeoutMs()),
+      });
+      if (!response.ok) {
+        throw new AppError(502, `PayPal RefundsGet failed: ${response.status}`);
+      }
+      return parsePayPalRefundResource(await response.json());
+    } catch (err) {
+      if (isTimeoutError(err)) throw new AppError(504, "PayPal RefundsGet timed out");
+      throw mapPayPalHttpError(err);
+    }
+  });
+}

--- a/server/src/modules/payments/refunds.service.ts
+++ b/server/src/modules/payments/refunds.service.ts
@@ -4,10 +4,21 @@ import { prisma } from "../../shared/database/index.js";
 import { AppError } from "../../shared/errors/AppError.js";
 import { MONEY_PRICE_SCALE } from "../../shared/money/policy.js";
 import { computeSellerLedgerCompensation } from "../../shared/money/sellerLedger.js";
+import { logger } from "../../shared/logger.js";
+import { appMetrics } from "../../shared/observability/metrics.js";
+import { withSpan } from "../../shared/observability/tracing.js";
+import {
+  PAYPAL_REFUND_FAILED_RETRY_MS,
+  PAYPAL_REFUND_OPERATOR_AGE_MS,
+  PAYPAL_REFUND_PENDING_RETRY_MS,
+  PAYPAL_REFUND_PROCESSING_RETRY_MS,
+  PAYPAL_REFUND_RECONCILE_BATCH_SIZE,
+} from "../../shared/config/paypal.js";
 import {
   refundPayPalCapture,
   type PayPalRefundStatus,
 } from "../../shared/utils/paypal.js";
+import { getPayPalRefund } from "./paypal-refunds.client.js";
 
 export type CreateRefundObligationInput = {
   orderId: string;
@@ -22,6 +33,16 @@ export type RecordProviderConfirmedRefundInput = {
 
 export type RecordProviderRefundObservationInput = RecordProviderConfirmedRefundInput & {
   status: Exclude<PayPalRefundStatus, "COMPLETED">;
+};
+
+export type RefundReconciliationResult = {
+  scanned: number;
+  attempted: number;
+  converged: number;
+  stillPending: number;
+  retryableFailures: number;
+  terminalFailures: number;
+  operatorRequired: number;
 };
 
 export const refundsService = {
@@ -181,7 +202,190 @@ export const refundsService = {
     });
     return { refund: observed, compensatedSellers: 0, requestId };
   },
+
+  /**
+   * Reconciles a bounded, persisted-time-selected batch. A conditional updatedAt
+   * claim keeps concurrent API replicas from issuing duplicate provider work in
+   * the same sweep; PayPal idempotency remains the cross-crash safety boundary.
+   */
+  async reconcileUnresolvedRefunds(now = new Date()): Promise<RefundReconciliationResult> {
+    return withSpan("refund.reconcile.sweep", {}, async (span) => {
+      const candidates = await prisma.refund.findMany({
+        where: {
+          OR: [
+            {
+              status: "PENDING",
+              updatedAt: { lte: new Date(now.getTime() - PAYPAL_REFUND_PENDING_RETRY_MS) },
+            },
+            {
+              status: "PROCESSING",
+              updatedAt: { lte: new Date(now.getTime() - PAYPAL_REFUND_PROCESSING_RETRY_MS) },
+            },
+            {
+              status: "FAILED",
+              updatedAt: { lte: new Date(now.getTime() - PAYPAL_REFUND_FAILED_RETRY_MS) },
+            },
+          ],
+        },
+        orderBy: { updatedAt: "asc" },
+        take: PAYPAL_REFUND_RECONCILE_BATCH_SIZE,
+      });
+
+      const result: RefundReconciliationResult = {
+        scanned: candidates.length,
+        attempted: 0,
+        converged: 0,
+        stillPending: 0,
+        retryableFailures: 0,
+        terminalFailures: 0,
+        operatorRequired: 0,
+      };
+      appMetrics.refundReconciliationScanned(candidates.length);
+
+      for (const candidate of candidates) {
+        const claimed = await prisma.refund.updateMany({
+          where: {
+            id: candidate.id,
+            status: candidate.status,
+            updatedAt: candidate.updatedAt,
+          },
+          data: { updatedAt: now },
+        });
+        if (claimed.count === 0) continue;
+
+        result.attempted += 1;
+        appMetrics.refundReconciliationAttempted();
+        const agedOut = now.getTime() - candidate.createdAt.getTime() >= PAYPAL_REFUND_OPERATOR_AGE_MS;
+
+        await withSpan(
+          "refund.reconcile",
+          {
+            attributes: {
+              "refund.id": candidate.id,
+              "order.id": candidate.orderId,
+              "paypal.capture_id": candidate.providerCaptureId,
+              "paypal.refund_id": candidate.providerRefundId ?? undefined,
+              "refund.status_before": candidate.status,
+            },
+          },
+          async (itemSpan) => {
+            try {
+              const reconciled = candidate.providerRefundId
+                ? await applyProviderObservation(
+                    candidate.id,
+                    await getPayPalRefund(candidate.providerRefundId)
+                  )
+                : await refundsService.executeProviderRefund(candidate.id);
+
+              itemSpan.setAttribute("refund.status_after", reconciled.refund.status);
+              if (reconciled.refund.status === "COMPLETED") {
+                result.converged += 1;
+                appMetrics.refundReconciliationConverged();
+                logger.info(refundLog(candidate, "COMPLETED", "provider_completed"), "refund reconciliation converged");
+                return;
+              }
+              if (reconciled.refund.status === "FAILED") {
+                result.terminalFailures += 1;
+                result.operatorRequired += 1;
+                appMetrics.refundReconciliationTerminalFailure();
+                appMetrics.refundReconciliationOperatorRequired();
+                logger.error(refundLog(candidate, "FAILED", reconciled.refund.failureReason ?? "provider_terminal_failure"), "refund reconciliation requires operator investigation");
+                return;
+              }
+
+              result.stillPending += 1;
+              appMetrics.refundReconciliationPending();
+              logger.info(refundLog(candidate, reconciled.refund.status, "provider_pending"), "refund reconciliation remains unresolved");
+              if (agedOut) {
+                result.operatorRequired += 1;
+                appMetrics.refundReconciliationOperatorRequired();
+                logger.error(refundLog(candidate, reconciled.refund.status, "unresolved_age_threshold"), "refund reconciliation requires operator investigation");
+              }
+            } catch (err) {
+              const reason = classifyRetryableRefundFailure(err);
+              await recordRetryableFailure(candidate.id, candidate.status, reason);
+              itemSpan.setAttribute("refund.status_after", candidate.status === "FAILED" ? "FAILED" : "PROCESSING");
+              itemSpan.setAttribute("refund.reconciliation_reason", reason);
+              result.retryableFailures += 1;
+              appMetrics.refundReconciliationRetryable();
+              logger.warn(refundLog(candidate, candidate.status === "FAILED" ? "FAILED" : "PROCESSING", reason), "refund reconciliation retry deferred");
+              if (agedOut) {
+                result.operatorRequired += 1;
+                appMetrics.refundReconciliationOperatorRequired();
+                logger.error(refundLog(candidate, candidate.status, "unresolved_age_threshold"), "refund reconciliation requires operator investigation");
+              }
+            }
+          }
+        );
+      }
+
+      span.setAttribute("app.refund_reconcile_scanned", result.scanned);
+      span.setAttribute("app.refund_reconcile_attempted", result.attempted);
+      span.setAttribute("app.refund_reconcile_converged", result.converged);
+      return result;
+    });
+  },
 };
+
+async function applyProviderObservation(refundId: string, provider: { id: string; status: PayPalRefundStatus }) {
+  if (provider.status === "COMPLETED") {
+    return refundsService.recordProviderConfirmedCompletion({
+      refundId,
+      providerRefundId: provider.id,
+    });
+  }
+  const refund = await refundsService.recordProviderObservation({
+    refundId,
+    providerRefundId: provider.id,
+    status: provider.status,
+  });
+  return { refund, compensatedSellers: 0 };
+}
+
+async function recordRetryableFailure(
+  refundId: string,
+  previousStatus: string,
+  reason: string
+) {
+  await prisma.refund.updateMany({
+    where: { id: refundId, status: { not: "COMPLETED" } },
+    data: {
+      status: previousStatus === "FAILED" ? "FAILED" : "PROCESSING",
+      failureReason: previousStatus === "FAILED" ? undefined : reason,
+    },
+  });
+}
+
+function classifyRetryableRefundFailure(err: unknown): string {
+  const message = err instanceof Error ? err.message : "unknown_error";
+  if (err instanceof AppError && err.statusCode === 504) return "paypal_timeout";
+  if (/PREVIOUS_REQUEST_IN_PROGRESS|failed: 409/i.test(message)) return "paypal_request_in_progress";
+  if (/failed: 429/i.test(message)) return "paypal_throttled";
+  if (/failed: 5\d\d/i.test(message)) return "paypal_provider_unavailable";
+  return "reconciliation_technical_failure";
+}
+
+function refundLog(
+  refund: {
+    id: string;
+    orderId: string;
+    providerCaptureId: string;
+    providerRefundId: string | null;
+    status: string;
+  },
+  statusAfter: string,
+  reason: string
+) {
+  return {
+    refundId: refund.id,
+    orderId: refund.orderId,
+    providerCaptureId: refund.providerCaptureId,
+    providerRefundId: refund.providerRefundId ?? undefined,
+    statusBefore: refund.status,
+    statusAfter,
+    reason,
+  };
+}
 
 /** Stable 36-character key derived only from the durable local refund identity. */
 export function buildPayPalRefundRequestId(refundId: string): string {

--- a/server/src/shared/config/paypal.ts
+++ b/server/src/shared/config/paypal.ts
@@ -9,6 +9,21 @@ export const PAYPAL_RECONCILE_MIN_AGE_MS = 2 * 60 * 1000;
 
 export const PAYPAL_RECONCILE_BATCH_SIZE = 20;
 
+/** Refund reconciliation shares the PayPal sweep without adding another timer. */
+export const PAYPAL_REFUND_RECONCILE_BATCH_SIZE = 20;
+
+/** New obligations wait briefly for the request path that created them to finish. */
+export const PAYPAL_REFUND_PENDING_RETRY_MS = 2 * 60 * 1000;
+
+/** Ambiguous attempts are retried only by a later sweep, never in a busy loop. */
+export const PAYPAL_REFUND_PROCESSING_RETRY_MS = 5 * 60 * 1000;
+
+/** Trusted FAILED observations are inspected less often for later provider convergence. */
+export const PAYPAL_REFUND_FAILED_RETRY_MS = 30 * 60 * 1000;
+
+/** Unresolved ambiguity older than this emits an operator-intervention signal. */
+export const PAYPAL_REFUND_OPERATOR_AGE_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Maximum |now − paypal-transmission-time| accepted during signature verification.
  * PayPal documents a 5-minute replay window for webhook timestamps.

--- a/server/src/shared/observability/__tests__/telemetry.test.ts
+++ b/server/src/shared/observability/__tests__/telemetry.test.ts
@@ -182,6 +182,13 @@ describe("OpenTelemetry runtime", () => {
     appMetrics.webhooksFailed();
     appMetrics.sellerLedgerDriftDetected();
     appMetrics.sellerLedgerCorrected();
+    appMetrics.refundReconciliationScanned();
+    appMetrics.refundReconciliationAttempted();
+    appMetrics.refundReconciliationConverged();
+    appMetrics.refundReconciliationPending();
+    appMetrics.refundReconciliationRetryable();
+    appMetrics.refundReconciliationTerminalFailure();
+    appMetrics.refundReconciliationOperatorRequired();
 
     const metrics = await collectMetrics();
     expect(sumMetric(metrics, "orders.created")).toBe(1);
@@ -191,6 +198,14 @@ describe("OpenTelemetry runtime", () => {
     expect(sumMetric(metrics, "paypal.webhooks.duplicate")).toBe(1);
     expect(sumMetric(metrics, "seller.ledger.drift_detected")).toBe(1);
     expect(sumMetric(metrics, "seller.ledger.corrected")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.scanned")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.attempted")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.converged")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.still_pending")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.retryable_failure")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.terminal_failure")).toBe(1);
+    expect(sumMetric(metrics, "refund.reconciliation.operator_required")).toBe(1);
+    expect(metricAttributeKeys(metrics, "refund.reconciliation.scanned")).toEqual(new Set());
     expect(telemetryContainsSensitive(await collectSpans(), metrics)).toBe(false);
   });
 

--- a/server/src/shared/observability/metrics.ts
+++ b/server/src/shared/observability/metrics.ts
@@ -28,6 +28,13 @@ type Instruments = {
   webhooksFailed: Counter;
   sellerLedgerDriftDetected: Counter;
   sellerLedgerCorrected: Counter;
+  refundReconciliationScanned: Counter;
+  refundReconciliationAttempted: Counter;
+  refundReconciliationConverged: Counter;
+  refundReconciliationPending: Counter;
+  refundReconciliationRetryable: Counter;
+  refundReconciliationTerminalFailure: Counter;
+  refundReconciliationOperatorRequired: Counter;
   outboxPublished: Counter;
   outboxRetry: Counter;
   outboxFailed: Counter;
@@ -110,6 +117,27 @@ function createInstruments(meter: Meter): Instruments {
     sellerLedgerCorrected: meter.createCounter("seller.ledger.corrected", {
       description: "Seller.balance set to PAID ledger SUM",
     }),
+    refundReconciliationScanned: meter.createCounter("refund.reconciliation.scanned", {
+      description: "Eligible unresolved refunds scanned",
+    }),
+    refundReconciliationAttempted: meter.createCounter("refund.reconciliation.attempted", {
+      description: "Refund reconciliation claims that performed provider work",
+    }),
+    refundReconciliationConverged: meter.createCounter("refund.reconciliation.converged", {
+      description: "Refunds converged to local COMPLETED",
+    }),
+    refundReconciliationPending: meter.createCounter("refund.reconciliation.still_pending", {
+      description: "Refunds still pending at PayPal",
+    }),
+    refundReconciliationRetryable: meter.createCounter("refund.reconciliation.retryable_failure", {
+      description: "Refund reconciliation transient or ambiguous failures",
+    }),
+    refundReconciliationTerminalFailure: meter.createCounter("refund.reconciliation.terminal_failure", {
+      description: "Trusted terminal PayPal refund failures",
+    }),
+    refundReconciliationOperatorRequired: meter.createCounter("refund.reconciliation.operator_required", {
+      description: "Refunds requiring operator investigation",
+    }),
     outboxPublished: meter.createCounter("outbox.published", {
       description: "Outbox events published",
     }),
@@ -191,6 +219,13 @@ export const appMetrics = {
   webhooksFailed: (value = 1) => add(getInstruments().webhooksFailed, undefined, value),
   sellerLedgerDriftDetected: (value = 1) => add(getInstruments().sellerLedgerDriftDetected, undefined, value),
   sellerLedgerCorrected: (value = 1) => add(getInstruments().sellerLedgerCorrected, undefined, value),
+  refundReconciliationScanned: (value = 1) => add(getInstruments().refundReconciliationScanned, undefined, value),
+  refundReconciliationAttempted: (value = 1) => add(getInstruments().refundReconciliationAttempted, undefined, value),
+  refundReconciliationConverged: (value = 1) => add(getInstruments().refundReconciliationConverged, undefined, value),
+  refundReconciliationPending: (value = 1) => add(getInstruments().refundReconciliationPending, undefined, value),
+  refundReconciliationRetryable: (value = 1) => add(getInstruments().refundReconciliationRetryable, undefined, value),
+  refundReconciliationTerminalFailure: (value = 1) => add(getInstruments().refundReconciliationTerminalFailure, undefined, value),
+  refundReconciliationOperatorRequired: (value = 1) => add(getInstruments().refundReconciliationOperatorRequired, undefined, value),
   outboxPublished: (value = 1) => add(getInstruments().outboxPublished, undefined, value),
   outboxRetry: (value = 1) => add(getInstruments().outboxRetry, undefined, value),
   outboxFailed: (value = 1) => add(getInstruments().outboxFailed, undefined, value),

--- a/server/src/shared/observability/paypal.ts
+++ b/server/src/shared/observability/paypal.ts
@@ -34,7 +34,7 @@ export async function withPaypalOperation<T>(
       } catch (err) {
         const timeout = err instanceof AppError && err.statusCode === 504;
         const statusMatch =
-          err instanceof Error ? err.message.match(/PayPal OrdersGet failed: (\d+)/) : null;
+          err instanceof Error ? err.message.match(/PayPal \w+ failed: (\d+)/) : null;
         const statusCode = statusMatch ? Number(statusMatch[1]) : undefined;
         appMetrics.recordPaypalRequest(
           operation,


### PR DESCRIPTION
## Summary

Implements TASK-0015 to make unresolved PayPal refund obligations converge safely through the existing in-process reconciliation runtime.

- selects bounded eligible PENDING / PROCESSING / FAILED refunds from PostgreSQL using persisted `updatedAt`
- conditionally claims each row so overlapping API replicas do not duplicate provider work in one sweep
- queries Payments v2 RefundsGet when `providerRefundId` is known
- safely replays CapturesRefund with the existing deterministic `PayPal-Request-Id` when a prior POST result is ambiguous and no provider identity is durable
- preserves provider PENDING and technical ambiguity as retryable; records trusted provider FAILED/CANCELLED explicitly
- reuses the existing atomic local completion and append-only seller compensation path
- adds low-cardinality metrics, safe logs/traces, operator escalation, runbook guidance, and durable verification evidence

No new infrastructure, refund semantics, schema, public API, partial refund, or generic provider abstraction is introduced.

## Selection and retry policy

- existing PayPal sweep interval: 60 seconds
- batch: oldest 20 eligible rows
- PENDING: eligible after 2 minutes
- PROCESSING: eligible after 5 minutes
- FAILED: provider read after 30 minutes
- operator signal: trusted terminal failure immediately, or unresolved age >= 24 hours
- timeout, 429, 5xx, and 409 / PREVIOUS_REQUEST_IN_PROGRESS-equivalent responses defer to a later persisted sweep; there is no busy retry loop and ambiguity is never promoted to economic completion/failure

## Concurrency and financial safety

A conditional `id + status + updatedAt` update is the lightweight replica claim. Cross-crash/provider duplication safety remains the durable Refund uniqueness plus the stable PayPal request ID. Known provider identities are read, not refunded again. Local completion is the existing single PostgreSQL transaction, and seller compensation uniqueness prevents double debit. Listing ownership is never changed by reconciliation.

## Observability and operations

Adds no-label counters for scanned, attempted, converged, still pending, retryable failure, terminal failure, and operator intervention. Per-item logs/traces include safe refund/order/provider IDs, status transition, and reason; no tokens, secrets, customer data, or provider payloads. The runbook documents read-only diagnosis, state meanings, remote-completed/local-incomplete recovery, ledger/balance expectations, escalation, and prohibited manual actions.

## Verification

Local passes:

- `npm run typecheck --prefix server`
- `npm run test:unit --prefix server -- --reporter=dot` — 421 passed
- `npm run test:contract --prefix server -- --reporter=dot` — 19 passed
- focused PayPal/refund/payment/telemetry unit suites — 51 passed
- `npm run build --prefix server`
- `python scripts/docs/validate_contracts.py`
- `python tests/tooling/test_docs_contracts.py` — 19 passed
- `git diff --check`

Remote CI #313 passed all jobs, including migrations and the complete integration suite against PostgreSQL 16, backend typecheck/unit/build, contract tests, documentation contracts, frontend checks, npm audit, and Trivy.

## Traceability

SPEC-0013 v1 -> PLAN-0012 v1 -> TASK-0015 v1 -> this PR -> `docs/verification/refund-reconciliation-operations.md`