### PR TITLE
feat(performance): enable controlled CI k6 evidence

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,142 +1,335 @@
-name: Ephemeral k6 load test
+name: Controlled CI k6 evidence
 
 on:
   workflow_dispatch:
     inputs:
       profile:
-        description: Read-only k6 profile to execute against an ephemeral API + PostgreSQL
+        description: Isolated k6 profile to execute against the controlled CI topology
         required: true
         type: choice
         default: smoke
-        options:
-          - smoke
-          - catalog
-          - webhook_rejection
+        options: [smoke, catalog, orders, payment_replay, webhook_rejection]
       target_rps:
-        description: Requests per second for catalog/webhook profiles
+        description: Offered RPS for catalog/webhook profiles (1-500)
         required: true
         type: string
-        default: "5"
-# The database is recreated per run; serialization keeps artifacts and runner
-# resources easy to correlate.
+        default: "20"
+      repetitions:
+        description: Execute once for a probe or exactly three times for claim evidence
+        required: true
+        type: choice
+        default: "1"
+        options: ["1", "3"]
+      order_listing_count:
+        description: Disposable unique listings for the orders profile (1-100)
+        required: true
+        type: string
+        default: "20"
+
+# Fresh DB per repetition. Serial execution reduces deliberate contention, but
+# GitHub-hosted hardware variability remains an explicit uncertainty.
 concurrency:
-  group: neon-arsenal-ephemeral-load-test
+  group: neon-arsenal-controlled-ci-load-test
   cancel-in-progress: false
 
 jobs:
   k6:
-    name: k6 (${{ inputs.profile }})
+    name: k6 (${{ inputs.profile }}, repetition ${{ matrix.repetition }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        repetition: ${{ fromJSON(inputs.repetitions == '3' && '[1,2,3]' || '[1]') }}
 
     env:
       BASE_URL: http://127.0.0.1:3001
-      DATABASE_URL: postgresql://neon:ci_password@localhost:5432/neon_arsenal_loadtest
-      PORT: "3001"
-      SEED_DEMO_DATA: "true"
-      JWT_SECRET: ephemeral-load-test-access-secret
-      JWT_REFRESH_SECRET: ephemeral-load-test-refresh-secret
       LOAD_PROFILE: ${{ inputs.profile }}
       LOAD_TARGET_RPS: ${{ inputs.target_rps }}
-
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: neon
-          POSTGRES_PASSWORD: ci_password
-          POSTGRES_DB: neon_arsenal_loadtest
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U neon -d neon_arsenal_loadtest"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+      ORDER_LISTING_COUNT: ${{ inputs.order_listing_count }}
+      PAYMENT_ORDER_COUNT: "5"
+      API_CPU_LIMIT: "1.0"
+      API_MEMORY_LIMIT: 512m
+      POSTGRES_CPU_LIMIT: "1.0"
+      POSTGRES_MEMORY_LIMIT: 1g
+      POSTGRES_MAX_CONNECTIONS: "100"
+      POSTGRES_SHARED_BUFFERS: 256MB
+      POSTGRES_IMAGE: postgres:16-alpine
+      API_IMAGE: neon-arsenal-loadtest:${{ github.sha }}
+      API_CONTAINER: neon-arsenal-api
+      POSTGRES_CONTAINER: neon-arsenal-postgres
+      LOAD_NETWORK: neon-arsenal-loadtest
 
     steps:
-      - name: Checkout
+      - name: Checkout exact revision
         uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-          cache: npm
-          cache-dependency-path: server/package-lock.json
-
-      - name: Install and build API
-        working-directory: server
-        run: |
-          npm ci
-          npx prisma generate
-          npm run test:db:prepare
-          npm run build
-
-      - name: Start ephemeral API
+      - name: Validate bounded inputs
         shell: bash
         run: |
           set -euo pipefail
+          [[ "$LOAD_TARGET_RPS" =~ ^[1-9][0-9]*$ ]] && (( LOAD_TARGET_RPS <= 500 ))
+          [[ "$ORDER_LISTING_COUNT" =~ ^[1-9][0-9]*$ ]] && (( ORDER_LISTING_COUNT <= 100 ))
           mkdir -p artifacts/k6
-          (cd server && NODE_ENV=production npm start > ../artifacts/k6/api.log 2>&1 & echo $! > ../artifacts/k6/api.pid)
+          run_id="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-r${{ matrix.repetition }}"
+          echo "RUN_ID=$run_id" >> "$GITHUB_ENV"
+          echo "ARTIFACT_DIR=artifacts/k6/$run_id" >> "$GITHUB_ENV"
+          mkdir -p "artifacts/k6/$run_id"
+
+      - name: Build production API image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build --pull --tag "$API_IMAGE" server
+          docker image inspect --format '{{.Id}}' "$API_IMAGE" > "$ARTIFACT_DIR/api-image-id.txt"
+
+      - name: Start isolated PostgreSQL 16
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker network create --internal "$LOAD_NETWORK"
+          docker pull "$POSTGRES_IMAGE"
+          docker run --detach \
+            --name "$POSTGRES_CONTAINER" \
+            --network "$LOAD_NETWORK" \
+            --network-alias postgres \
+            --cpus "$POSTGRES_CPU_LIMIT" \
+            --memory "$POSTGRES_MEMORY_LIMIT" \
+            --memory-swap "$POSTGRES_MEMORY_LIMIT" \
+            --health-cmd 'pg_isready -U neon -d neon_arsenal_loadtest' \
+            --health-interval 5s --health-timeout 5s --health-retries 20 \
+            --env POSTGRES_USER=neon \
+            --env POSTGRES_PASSWORD=ci_password \
+            --env POSTGRES_DB=neon_arsenal_loadtest \
+            "$POSTGRES_IMAGE" \
+            -c "max_connections=$POSTGRES_MAX_CONNECTIONS" \
+            -c "shared_buffers=$POSTGRES_SHARED_BUFFERS"
+          for attempt in {1..30}; do
+            [[ "$(docker inspect --format '{{.State.Health.Status}}' "$POSTGRES_CONTAINER")" == healthy ]] && exit 0
+            sleep 5
+          done
+          docker logs "$POSTGRES_CONTAINER"
+          exit 1
+
+      - name: Start production API container
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --detach \
+            --name "$API_CONTAINER" \
+            --network "$LOAD_NETWORK" \
+            --publish 127.0.0.1:3001:3001 \
+            --cpus "$API_CPU_LIMIT" \
+            --memory "$API_MEMORY_LIMIT" \
+            --memory-swap "$API_MEMORY_LIMIT" \
+            --restart no \
+            --env NODE_ENV=production \
+            --env PORT=3001 \
+            --env DATABASE_URL=postgresql://neon:ci_password@postgres:5432/neon_arsenal_loadtest \
+            --env SEED_DEMO_DATA=true \
+            --env JWT_SECRET=ephemeral-load-test-access-secret \
+            --env JWT_REFRESH_SECRET=ephemeral-load-test-refresh-secret \
+            --env PAYPAL_WEBHOOK_ID=controlled-ci-invalid-signature-only \
+            "$API_IMAGE"
 
       - name: Wait for API readiness
         shell: bash
         run: |
           set -euo pipefail
-          for attempt in {1..30}; do
-            if curl --fail --silent --show-error --max-time 10 "$BASE_URL/ready" > /dev/null; then
-              exit 0
-            fi
-            sleep 10
+          for attempt in {1..60}; do
+            curl --fail --silent --show-error --max-time 5 "$BASE_URL/ready" > /dev/null && exit 0
+            sleep 5
           done
-          echo "Timed out waiting for $BASE_URL/ready" >&2
-          cat artifacts/k6/api.log || true
+          docker logs "$API_CONTAINER" || true
           exit 1
+
+      - name: Generate disposable fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash load-tests/k6/ci/prepare-fixtures.sh \
+            "$POSTGRES_CONTAINER" "$RUN_ID" "$ORDER_LISTING_COUNT" "$PAYMENT_ORDER_COUNT" \
+            "$GITHUB_ENV" "$ARTIFACT_DIR"
+
+      - name: Configure selected profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$LOAD_PROFILE" in
+            smoke) printf '%s\n' 'LOAD_VUS=1' 'LOAD_DURATION=15s' >> "$GITHUB_ENV" ;;
+            catalog)
+              printf '%s\n' 'LOAD_START_RPS=5' 'LOAD_RAMP_DURATION=30s' 'LOAD_HOLD_DURATION=60s' \
+                'LOAD_COOLDOWN_DURATION=15s' 'LOAD_PREALLOCATED_VUS=20' 'LOAD_MAX_VUS=100' >> "$GITHUB_ENV"
+              ;;
+            orders) printf '%s\n' 'ALLOW_WRITES=true' 'LOAD_VUS=5' 'LOAD_MAX_DURATION=2m' >> "$GITHUB_ENV" ;;
+            payment_replay) printf '%s\n' 'LOAD_VUS=2' 'LOAD_DURATION=30s' >> "$GITHUB_ENV" ;;
+            webhook_rejection)
+              printf '%s\n' 'LOAD_DURATION=30s' 'LOAD_PREALLOCATED_VUS=5' 'LOAD_MAX_VUS=20' >> "$GITHUB_ENV"
+              ;;
+          esac
+
+      - name: Capture pre-run PostgreSQL snapshot
+        shell: bash
+        run: bash load-tests/k6/ci/capture-db-snapshot.sh "$POSTGRES_CONTAINER" pre "$ARTIFACT_DIR/postgres-pre.txt"
 
       - name: Setup k6
         uses: grafana/setup-k6-action@v1
 
-      - name: Run k6 profile
+      - name: Inspect k6 harness
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p artifacts/k6
-          export RUN_ID="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          export LOAD_SUMMARY_PATH="artifacts/k6/${LOAD_PROFILE}-${RUN_ID}.json"
+          k6 version | tee "$ARTIFACT_DIR/k6-version.txt"
+          k6 inspect load-tests/k6/neon-arsenal.js | tee "$ARTIFACT_DIR/k6-inspect.json"
+
+      - name: Start synchronized resource sampler
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f "$ARTIFACT_DIR/stop-sampling"
+          nohup bash load-tests/k6/ci/sample-resources.sh \
+            "$API_CONTAINER" "$POSTGRES_CONTAINER" \
+            "$ARTIFACT_DIR/stop-sampling" "$ARTIFACT_DIR/resource-samples.jsonl" \
+            > "$ARTIFACT_DIR/resource-sampler.log" 2>&1 &
+          echo $! > "$ARTIFACT_DIR/resource-sampler.pid"
+
+      - name: Run k6 profile
+        id: k6
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          date -u +%Y-%m-%dT%H:%M:%SZ | tee "$ARTIFACT_DIR/start-utc.txt"
+          export LOAD_SUMMARY_PATH="$ARTIFACT_DIR/k6-summary.json"
           k6 run load-tests/k6/neon-arsenal.js
+          date -u +%Y-%m-%dT%H:%M:%SZ | tee "$ARTIFACT_DIR/end-utc.txt"
+
+      - name: Stop synchronized resource sampler
+        if: always()
+        shell: bash
+        run: |
+          touch "$ARTIFACT_DIR/stop-sampling"
+          if [[ -f "$ARTIFACT_DIR/resource-sampler.pid" ]]; then
+            wait "$(cat "$ARTIFACT_DIR/resource-sampler.pid")" 2>/dev/null || true
+          fi
+          [[ -f "$ARTIFACT_DIR/end-utc.txt" ]] || date -u +%Y-%m-%dT%H:%M:%SZ > "$ARTIFACT_DIR/end-utc.txt"
+
+      - name: Validate post-run invariants
+        id: invariants
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          bash load-tests/k6/ci/validate-invariants.sh \
+            "$POSTGRES_CONTAINER" "$LOAD_PROFILE" "$RUN_ID" \
+            "$ORDER_LISTING_COUNT" "$PAYMENT_ORDER_COUNT" "$ARTIFACT_DIR/invariant-validation.json"
+
+      - name: Capture post-run evidence
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash load-tests/k6/ci/capture-db-snapshot.sh "$POSTGRES_CONTAINER" post "$ARTIFACT_DIR/postgres-post.txt"
+          docker stop --time 30 "$API_CONTAINER" > "$ARTIFACT_DIR/api-stop.txt"
+          docker logs --timestamps "$API_CONTAINER" > "$ARTIFACT_DIR/api.log" 2>&1 || true
+          grep -Eai '"level":[[:space:]]*(40|50|60)|error|fatal|uncaught|unhandled' \
+            "$ARTIFACT_DIR/api.log" > "$ARTIFACT_DIR/api-errors.log" || true
+          docker logs --timestamps "$POSTGRES_CONTAINER" > "$ARTIFACT_DIR/postgres.log" 2>&1 || true
+
+      - name: Record controlled environment metadata
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          api_image_id=$(docker image inspect --format '{{.Id}}' "$API_IMAGE")
+          postgres_image_id=$(docker image inspect --format '{{.Id}}' "$POSTGRES_IMAGE")
+          node_version=$(docker run --rm --entrypoint node "$API_IMAGE" --version)
+          postgres_version=$(docker exec "$POSTGRES_CONTAINER" psql -X -A -t -U neon -d neon_arsenal_loadtest -c 'SHOW server_version')
+          api_limits=$(docker inspect --format '{{json .HostConfig}}' "$API_CONTAINER" | jq '{NanoCpus, Memory, MemorySwap, RestartPolicy}')
+          postgres_limits=$(docker inspect --format '{{json .HostConfig}}' "$POSTGRES_CONTAINER" | jq '{NanoCpus, Memory, MemorySwap, RestartPolicy}')
+          api_state=$(docker inspect --format '{"state":{{json .State}},"restartCount":{{.RestartCount}}}' "$API_CONTAINER" | jq '{status: .state.Status, running: .state.Running, exitCode: .state.ExitCode, oomKilled: .state.OOMKilled, restarting: .state.Restarting, startedAt: .state.StartedAt, finishedAt: .state.FinishedAt, restartCount}')
+          dataset=$(docker exec "$POSTGRES_CONTAINER" psql -X -A -t -U neon -d neon_arsenal_loadtest -c "
+            SELECT json_build_object(
+              'products', (SELECT count(*) FROM \"Product\"),
+              'active_listings', (SELECT count(*) FROM \"Listing\" WHERE status = 'ACTIVE'),
+              'reserved_listings', (SELECT count(*) FROM \"Listing\" WHERE status = 'RESERVED'),
+              'sold_listings', (SELECT count(*) FROM \"Listing\" WHERE status = 'SOLD'),
+              'orders', (SELECT count(*) FROM \"Order\"),
+              'payment_links', (SELECT count(*) FROM \"PaymentLink\"),
+              'refunds', (SELECT count(*) FROM \"Refund\")
+            );")
+          jq -n \
+            --arg evidenceClass 'controlled CI capacity evidence' \
+            --arg commitSha "$GITHUB_SHA" \
+            --arg workflowRun "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --arg repetition '${{ matrix.repetition }}' \
+            --arg runId "$RUN_ID" --arg profile "$LOAD_PROFILE" --arg targetRps "$LOAD_TARGET_RPS" \
+            --arg orderListingCount "$ORDER_LISTING_COUNT" \
+            --arg startUtc "$(cat "$ARTIFACT_DIR/start-utc.txt" 2>/dev/null || echo unavailable)" \
+            --arg endUtc "$(cat "$ARTIFACT_DIR/end-utc.txt" 2>/dev/null || echo unavailable)" \
+            --arg apiImage "$API_IMAGE" --arg apiImageId "$api_image_id" --arg postgresImage "$POSTGRES_IMAGE" \
+            --arg postgresImageId "$postgres_image_id" --arg nodeVersion "$node_version" \
+            --arg postgresVersion "$postgres_version" --arg postgresMaxConnections "$POSTGRES_MAX_CONNECTIONS" \
+            --arg postgresSharedBuffers "$POSTGRES_SHARED_BUFFERS" \
+            --arg k6Version "$(cat "$ARTIFACT_DIR/k6-version.txt" 2>/dev/null || echo unavailable)" \
+            --argjson apiLimits "$api_limits" --argjson postgresLimits "$postgres_limits" \
+            --argjson apiState "$api_state" --argjson dataset "$dataset" \
+            '{
+              evidenceClass: $evidenceClass,
+              qualification: "Not Render or production capacity; GitHub-hosted runner hardware and co-located k6 introduce variability.",
+              commitSha: $commitSha, workflowRun: $workflowRun, repetition: ($repetition | tonumber), runId: $runId,
+              utc: {start: $startUtc, end: $endUtc},
+              workload: {profile: $profile, offeredRps: ($targetRps | tonumber), orderListingCount: ($orderListingCount | tonumber)},
+              api: {image: $apiImage, imageId: $apiImageId, nodeVersion: $nodeVersion, replicas: 1, limits: $apiLimits, finalState: $apiState},
+              postgres: {image: $postgresImage, imageId: $postgresImageId, version: $postgresVersion, maxConnections: ($postgresMaxConnections | tonumber), sharedBuffers: $postgresSharedBuffers, limits: $postgresLimits},
+              dataset: $dataset, k6Version: $k6Version,
+              externalNetwork: "API and PostgreSQL use an internal Docker network; provider egress is unavailable."
+            }' > "$ARTIFACT_DIR/environment.json"
 
       - name: Publish run summary
         if: always()
         shell: bash
         run: |
-          set -euo pipefail
-          summary_file=$(find artifacts/k6 -maxdepth 1 -name '*.json' -print -quit || true)
-          if [[ -z "$summary_file" ]]; then
-            echo "## k6" >> "$GITHUB_STEP_SUMMARY"
-            echo "No JSON summary was generated." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          echo "## k6 — ${LOAD_PROFILE}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Target: \`${BASE_URL}\`" >> "$GITHUB_STEP_SUMMARY"
-          jq -r '
-            .metrics as $m |
-            [
-              ["requests", ($m.http_reqs.values.count // "n/a")],
-              ["rps", ($m.http_reqs.values.rate // "n/a")],
-              ["p95 ms", ($m.http_req_duration.values["p(95)"] // "n/a")],
-              ["p99 ms", ($m.http_req_duration.values["p(99)"] // "n/a")],
-              ["http failure rate", ($m.http_req_failed.values.rate // "n/a")]
-            ] | .[] | "| " + .[0] + " | " + (.[1] | tostring) + " |"' "$summary_file" \
-            | { echo "| Metric | Value |"; echo "| --- | ---: |"; cat; } >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Controlled CI k6 evidence — ${LOAD_PROFILE} — repetition ${{ matrix.repetition }}"
+            echo
+            echo "This is not Render or production capacity. GitHub-hosted runner variability remains explicit."
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- API limits: \`${API_CPU_LIMIT} CPU / ${API_MEMORY_LIMIT}\`"
+            echo "- PostgreSQL limits: \`${POSTGRES_CPU_LIMIT} CPU / ${POSTGRES_MEMORY_LIMIT}\`"
+            echo "- Offered RPS input: \`${LOAD_TARGET_RPS}\` (arrival-rate profiles only)"
+            if [[ -f "$ARTIFACT_DIR/k6-summary.json" ]]; then
+              jq -r '.metrics as $m | [["Achieved RPS", ($m.http_reqs.values.rate // "n/a")], ["p50 ms", ($m.http_req_duration.values["p(50)"] // "n/a")], ["p95 ms", ($m.http_req_duration.values["p(95)"] // "n/a")], ["p99 ms", ($m.http_req_duration.values["p(99)"] // "n/a")], ["HTTP failure rate", ($m.http_req_failed.values.rate // "n/a")], ["Dropped iterations", ($m.dropped_iterations.values.count // 0)]] | .[] | "| " + .[0] + " | " + (.[1] | tostring) + " |"' "$ARTIFACT_DIR/k6-summary.json" \
+                | { echo; echo "| Metric | Measured value |"; echo "| --- | ---: |"; cat; }
+            else
+              echo "- No k6 JSON summary was generated."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload k6 evidence
+      - name: Upload complete evidence bundle
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: k6-${{ inputs.profile }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: artifacts/k6/
-          if-no-files-found: warn
+          name: controlled-ci-k6-${{ inputs.profile }}-r${{ matrix.repetition }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/k6/${{ github.run_id }}-${{ github.run_attempt }}-r${{ matrix.repetition }}/
+          if-no-files-found: error
           retention-days: 30
+
+      - name: Enforce k6 thresholds and invariant validation
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ '${{ steps.k6.outcome }}' == success ]] || { echo 'k6 execution or thresholds failed' >&2; exit 1; }
+          [[ '${{ steps.invariants.outcome }}' == success ]] || { echo 'Post-run invariant validation failed' >&2; exit 1; }
+
+      - name: Cleanup isolated containers
+        if: always()
+        shell: bash
+        run: |
+          docker rm --force "$API_CONTAINER" "$POSTGRES_CONTAINER" 2>/dev/null || true
+          docker network rm "$LOAD_NETWORK" 2>/dev/null || true

--- a/docs/operations/load-test-ci.md
+++ b/docs/operations/load-test-ci.md
@@ -1,22 +1,51 @@
-# Ephemeral load-test CI runbook
+# Controlled CI load-test runbook
 
-This is the executable path for issue #55 without a cloud account or credit card. GitHub Actions starts PostgreSQL 16, migrates and seeds the API, then runs k6 against `127.0.0.1` in the same disposable runner. Vercel and Render are deliberately not targets.
+This is the executable path for issue #55 without a cloud account, external credentials, or a credit card. It produces **controlled CI capacity evidence**. Vercel and Render are deliberately not targets, and results must not be described as Render or production capacity.
 
-## What is already automated
+## Controlled topology
 
-- `.github/workflows/load-test.yml` is manually dispatched, serialized, creates a fresh PostgreSQL database for every run, waits for `/ready`, runs k6 and retains JSON plus API logs for 30 days.
-- Only the safe `smoke`, `catalog` and `webhook_rejection` profiles are exposed. `orders` and `payment_replay` remain intentionally manual because they mutate data or require a pre-warmed PayPal Sandbox order.
-- No GitHub Environment, external URL, secret, Blueprint, Vercel configuration, Render configuration, or card is required.
+- The API is the production image built from `server/Dockerfile`, limited to 1 CPU and 512 MiB, with one replica and `NODE_ENV=production`.
+- PostgreSQL uses `postgres:16-alpine`, limited to 1 CPU and 1 GiB, with `max_connections=100` and `shared_buffers=256MB`.
+- Both containers use a per-job internal Docker network. The API is published only on runner loopback; the containers have no provider egress.
+- Every repetition starts a fresh PostgreSQL container, applies migrations, seeds the demo catalog, and creates equivalent disposable fixtures.
+- k6 runs on the GitHub host. Its CPU is not isolated from Docker, and the underlying runner model/noisy-neighbor load is not guaranteed. This is a material uncertainty in cross-workflow comparisons.
+
+No GitHub Environment, external URL, PayPal credential, Blueprint, Vercel configuration, Render configuration, or card is required.
+
+## Profile safety
+
+- `smoke` and `catalog` are read-only. `ALLOW_WRITES` is absent.
+- `orders` alone receives `ALLOW_WRITES=true` and a generated list of unique `ACTIVE` listing IDs. Post-run SQL requires one order/reservation/idempotency result per listing and rejects duplicate consumption or payment/ledger side effects.
+- `payment_replay` receives local pending orders whose `PaymentLink` rows are already `COMPLETED` and whose PayPal IDs are synthetic local fixture identities. This exercises the existing replay early return. No PayPal credential is present and the internal Docker network has no provider egress, so an accidental provider call fails the run.
+- `webhook_rejection` sends only invalid signatures. Post-run SQL requires zero matching webhook-event rows.
 
 ## Per-run procedure
 
 1. Merge the PR containing the workflow. GitHub exposes `workflow_dispatch` from the default branch.
-2. Go to **Actions → Ephemeral k6 load test → Run workflow**.
-3. Run `smoke` once, then `catalog` three times at the same conservative RPS (start with `5`). Run `webhook_rejection` separately.
-4. Download each artifact and complete `docs/performance/load-test-report-template.md`, including the workflow URL, commit SHA and configured RPS.
+2. Go to **Actions → Controlled CI k6 evidence → Run workflow**.
+3. Select one of all five profiles. Use one repetition while proving connectivity and selecting a stable catalog offered rate.
+4. For catalog, raise `target_rps` in separate one-run probes until a threshold, errors, dropped iterations, API/container limit, PostgreSQL signal, or runner/client limit identifies the knee. Offered RPS is configuration; achieved RPS is `http_reqs.rate` in the k6 summary.
+5. Once a stable point is selected, dispatch with exactly three repetitions. The matrix runs serially at the same commit and input configuration, with a fresh equivalent dataset per repetition. Before treating them as equivalent, confirm the recorded API/PostgreSQL image IDs, versions, limits and dataset cardinalities match; mutable upstream base-image tags can otherwise invalidate the set.
+6. Download all three artifacts and complete `docs/performance/load-test-report-template.md`. Report each run, median statistics, worst error rate, dropped iterations, variability, first bottleneck and residual uncertainty.
+
+Run all five profiles at least once before evaluating SPEC-0009 AC-07. Do not mark AC-07 complete in the enablement PR; only subsequent successful workflow artifacts can supply that evidence.
+
+## Evidence bundle
+
+Each repetition retains for 30 days:
+
+- raw k6 JSON summary and `k6 inspect` output;
+- exact commit, image IDs, Node/PostgreSQL/k6 versions, limits and workload metadata;
+- API/PostgreSQL logs and a filtered API-error view;
+- two-second API CPU, container memory, process RSS, restart/state and PostgreSQL activity samples;
+- PostgreSQL pre/post connections, waits, deadlocks and transaction counters;
+- dataset cardinalities and generated fixture IDs;
+- post-run invariant validation output.
+
+The workflow uploads evidence before enforcing the final k6-threshold and invariant gate, so failed experiments remain diagnosable.
 
 ## What these results mean
 
-They prove repeatable application + PostgreSQL behavior from a clean environment and can catch regressions in latency, errors, readiness and the webhook trust boundary. They are **not** a Render capacity claim: GitHub runner CPU/network, no provider metrics, and local loopback traffic are different from a public deployment.
+Successful three-run bundles can support an environment-qualified controlled CI capacity statement. They are **not** a Render or production capacity claim: GitHub runner CPU/network, host contention, and local loopback traffic differ from a public deployment. A material spread between equivalent repetitions means runner variability or another unknown is unresolved; report it and do not claim a stable point.
 
 Do not use these results to justify Redis, SQS/Kafka or AWS. Revisit those only after a concrete production constraint exists. If a real deployed capacity test becomes necessary later, provision a dedicated paid/free provider environment only after deciding its budget and observability requirements.

--- a/docs/performance/load-test-report-template.md
+++ b/docs/performance/load-test-report-template.md
@@ -1,5 +1,9 @@
 # Load-test report — YYYY-MM-DD — PROFILE
 
+Evidence class: controlled CI capacity evidence | isolated deployed evidence
+
+This report does not imply Render or production capacity unless the named environment actually is that platform and has its own correlated provider evidence.
+
 ## Identity
 
 - Git SHA:
@@ -14,6 +18,7 @@
 - PostgreSQL version / tier / connection limit:
 - Dataset: products / listings by status / orders / payment links:
 - External dependencies enabled:
+- Runner / host uncertainty:
 
 ## Workload
 
@@ -51,6 +56,16 @@
 - Lowest-complexity mitigation:
 - Does this trigger an ADR 0018/0019 review? Why?
 - Capacity statement that may be added to `docs/architecture/capacity.md`:
+
+## Equivalent repetitions
+
+- Equivalence basis: same commit / image / limits / dataset shape / workload configuration
+- Run 1 artifact and result:
+- Run 2 artifact and result:
+- Run 3 artifact and result:
+- Median achieved RPS / p50 / p95 / p99:
+- Worst observed failure rate / dropped iterations:
+- Variability and anomalies (do not average away failures):
 
 ## Artifacts
 

--- a/docs/performance/load-testing.md
+++ b/docs/performance/load-testing.md
@@ -7,7 +7,7 @@ For the no-card GitHub Actions execution path, see
 
 ## Safety gate
 
-Use an isolated API and PostgreSQL database with production-like limits and disposable fixtures. Do not run write profiles against the public demo or a database containing user data. Do not run PayPal capture/webhook-success traffic without explicit operator approval and PayPal Sandbox isolation.
+Use an isolated API and PostgreSQL database with production-like limits and disposable fixtures. The repository's no-credential path is the manually dispatched **controlled CI capacity evidence** workflow documented in `docs/operations/load-test-ci.md`. Do not call its results Render or production capacity. Do not run write profiles against the public demo or a database containing user data. Do not run PayPal capture/webhook-success traffic without explicit operator approval and PayPal Sandbox isolation.
 
 Before a run, record:
 
@@ -26,7 +26,7 @@ Before a run, record:
 5. `webhook_rejection`: measure the unauthenticated trust-boundary rejection path.
 6. Cool down, capture final database state, and verify invariants/tests.
 
-Run one profile at a time. Repeat each stable point at least three times; report the median run and the spread. A single run is a probe, not a capacity claim.
+Run one profile at a time. Select the workflow's three-repetition mode only after a stable point is chosen. It creates three serial jobs at the same commit and configuration, each with a fresh equivalent dataset. Report every run, the median and the spread; do not average away an anomaly. A single run is a probe, not a capacity claim.
 
 ## Metrics to capture
 
@@ -45,7 +45,7 @@ SELECT wait_event_type, wait_event, count(*) FROM pg_stat_activity WHERE datname
 SELECT deadlocks, xact_commit, xact_rollback FROM pg_stat_database WHERE datname = current_database();
 ```
 
-Provider charts and SQL snapshots must cover the same UTC window as the k6 JSON summary. Do not infer database saturation from HTTP latency alone.
+Resource samples and SQL snapshots must cover the same UTC window as the k6 JSON summary. In controlled CI, Docker statistics and PostgreSQL activity/statistics are the resource source; in a deployed environment, use provider charts. Do not infer database saturation from HTTP latency alone.
 
 ## Capacity decision rule
 
@@ -57,7 +57,7 @@ Record the highest repeatable offered rate where all of these remain true:
 - PostgreSQL connections retain operational headroom and lock waits are explained;
 - domain invariants remain intact after the run.
 
-The committed thresholds are test guardrails, not production SLOs. Update `docs/architecture/capacity.md` only with measured environment-qualified results.
+The committed thresholds are test guardrails, not production SLOs. Controlled CI results must name the fixed container limits and GitHub-hosted runner uncertainty. Update `docs/architecture/capacity.md` only after the required runs exist and only with environment-qualified language.
 
 ## Architecture gate
 

--- a/docs/plans/PLAN-0006-k6-load-testing.md
+++ b/docs/plans/PLAN-0006-k6-load-testing.md
@@ -1,13 +1,13 @@
 ---
 id: PLAN-0006
 status: Ready
-version: 2
+version: 3
 source_spec: SPEC-0009
-source_spec_version: 2
-baseline_revision: bb829f41e320be915d9633e637071011701e4dc1
+source_spec_version: 3
+baseline_revision: 9f4c60885d8a1c9c11362d1b236c6179b7f787e9
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # [PLAN-0006] — k6 load testing and capacity evidence
@@ -18,18 +18,18 @@ updated: 2026-09-08
 
 ## Source
 
-- Specification: `SPEC-0009` v2
+- Specification: `SPEC-0009` v3
 - External tracker: `#55` (optional)
 - Planning task: performance evidence before infrastructure expansion
-- Baseline: `bb829f41e320be915d9633e637071011701e4dc1`
+- Baseline: `9f4c60885d8a1c9c11362d1b236c6179b7f787e9`
 
 ## Current State
 
-The baseline contains EXPLAIN/query timing evidence, capacity hypotheses, OTel instruments and explicit scale triggers. It has no k6 scripts or load reports. ADR 0018 rejects Redis and ADR 0019 rejects SQS/Kafka until a measured trigger exists.
+The baseline contains the five-profile k6 harness and a safe but incomplete ephemeral workflow. The workflow runs `npm start`, exposes only three profiles, has no explicit container limits, fixtures, invariant gate or synchronized resource evidence, and is explicitly ineligible for a capacity claim.
 
 ## Goal
 
-Add the safe k6 harness, operating procedure and report contract; then execute it in an isolated production-like environment before publishing capacity numbers or changing infrastructure ADRs.
+Run the production Docker image and PostgreSQL 16 in a controlled, resource-limited, isolated CI topology; generate safe fixtures and complete evidence bundles; then execute all profiles before publishing controlled CI capacity numbers or changing infrastructure ADRs.
 
 ## Affected Areas
 
@@ -53,8 +53,9 @@ No schema change. The opt-in orders profile mutates disposable fixture rows thro
 2. Implement profiles, checks, thresholds, input gates and JSON summary.
 3. Document environment/resource capture and reporting.
 4. Validate documentation contracts and inspect the k6 script when the binary is available.
-5. Deploy/provision an isolated production-like target and run all profiles three times.
-6. Update capacity evidence and evaluate whether an ADR 0018/0019 review is triggered.
+5. Build the controlled CI topology, fixture preparation, synchronized sampling, invariant gate and one/three repetition dispatch modes.
+6. In subsequent workflow runs, execute all profiles and repeat each claimed stable point three times.
+7. Update capacity evidence and evaluate whether an ADR 0018/0019 review is triggered.
 
 ## Task Graph
 
@@ -77,7 +78,7 @@ k6 inspect load-tests/k6/neon-arsenal.js
 k6 run load-tests/k6/neon-arsenal.js
 ```
 
-AC-01–04 map to harness inspection/runtime; AC-05–06 to procedure/template review; AC-07 to external isolated runs; AC-08 to diff and existing CI.
+AC-01–04 map to harness inspection/runtime; AC-05–06 to procedure/template review; AC-07 to subsequent controlled CI run artifacts; AC-08 to diff and existing CI.
 
 ## Risks
 
@@ -88,7 +89,7 @@ AC-01–04 map to harness inspection/runtime; AC-05–06 to procedure/template r
 
 ## Dependencies
 
-An isolated production-like API/PostgreSQL environment and k6 binary are required for AC-07. PayPal Sandbox valid-event load is not required or authorized by v1.
+Successful controlled CI workflow artifacts are required for AC-07. PayPal credentials and valid-event load are neither required nor authorized; payment replay uses a completed local fixture on a no-egress container network.
 
 ## Stop Conditions
 
@@ -99,7 +100,7 @@ An isolated production-like API/PostgreSQL environment and k6 binary are require
 
 ## Definition of Done
 
-Harness/docs are reviewed and inspect successfully; all five profiles run against an isolated production-like target; three repetitions support published capacity claims; resource and invariant evidence is attached; #55 receives the report and may close.
+Enablement is reviewed and inspects successfully; then all five profiles run in controlled CI, three equivalent repetitions support every published claim, resource and invariant evidence is attached, and #55 receives the qualified report. The enablement PR alone does not complete AC-07.
 
 ## Traceability
 
@@ -108,13 +109,14 @@ SPEC → PLAN → TASK(S) → PR → EVIDENCE
 ```
 
 - External tracker: `#55` (optional)
-- Specification: `SPEC-0009` v2
-- Plan: `PLAN-0006` v2
-- Tasks: `TASK-0010` v2
+- Specification: `SPEC-0009` v3
+- Plan: `PLAN-0006` v3
+- Tasks: `TASK-0010` v3
 - PR: pending
 - Evidence: pending isolated runtime
 
 ## Change History
 
+- `v3` — Replaced the missing external environment dependency with a controlled, production-image CI topology and deferred capacity claims to subsequent runs — 2026-09-09
 - `v2` — Migrated validation commands, baseline and traceability to the direct-agent documentation contract — 2026-09-08
 - `v1` — Ready plan for SPEC-0009 — 2026-09-07

--- a/docs/specs/SPEC-0009-load-testing-and-capacity-evidence.md
+++ b/docs/specs/SPEC-0009-load-testing-and-capacity-evidence.md
@@ -1,11 +1,11 @@
 ---
 id: SPEC-0009
 status: Accepted
-version: 2
+version: 3
 source_issue: "#55"
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-07
+updated: 2026-09-09
 ---
 
 # [SPEC-0009] — Reproducible load testing and capacity evidence
@@ -20,7 +20,7 @@ The repository has query-plan measurements and capacity hypotheses, but no repro
 
 ## Goal
 
-Provide safe, reproducible k6 profiles and a report contract that correlate HTTP RPS/p50/p95/p99/errors with API and PostgreSQL resource evidence, without silently mutating production or triggering PayPal side effects.
+Provide safe, reproducible k6 profiles and a controlled production-like CI environment that correlate HTTP RPS/p50/p95/p99/errors with API and PostgreSQL resource evidence, without external cloud credentials, silently mutating production, or triggering PayPal side effects.
 
 ## Actors
 
@@ -36,6 +36,7 @@ Provide safe, reproducible k6 profiles and a report contract that correlate HTTP
 - Idempotent payment-link replay using pre-warmed completed links.
 - Invalid-signature webhook rejection at the trust boundary.
 - JSON summaries, metric thresholds, resource-correlation procedure and report template.
+- A manually gated controlled CI topology using the production Docker image, explicit resource limits, PostgreSQL 16, disposable fixtures and synchronized evidence capture.
 
 ## Non-goals
 
@@ -54,6 +55,7 @@ Provide safe, reproducible k6 profiles and a report contract that correlate HTTP
 - `BR-04`: Webhook load proves invalid signatures are rejected before persistence; valid signed webhook load remains operator-gated.
 - `BR-05`: Every accepted capacity result records commit, environment, dataset, workload, UTC window, k6 percentiles/errors and API/PostgreSQL resource signals.
 - `BR-06`: A single run or a k6-only summary is not a capacity claim.
+- `BR-07`: GitHub-hosted results are named controlled CI capacity evidence; they are not Render or production capacity, and runner variability remains explicit.
 
 ## Invariants
 
@@ -102,13 +104,13 @@ No runtime, API, schema, deploy or client behavior changes. This adds an operato
 - [ ] `AC-04` — Profile thresholds fail on checks/custom failures and p95/p99 regressions. **Evidence:** k6 inspect
 - [ ] `AC-05` — The procedure requires correlated CPU, memory, connections, waits, deadlocks and invariant evidence. **Evidence:** static check
 - [ ] `AC-06` — A report template separates measured facts from hypotheses and records the first bottleneck. **Evidence:** static check
-- [ ] `AC-07` — At least one isolated production-like run covers each profile and three repetitions support any committed capacity claim. **Evidence:** runtime/external evidence
+- [ ] `AC-07` — At least one controlled, isolated production-like run covers each profile and three equivalent repetitions support any committed capacity claim. GitHub-hosted evidence must disclose runner variability and must not be called Render or production capacity. **Evidence:** runtime artifacts
 - [ ] `AC-08` — Existing API/payment/schema/deploy behavior is unchanged. **Evidence:** diff review and existing tests
 
 ## Verification Strategy
 
 - `k6 inspect load-tests/k6/neon-arsenal.js`
-- `k6 run` for each profile against an isolated production-like deployment.
+- `k6 run` for each profile against the isolated controlled CI topology or another explicitly qualified production-like environment.
 - `python scripts/docs/validate_contracts.py`
 - `python tests/tooling/test_docs_contracts.py`
 - Existing backend typecheck/unit/integration suite; diff review proves no runtime change.
@@ -127,12 +129,13 @@ SPEC → PLAN → TASK(S) → PR → EVIDENCE
 
 - External tracker: `#55` (optional)
 - Spec: `SPEC-0009`
-- Plan: `PLAN-0006` v2
-- Tasks: `TASK-0010` v2
+- Plan: `PLAN-0006` v3
+- Tasks: `TASK-0010` v3
 - PR: pending
 - Evidence: pending runtime evidence
 
 ## Change History
 
+- `v3` — Accepted a no-cloud-credential controlled CI environment as eligible AC-07 evidence when all profile, repetition, resource and uncertainty requirements are satisfied — 2026-09-09
 - `v2` — Migrated validation commands and traceability to the direct-agent documentation contract — 2026-09-08
 - `v1` — Accepted harness and evidence contract — 2026-09-07

--- a/docs/tasks/TASK-0010-k6-harness.md
+++ b/docs/tasks/TASK-0010-k6-harness.md
@@ -1,16 +1,16 @@
 ---
 id: TASK-0010
-status: Ready
-version: 2
+status: InProgress
+version: 3
 source_issue: "#55"
 source_spec: SPEC-0009
-source_spec_version: 2
+source_spec_version: 3
 source_plan: PLAN-0006
-source_plan_version: 2
-baseline_revision: bb829f41e320be915d9633e637071011701e4dc1
+source_plan_version: 3
+baseline_revision: 9f4c60885d8a1c9c11362d1b236c6179b7f787e9
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-08
+updated: 2026-09-09
 ---
 
 # [TASK-0010] — Build and run the k6 capacity harness
@@ -21,13 +21,13 @@ updated: 2026-09-08
 
 ## Source
 
-- Specification: `SPEC-0009` v2
-- Plan: `PLAN-0006` v2
+- Specification: `SPEC-0009` v3
+- Plan: `PLAN-0006` v3
 - External tracker: #55 (optional)
 
 ## Objective
 
-Deliver safe k6 profiles plus correlated capacity evidence from an isolated production-like environment.
+Enable a no-cloud-credential controlled CI environment that can later produce safe, correlated capacity evidence for all five profiles.
 
 ## Scope
 
@@ -39,16 +39,16 @@ Deliver safe k6 profiles plus correlated capacity evidence from an isolated prod
 
 ## Preconditions
 
-`SPEC-0009` Accepted; `PLAN-0006` Ready. Runtime phase requires a disposable API/PostgreSQL target and operator-approved test credentials.
+`SPEC-0009` Accepted; `PLAN-0006` Ready. Runtime phase requires GitHub Actions with Docker support; it uses only disposable local credentials and data.
 
 ## Acceptance Criteria
 
-- [ ] `AC-01`: Harness inspection succeeds and exposes five gated profiles **Evidence:** static check
-- [ ] AC-02: Default smoke and catalog are read-only
-- [ ] AC-03: Orders require explicit write opt-in and unique disposable listing IDs
-- [ ] AC-04: Payment is replay-only; webhook profile rejects invalid signatures
-- [ ] AC-05: JSON summary and report capture HTTP, API, PostgreSQL and invariant evidence
-- [ ] AC-06: Three isolated repetitions support any capacity statement
+- [ ] `AC-01` — Production Docker image and PostgreSQL 16 run with explicit recorded resource limits. **Evidence:** static check
+- [ ] `AC-02` — All five profiles are manually dispatchable; only orders receives write opt-in and disposable unique listings. **Evidence:** static check
+- [ ] `AC-03` — Payment replay is prepared locally and cannot reach PayPal; webhook verification remains intact. **Evidence:** manual review
+- [ ] `AC-04` — Raw k6, API, resource, PostgreSQL and invariant evidence is retained for the same UTC window. **Evidence:** static check
+- [ ] `AC-05` — One/three repetition modes preserve the same commit and configuration with a fresh equivalent dataset. **Evidence:** static check
+- [ ] `AC-06` — Subsequent successful runs cover all profiles and three repetitions support any controlled CI capacity statement. **Evidence:** runtime
 
 ## Dependencies
 
@@ -69,7 +69,7 @@ k6 run load-tests/k6/neon-arsenal.js
 
 ## Expected Evidence
 
-Documentation contract validation exits 0; k6 inspection succeeds; each profile has a JSON summary and synchronized API/PostgreSQL evidence; post-run invariants remain valid.
+Enablement validation exits 0 and the workflow is statically valid. Subsequent workflow execution supplies per-profile JSON, synchronized API/PostgreSQL evidence and post-run invariant proof. AC-07 remains open until those runs exist.
 
 ## Stop Conditions
 
@@ -81,5 +81,6 @@ SPEC → PLAN → TASK(S) → PR → EVIDENCE
 
 ## Change History
 
+- 2026-09-09 — v3 — Started controlled CI capacity-evidence enablement; runtime evidence and AC-07 remain pending.
 - 2026-09-08 — v2 — Migrated dependencies, validation commands, baseline and traceability to the direct-agent documentation contract.
 - 2026-09-08 — v1 — Migrated to the task artifact contract.

--- a/load-tests/k6/README.md
+++ b/load-tests/k6/README.md
@@ -1,6 +1,6 @@
 # k6 load-test harness
 
-Issue #55. Run only against an isolated, production-like environment with disposable data. The default `smoke` profile is read-only. Write profiles require explicit data and never create users, listings, or PayPal resources implicitly.
+Issue #55. Run only against an isolated, production-like environment with disposable data. The default `smoke` profile is read-only. Write profiles require explicit data and never create users, listings, or PayPal resources implicitly. The manual GitHub Actions path is classified as **controlled CI capacity evidence**, not Render or production capacity.
 
 ## Profiles
 
@@ -47,6 +47,12 @@ k6 run load-tests/k6/neon-arsenal.js
 ```
 
 Never commit credentials or generated summary JSON. Use a unique `RUN_ID` for traceability.
+
+## Controlled CI support
+
+`.github/workflows/load-test.yml` builds and runs the production Docker image with fixed CPU and memory limits beside a resource-limited PostgreSQL 16 container. The helpers under `load-tests/k6/ci/` create disposable order/payment-replay fixtures, sample both containers and PostgreSQL during the exact k6 window, capture pre/post database snapshots, and fail if post-run invariants do not hold.
+
+The payment fixture contains an already-completed local `PaymentLink`. The API and PostgreSQL run on an internal Docker network with no provider egress and no PayPal credentials. A replay therefore succeeds only through the existing early-return path; an accidental `OrdersCreate` or `OrdersCapture` attempt cannot reach PayPal and causes the run to fail.
 
 ## Evidence outside k6
 

--- a/load-tests/k6/ci/capture-db-snapshot.sh
+++ b/load-tests/k6/ci/capture-db-snapshot.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pg_container=${1:?PostgreSQL container name is required}
+phase=${2:?Snapshot phase is required}
+output=${3:?Output path is required}
+
+mkdir -p "$(dirname "$output")"
+{
+  echo "phase=$phase"
+  echo "captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  docker exec -i "$pg_container" psql -X -v ON_ERROR_STOP=1 -P pager=off \
+    -U neon -d neon_arsenal_loadtest <<'SQL'
+SELECT version();
+SHOW max_connections;
+SELECT state, count(*) FROM pg_stat_activity WHERE datname = current_database() GROUP BY state ORDER BY state;
+SELECT wait_event_type, wait_event, count(*)
+FROM pg_stat_activity
+WHERE datname = current_database()
+GROUP BY wait_event_type, wait_event
+ORDER BY wait_event_type NULLS FIRST, wait_event NULLS FIRST;
+SELECT datname, numbackends, xact_commit, xact_rollback, deadlocks
+FROM pg_stat_database WHERE datname = current_database();
+SELECT status, count(*) FROM "Listing" GROUP BY status ORDER BY status;
+SELECT status, "paymentStatus", count(*) FROM "Order" GROUP BY status, "paymentStatus" ORDER BY status, "paymentStatus";
+SELECT
+  (SELECT count(*) FROM "Product") AS products,
+  (SELECT count(*) FROM "Listing") AS listings,
+  (SELECT count(*) FROM "Order") AS orders,
+  (SELECT count(*) FROM "PaymentLink") AS payment_links,
+  (SELECT count(*) FROM "PaymentWebhookEvent") AS webhook_events,
+  (SELECT count(*) FROM "Refund") AS refunds;
+SQL
+} > "$output" 2>&1

--- a/load-tests/k6/ci/prepare-fixtures.sh
+++ b/load-tests/k6/ci/prepare-fixtures.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pg_container=${1:?PostgreSQL container name is required}
+run_id=${2:?Run ID is required}
+order_count=${3:?Order listing count is required}
+payment_count=${4:?Payment order count is required}
+github_env=${5:?GITHUB_ENV path is required}
+output_dir=${6:?Output directory is required}
+
+if [[ ! "$run_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "RUN_ID contains unsupported characters" >&2
+  exit 1
+fi
+if [[ ! "$order_count" =~ ^[1-9][0-9]*$ ]] || (( order_count > 100 )); then
+  echo "Order listing count must be between 1 and 100" >&2
+  exit 1
+fi
+if [[ ! "$payment_count" =~ ^[1-9][0-9]*$ ]] || (( payment_count > 20 )); then
+  echo "Payment order count must be between 1 and 20" >&2
+  exit 1
+fi
+
+mkdir -p "$output_dir"
+
+docker exec -i "$pg_container" psql -X -v ON_ERROR_STOP=1 \
+  -U neon -d neon_arsenal_loadtest \
+  -v run_id="$run_id" -v order_count="$order_count" -v payment_count="$payment_count" \
+  > "$output_dir/fixture-preparation.log" <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE k6_context AS
+SELECT
+  (SELECT id FROM "User" WHERE email = 'buyer@skinmarket.gg' AND role = 'CUSTOMER' LIMIT 1) AS customer_id,
+  (SELECT id FROM "Seller" WHERE "isApproved" = true ORDER BY id LIMIT 1) AS seller_id,
+  (SELECT id FROM "Product" ORDER BY id LIMIT 1) AS product_id;
+
+DO $validation$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM k6_context
+    WHERE customer_id IS NULL OR seller_id IS NULL OR product_id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Demo seed did not provide the required customer, seller and product';
+  END IF;
+END
+$validation$;
+
+INSERT INTO "Listing" (
+  id, "productId", "sellerId", "floatValue", pattern, price, currency,
+  status, "createdAt", "updatedAt"
+)
+SELECT
+  'k6-order-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  product_id,
+  seller_id,
+  0.10,
+  600000 + series,
+  10.00,
+  'BRL',
+  'ACTIVE',
+  now(),
+  now()
+FROM k6_context
+CROSS JOIN generate_series(1, :order_count) AS series;
+
+INSERT INTO "Order" (
+  id, "customerId", "totalAmount", status, "paymentStatus", "paypalOrderId",
+  "createdAt", "updatedAt"
+)
+SELECT
+  'k6-payment-order-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  customer_id,
+  10.00,
+  'PENDING',
+  'PENDING',
+  'K6-CI-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  now(),
+  now()
+FROM k6_context
+CROSS JOIN generate_series(1, :payment_count) AS series;
+
+INSERT INTO "Listing" (
+  id, "productId", "sellerId", "floatValue", pattern, price, currency,
+  status, "reservedAt", "reservationExpiresAt", "reservedByOrderId",
+  "createdAt", "updatedAt"
+)
+SELECT
+  'k6-payment-listing-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  product_id,
+  seller_id,
+  0.11,
+  700000 + series,
+  10.00,
+  'BRL',
+  'RESERVED',
+  now(),
+  now() + interval '10 minutes',
+  'k6-payment-order-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  now(),
+  now()
+FROM k6_context
+CROSS JOIN generate_series(1, :payment_count) AS series;
+
+INSERT INTO "OrderItem" (id, "orderId", "listingId", "sellerId", "priceSnapshot")
+SELECT
+  'k6-payment-item-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  'k6-payment-order-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  'k6-payment-listing-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  seller_id,
+  10.00
+FROM k6_context
+CROSS JOIN generate_series(1, :payment_count) AS series;
+
+INSERT INTO "OrderIdempotencyKey" (
+  id, "customerId", key, "requestHash", status, "orderId", "createdAt", "updatedAt"
+)
+SELECT
+  'k6-payment-key-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  customer_id,
+  'k6-payment-fixture-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  repeat('0', 64),
+  'COMPLETED',
+  'k6-payment-order-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  now(),
+  now()
+FROM k6_context
+CROSS JOIN generate_series(1, :payment_count) AS series;
+
+INSERT INTO "PaymentLink" (
+  "orderId", "paypalOrderId", "approvalUrl", status, "createdAt", "updatedAt"
+)
+SELECT
+  'k6-payment-order-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  'K6-CI-' || :'run_id' || '-' || lpad(series::text, 4, '0'),
+  'https://example.invalid/k6-ci/' || :'run_id' || '/' || series,
+  'COMPLETED',
+  now(),
+  now()
+FROM generate_series(1, :payment_count) AS series;
+
+COMMIT;
+
+SELECT 'fixture_orders', count(*)
+FROM "Listing" WHERE id LIKE 'k6-order-' || :'run_id' || '-%';
+SELECT 'fixture_payment_links', count(*)
+FROM "PaymentLink" WHERE "orderId" LIKE 'k6-payment-order-' || :'run_id' || '-%';
+SQL
+
+order_ids=$(docker exec "$pg_container" psql -X -A -t -U neon -d neon_arsenal_loadtest \
+  -c "SELECT string_agg(id, ',' ORDER BY id) FROM \"Listing\" WHERE id LIKE 'k6-order-${run_id}-%'")
+payment_ids=$(docker exec "$pg_container" psql -X -A -t -U neon -d neon_arsenal_loadtest \
+  -c "SELECT string_agg(id, ',' ORDER BY id) FROM \"Order\" WHERE id LIKE 'k6-payment-order-${run_id}-%'")
+
+if [[ -z "$order_ids" ]] || [[ -z "$payment_ids" ]]; then
+  echo "Fixture IDs were not generated" >&2
+  exit 1
+fi
+
+{
+  echo "CUSTOMER_EMAIL=buyer@skinmarket.gg"
+  echo "CUSTOMER_PASSWORD=buyer123"
+  echo "ORDER_LISTING_IDS=$order_ids"
+  echo "PAYMENT_ORDER_IDS=$payment_ids"
+} >> "$github_env"
+
+printf '%s\n' "$order_ids" | tr ',' '\n' > "$output_dir/order-listing-ids.txt"
+printf '%s\n' "$payment_ids" | tr ',' '\n' > "$output_dir/payment-order-ids.txt"

--- a/load-tests/k6/ci/sample-resources.sh
+++ b/load-tests/k6/ci/sample-resources.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+api_container=${1:?API container name is required}
+pg_container=${2:?PostgreSQL container name is required}
+stop_file=${3:?Stop-file path is required}
+output=${4:?Output path is required}
+
+mkdir -p "$(dirname "$output")"
+: > "$output"
+
+while [[ ! -e "$stop_file" ]]; do
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  api_stats=$(docker stats --no-stream --format '{{json .}}' "$api_container" 2>/dev/null || echo '{}')
+  pg_stats=$(docker stats --no-stream --format '{{json .}}' "$pg_container" 2>/dev/null || echo '{}')
+  api_state=$(docker inspect --format '{"state":{{json .State}},"restartCount":{{.RestartCount}}}' "$api_container" 2>/dev/null || echo '{}')
+  api_rss_kib=$(docker exec "$api_container" sh -c "awk '/^VmRSS:/ { print \$2 }' /proc/1/status" 2>/dev/null || true)
+  pg_sample=$(docker exec "$pg_container" psql -X -A -t -U neon -d neon_arsenal_loadtest -c "
+    SELECT json_build_object(
+      'connections', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database()),
+      'active', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'active'),
+      'idle', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND state = 'idle'),
+      'waiting', (SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND wait_event_type IS NOT NULL),
+      'wait_events', COALESCE((
+        SELECT json_agg(wait_sample ORDER BY wait_event_type, wait_event)
+        FROM (
+          SELECT wait_event_type, wait_event, count(*) AS connections
+          FROM pg_stat_activity
+          WHERE datname = current_database() AND wait_event_type IS NOT NULL
+          GROUP BY wait_event_type, wait_event
+        ) wait_sample
+      ), '[]'::json),
+      'max_connections', current_setting('max_connections')::int,
+      'deadlocks', deadlocks,
+      'xact_commit', xact_commit,
+      'xact_rollback', xact_rollback
+    ) FROM pg_stat_database WHERE datname = current_database();
+  " 2>/dev/null || echo '{}')
+
+  jq -cn \
+    --arg timestamp "$timestamp" \
+    --argjson api "$api_stats" \
+    --argjson postgres "$pg_stats" \
+    --argjson apiState "$api_state" \
+    --arg apiRssKiB "${api_rss_kib:-unavailable}" \
+    --argjson postgresActivity "$pg_sample" \
+    '{timestamp: $timestamp, api: $api, apiState: $apiState, apiRssKiB: $apiRssKiB, postgres: $postgres, postgresActivity: $postgresActivity}' \
+    >> "$output"
+  sleep 2
+done

--- a/load-tests/k6/ci/validate-invariants.sh
+++ b/load-tests/k6/ci/validate-invariants.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pg_container=${1:?PostgreSQL container name is required}
+profile=${2:?Load profile is required}
+run_id=${3:?Run ID is required}
+order_count=${4:?Order listing count is required}
+payment_count=${5:?Payment order count is required}
+output=${6:?Output path is required}
+
+if [[ ! "$run_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "RUN_ID contains unsupported characters" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$output")"
+result=$(docker exec "$pg_container" psql -X -A -t -U neon -d neon_arsenal_loadtest -c "
+  SELECT json_build_object(
+    'profile', '${profile}',
+    'run_id', '${run_id}',
+    'order_fixture_listings', (SELECT count(*) FROM \"Listing\" WHERE id LIKE 'k6-order-${run_id}-%'),
+    'order_active_listings', (
+      SELECT count(*) FROM \"Listing\" WHERE id LIKE 'k6-order-${run_id}-%' AND status = 'ACTIVE'
+    ),
+    'order_fixture_orders', (
+      SELECT count(DISTINCT oi.\"orderId\") FROM \"OrderItem\" oi
+      WHERE oi.\"listingId\" LIKE 'k6-order-${run_id}-%'
+    ),
+    'order_valid_reservations', (
+      SELECT count(*) FROM \"OrderItem\" oi
+      JOIN \"Listing\" l ON l.id = oi.\"listingId\"
+      JOIN \"Order\" o ON o.id = oi.\"orderId\"
+      WHERE l.id LIKE 'k6-order-${run_id}-%'
+        AND l.status = 'RESERVED'
+        AND l.\"reservedByOrderId\" = o.id
+        AND o.status = 'PENDING'
+        AND o.\"paymentStatus\" = 'PENDING'
+    ),
+    'order_completed_idempotency_keys', (
+      SELECT count(*) FROM \"OrderIdempotencyKey\"
+      WHERE key LIKE 'k6-${run_id}-%' AND status = 'COMPLETED' AND \"orderId\" IS NOT NULL
+    ),
+    'order_duplicate_consumption', (
+      SELECT count(*) FROM (
+        SELECT oi.\"listingId\" FROM \"OrderItem\" oi
+        WHERE oi.\"listingId\" LIKE 'k6-order-${run_id}-%'
+        GROUP BY oi.\"listingId\" HAVING count(*) > 1
+      ) duplicates
+    ),
+    'order_payment_links', (
+      SELECT count(*) FROM \"PaymentLink\" pl
+      WHERE pl.\"orderId\" IN (
+        SELECT oi.\"orderId\" FROM \"OrderItem\" oi WHERE oi.\"listingId\" LIKE 'k6-order-${run_id}-%'
+      )
+    ),
+    'order_seller_transactions', (
+      SELECT count(*) FROM \"SellerTransaction\" st
+      WHERE st.\"orderId\" IN (
+        SELECT oi.\"orderId\" FROM \"OrderItem\" oi WHERE oi.\"listingId\" LIKE 'k6-order-${run_id}-%'
+      )
+    ),
+    'payment_fixture_orders', (SELECT count(*) FROM \"Order\" WHERE id LIKE 'k6-payment-order-${run_id}-%'),
+    'payment_completed_links', (
+      SELECT count(*) FROM \"PaymentLink\"
+      WHERE \"orderId\" LIKE 'k6-payment-order-${run_id}-%'
+        AND status = 'COMPLETED'
+        AND \"paypalOrderId\" IS NOT NULL
+        AND \"approvalUrl\" IS NOT NULL
+    ),
+    'payment_link_mismatches', (
+      SELECT count(*) FROM \"Order\" o JOIN \"PaymentLink\" pl ON pl.\"orderId\" = o.id
+      WHERE o.id LIKE 'k6-payment-order-${run_id}-%'
+        AND o.\"paypalOrderId\" IS DISTINCT FROM pl.\"paypalOrderId\"
+    ),
+    'payment_seller_transactions', (
+      SELECT count(*) FROM \"SellerTransaction\" WHERE \"orderId\" LIKE 'k6-payment-order-${run_id}-%'
+    ),
+    'unexpected_webhook_events', (
+      SELECT count(*) FROM \"PaymentWebhookEvent\" WHERE \"externalEventId\" LIKE 'k6-invalid-${run_id}-%'
+    )
+  );
+")
+
+printf '%s\n' "$result" | jq . | tee "$output"
+
+case "$profile" in
+  orders)
+    jq -e \
+      --argjson expected "$order_count" \
+      '.order_fixture_listings == $expected and
+       .order_fixture_orders == $expected and
+       .order_valid_reservations == $expected and
+       .order_completed_idempotency_keys == $expected and
+       .order_duplicate_consumption == 0 and
+       .order_payment_links == 0 and
+       .order_seller_transactions == 0' <<< "$result" > /dev/null
+    ;;
+  payment_replay)
+    jq -e \
+      --argjson expected "$payment_count" \
+      '.payment_fixture_orders == $expected and
+       .payment_completed_links == $expected and
+       .payment_link_mismatches == 0 and
+       .payment_seller_transactions == 0 and
+       .order_fixture_orders == 0' <<< "$result" > /dev/null
+    ;;
+  webhook_rejection)
+    jq -e \
+      --argjson expected "$order_count" \
+      '.unexpected_webhook_events == 0 and .order_active_listings == $expected and .order_fixture_orders == 0' \
+      <<< "$result" > /dev/null
+    ;;
+  smoke|catalog)
+    jq -e \
+      --argjson expected "$order_count" \
+      '.order_active_listings == $expected and .order_fixture_orders == 0 and .unexpected_webhook_events == 0' \
+      <<< "$result" > /dev/null
+    ;;
+  *)
+    echo "Unknown profile: $profile" >&2
+    exit 1
+    ;;
+esac
+
+echo "Invariant validation passed for profile=$profile run_id=$run_id"

--- a/load-tests/k6/neon-arsenal.js
+++ b/load-tests/k6/neon-arsenal.js
@@ -77,6 +77,7 @@ if (!profiles[PROFILE]) {
 
 export const options = {
   scenarios: profiles[PROFILE],
+  summaryTrendStats: ["avg", "min", "med", "max", "p(50)", "p(90)", "p(95)", "p(99)"],
   thresholds: {
     checks: ["rate>0.99"],
     "catalog_failures{scenario:catalog_browse}": ["rate<0.01"],
@@ -193,6 +194,20 @@ export function handleSummary(data) {
     baseUrl: BASE_URL,
     runId: RUN_ID,
     generatedAt: new Date().toISOString(),
+    workload: {
+      offeredRps:
+        PROFILE === "catalog" || PROFILE === "webhook_rejection"
+          ? intEnv("LOAD_TARGET_RPS", PROFILE === "catalog" ? 20 : 5)
+          : null,
+      startRps: PROFILE === "catalog" ? intEnv("LOAD_START_RPS", 5) : null,
+      vus: __ENV.LOAD_VUS || null,
+      duration: __ENV.LOAD_DURATION || null,
+      rampDuration: __ENV.LOAD_RAMP_DURATION || null,
+      holdDuration: __ENV.LOAD_HOLD_DURATION || null,
+      cooldownDuration: __ENV.LOAD_COOLDOWN_DURATION || null,
+      preAllocatedVUs: __ENV.LOAD_PREALLOCATED_VUS || null,
+      maxVUs: __ENV.LOAD_MAX_VUS || null,
+    },
     metrics: data.metrics,
     rootGroup: data.root_group,
   };
@@ -247,6 +262,7 @@ function summaryLine(data) {
   const duration = data.metrics.http_req_duration?.values || {};
   const requests = data.metrics.http_reqs?.values || {};
   const failures = data.metrics.http_req_failed?.values || {};
+  const dropped = data.metrics.dropped_iterations?.values || {};
   return [
     `profile=${PROFILE}`,
     `requests=${requests.count ?? 0}`,
@@ -255,6 +271,7 @@ function summaryLine(data) {
     `p95_ms=${format(duration["p(95)"])}`,
     `p99_ms=${format(duration["p(99)"])}`,
     `http_failed_rate=${format(failures.rate)}`,
+    `dropped_iterations=${dropped.count ?? 0}`,
     `summary=${__ENV.LOAD_SUMMARY_PATH || `k6-summary-${PROFILE}-${RUN_ID}.json`}`,
     "",
   ].join(" ");


### PR DESCRIPTION
## Summary

Enables TASK-0010's controlled CI capacity-evidence environment without publishing capacity numbers.

- runs the production `server/Dockerfile` image with 1 CPU / 512 MiB
- runs isolated PostgreSQL 16 with 1 CPU / 1 GiB, `max_connections=100`, and `shared_buffers=256MB`
- exposes all five profiles through manual `workflow_dispatch`
- generates disposable orders and replay-only payment fixtures
- isolates API/PostgreSQL on a no-egress Docker network; no PayPal credentials are supplied
- captures raw k6 JSON, API logs/errors, two-second resource samples, pre/post PostgreSQL snapshots, metadata, and invariant output
- supports one-run probes and an exactly-three-run serial matrix

## How subsequent runs produce the three-run evidence

1. Dispatch one-run probes for smoke and every safety profile.
2. Increase the catalog `target_rps` in controlled one-run steps until the first threshold failure, error/dropped-iteration increase, or resource knee.
3. Select the highest stable catalog point.
4. Dispatch that unchanged commit/profile/input configuration with `repetitions=3`.
5. Each repetition receives a fresh, equivalently seeded database and fixtures under the same explicit resource limits.
6. Verify API/PostgreSQL image IDs, versions, resource limits, dataset cardinalities, and profile inputs match across artifacts; mutable base-image drift invalidates run equivalence.
7. Report runs 1/2/3 individually, median achieved RPS and p50/p95/p99, worst error rate, dropped iterations, variability, resource correlation, and the first observed bottleneck.
8. Run every profile at least once before evaluating SPEC-0009 AC-07.

## Safety and scope

- `ALLOW_WRITES=true` only for the orders profile.
- Payment replay uses completed local `PaymentLink` fixtures and cannot reach PayPal.
- Webhook testing remains an invalid-signature rejection path; verification is not weakened.
- The evidence is **controlled CI capacity evidence**, not Render capacity or production capacity.
- GitHub-hosted runner and co-located load-generator variability remain explicit limitations.
- SPEC-0009 AC-07 remains open until successful real workflow artifacts exist.

## Verification

- `python scripts/docs/validate_contracts.py` — PASS
- `python tests/tooling/test_docs_contracts.py` — PASS (19 tests)
- server typecheck — PASS
- backend unit suite — PASS (71 files, 421 tests)
- `k6 inspect` for all five profiles — PASS (k6 v2.2.0)
- actionlint — PASS
- Bash syntax validation for all four CI helpers — PASS
- workflow YAML parse — PASS
- `git diff --check` — PASS

The full container topology and PostgreSQL-backed integration tests were not run locally because the Docker Desktop Linux engine was unavailable. The subsequent manual workflow executions are the runtime proof.

No capacity number is claimed in this PR. No Redis, Kafka, SQS, AWS, Grafana, or Prometheus architecture is introduced.