### PR TITLE
fix(performance): pace smoke and persist k6 summary

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -169,7 +169,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$LOAD_PROFILE" in
-            smoke) printf '%s\n' 'LOAD_VUS=1' 'LOAD_DURATION=15s' >> "$GITHUB_ENV" ;;
+            smoke) printf '%s\n' 'LOAD_TARGET_RPS=1' 'LOAD_DURATION=15s' 'LOAD_PREALLOCATED_VUS=1' 'LOAD_MAX_VUS=2' >> "$GITHUB_ENV" ;;
             catalog)
               printf '%s\n' 'LOAD_START_RPS=5' 'LOAD_RAMP_DURATION=30s' 'LOAD_HOLD_DURATION=60s' \
                 'LOAD_COOLDOWN_DURATION=15s' 'LOAD_PREALLOCATED_VUS=20' 'LOAD_MAX_VUS=100' >> "$GITHUB_ENV"
@@ -222,6 +222,7 @@ jobs:
           date -u +%Y-%m-%dT%H:%M:%SZ | tee "$ARTIFACT_DIR/start-utc.txt"
           export LOAD_SUMMARY_PATH="$ARTIFACT_DIR/k6-summary.json"
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
             --network "$LOAD_NETWORK" \
             --volume "$GITHUB_WORKSPACE:/work" \
             --workdir /work \

--- a/docs/operations/load-test-ci.md
+++ b/docs/operations/load-test-ci.md
@@ -14,7 +14,7 @@ No GitHub Environment, external URL, PayPal credential, Blueprint, Vercel config
 
 ## Profile safety
 
-- `smoke` and `catalog` are read-only. `ALLOW_WRITES` is absent.
+- `smoke` and `catalog` are read-only. `ALLOW_WRITES` is absent. Smoke is deliberately paced at 1 request/second so it proves connectivity/response shape without tripping the production API rate limit; it is not a capacity profile.
 - `orders` alone receives `ALLOW_WRITES=true` and a generated list of unique `ACTIVE` listing IDs. Post-run SQL requires one order/reservation/idempotency result per listing and rejects duplicate consumption or payment/ledger side effects.
 - `payment_replay` receives local pending orders whose `PaymentLink` rows are already `COMPLETED` and whose PayPal IDs are synthetic local fixture identities. This exercises the existing replay early return. No PayPal credential is present and the internal Docker network has no provider egress, so an accidental provider call fails the run.
 - `webhook_rejection` sends only invalid signatures. Post-run SQL requires zero matching webhook-event rows.

--- a/load-tests/k6/neon-arsenal.js
+++ b/load-tests/k6/neon-arsenal.js
@@ -20,10 +20,13 @@ const webhookFailures = new Rate("webhook_failures");
 const profiles = {
   smoke: {
     catalog_browse: {
-      executor: "constant-vus",
+      executor: "constant-arrival-rate",
       exec: "catalogBrowse",
-      vus: intEnv("LOAD_VUS", 1),
+      rate: intEnv("LOAD_TARGET_RPS", 1),
+      timeUnit: "1s",
       duration: __ENV.LOAD_DURATION || "15s",
+      preAllocatedVUs: intEnv("LOAD_PREALLOCATED_VUS", 1),
+      maxVUs: intEnv("LOAD_MAX_VUS", 2),
     },
   },
   catalog: {


### PR DESCRIPTION
## Root cause from controlled smoke run #34399775113

The internal-network correction worked: readiness, fixtures, k6 execution, invariant checks and evidence capture all ran.

Two issues remained:

1. k6 could not write `k6-summary.json` into the host-mounted workspace because the pinned k6 image runs as a non-host user.
2. the smoke profile used an unpaced constant VU. It generated ~2.4k req/s and immediately exhausted the real production API limit (100 requests / 15 min), making subsequent responses 429 and crossing checks/catalog thresholds.

## Fix

- run the k6 load container with the GitHub runner UID/GID so mounted evidence files are writable
- change smoke from unbounded `constant-vus` to a controlled 1 RPS `constant-arrival-rate`
- keep smoke at 15s and read-only
- document that smoke proves connectivity/response shape and is not a capacity profile

No rate-limit bypass or runtime change is introduced. Catalog capacity behavior remains unchanged and will be evaluated separately.

After merge, rerun one smoke probe before other profiles.