### PR TITLE
fix(performance): account for rate-limited webhook rejection

### DIFF
--- a/docs/operations/load-test-ci.md
+++ b/docs/operations/load-test-ci.md
@@ -17,7 +17,7 @@ No GitHub Environment, external URL, PayPal credential, Blueprint, Vercel config
 - `smoke` and `catalog` are read-only. `ALLOW_WRITES` is absent. Smoke is deliberately paced at 1 request/second so it proves connectivity/response shape without tripping the production API rate limit; it is not a capacity profile.
 - `orders` alone receives `ALLOW_WRITES=true` and a generated list of unique `ACTIVE` listing IDs. Post-run SQL requires one order/reservation/idempotency result per listing and rejects duplicate consumption or payment/ledger side effects.
 - `payment_replay` receives local pending orders whose `PaymentLink` rows are already `COMPLETED` and whose PayPal IDs are synthetic local fixture identities. This exercises the existing replay early return. No PayPal credential is present and the internal Docker network has no provider egress, so an accidental provider call fails the run.
-- `webhook_rejection` sends only invalid signatures. Post-run SQL requires zero matching webhook-event rows.
+- `webhook_rejection` sends only invalid signatures. A `401` proves the signature verifier rejected the payload; after the production per-client limiter is exhausted, `429` is also a safe rejection at the earlier security boundary. The k6 profile accepts only `401` or `429`, requires at least one observed `401`, and post-run SQL requires zero matching webhook-event rows.
 
 ## Per-run procedure
 

--- a/load-tests/k6/neon-arsenal.js
+++ b/load-tests/k6/neon-arsenal.js
@@ -2,7 +2,7 @@ import http from "k6/http";
 import { check, fail } from "k6";
 import exec from "k6/execution";
 import { SharedArray } from "k6/data";
-import { Rate } from "k6/metrics";
+import { Counter, Rate } from "k6/metrics";
 
 const BASE_URL = (__ENV.BASE_URL || "http://127.0.0.1:3001").replace(/\/$/, "");
 const PROFILE = __ENV.LOAD_PROFILE || "smoke";
@@ -16,6 +16,7 @@ const catalogFailures = new Rate("catalog_failures");
 const orderFailures = new Rate("order_failures");
 const paymentFailures = new Rate("payment_failures");
 const webhookFailures = new Rate("webhook_failures");
+const webhookSignatureRejections = new Counter("webhook_signature_rejections");
 
 const profiles = {
   smoke: {
@@ -87,6 +88,7 @@ export const options = {
     "order_failures{scenario:order_create}": ["rate<0.01"],
     "payment_failures{scenario:payment_replay}": ["rate<0.01"],
     "webhook_failures{scenario:webhook_rejection}": ["rate<0.01"],
+    "webhook_signature_rejections{scenario:webhook_rejection}": ["count>0"],
     "http_req_duration{scenario:catalog_browse}": ["p(95)<500", "p(99)<1000"],
     "http_req_duration{scenario:order_create}": ["p(95)<1000", "p(99)<2000"],
     "http_req_duration{scenario:payment_replay}": ["p(95)<750", "p(99)<1500"],
@@ -184,10 +186,13 @@ export function webhookRejection() {
         "paypal-cert-url": "https://example.invalid/cert.pem",
         "paypal-auth-algo": "SHA256withRSA",
       },
-      [401]
+      [401, 429]
     )
   );
-  const ok = check(response, { "invalid webhook is rejected": (r) => r.status === 401 });
+  if (response.status === 401) webhookSignatureRejections.add(1);
+  const ok = check(response, {
+    "invalid webhook is safely rejected": (r) => r.status === 401 || r.status === 429,
+  });
   webhookFailures.add(!ok);
 }
 


### PR DESCRIPTION
## Root cause

Controlled run #34401998825 executed 600 invalid-signature webhook requests at 20 RPS.

The production API limiter allows 100 requests per client / 15 minutes. Therefore:
- initial requests reached webhook verification and returned `401`;
- subsequent requests were safely rejected earlier by the global rate limiter with `429`;
- post-run invariant validation confirmed zero webhook business events.

The harness incorrectly treated every `429` as a webhook failure.

## Fix

- accept only `401` or `429` as safe webhook rejection outcomes
- keep all other statuses as failures
- add `webhook_signature_rejections` counter
- require `webhook_signature_rejections > 0` so every successful run proves the signature verifier itself was exercised at least once
- retain the SQL invariant requiring zero persisted webhook business events
- document the two valid security boundaries

No rate-limit bypass, signature weakening, runtime change, or provider call is introduced.

After merge, rerun one `webhook_rejection` probe.