### PR TITLE
fix(performance): pace payment replay below API limiter

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -175,7 +175,7 @@ jobs:
                 'LOAD_COOLDOWN_DURATION=15s' 'LOAD_PREALLOCATED_VUS=20' 'LOAD_MAX_VUS=100' >> "$GITHUB_ENV"
               ;;
             orders) printf '%s\n' 'ALLOW_WRITES=true' 'LOAD_VUS=5' 'LOAD_MAX_DURATION=2m' >> "$GITHUB_ENV" ;;
-            payment_replay) printf '%s\n' 'LOAD_VUS=2' 'LOAD_DURATION=30s' >> "$GITHUB_ENV" ;;
+            payment_replay) printf '%s\n' 'LOAD_TARGET_RPS=2' 'LOAD_DURATION=30s' 'LOAD_PREALLOCATED_VUS=2' 'LOAD_MAX_VUS=5' >> "$GITHUB_ENV" ;;
             webhook_rejection)
               printf '%s\n' 'LOAD_DURATION=30s' 'LOAD_PREALLOCATED_VUS=5' 'LOAD_MAX_VUS=20' >> "$GITHUB_ENV"
               ;;

--- a/load-tests/k6/neon-arsenal.js
+++ b/load-tests/k6/neon-arsenal.js
@@ -56,10 +56,13 @@ const profiles = {
   },
   payment_replay: {
     payment_replay: {
-      executor: "constant-vus",
+      executor: "constant-arrival-rate",
       exec: "paymentReplay",
-      vus: intEnv("LOAD_VUS", 2),
+      rate: intEnv("LOAD_TARGET_RPS", 2),
+      timeUnit: "1s",
       duration: __ENV.LOAD_DURATION || "30s",
+      preAllocatedVUs: intEnv("LOAD_PREALLOCATED_VUS", 2),
+      maxVUs: intEnv("LOAD_MAX_VUS", 5),
     },
   },
   webhook_rejection: {


### PR DESCRIPTION
## Root cause

Controlled payment_replay run #34419424044 successfully prepared and preflighted the replay fixtures, and post-run invariants passed with no PayPal/provider side effects.

The k6 workload itself used unpaced `constant-vus`:
- 2 VUs
- ~2,070 req/s
- >62k requests in 30 seconds

The production API limiter is 100 requests / 15 minutes per client, so after the initial valid replays almost all requests were rejected with `429`. The harness correctly failed its replay checks, but the workload shape was invalid for the purpose of this profile.

## Fix

- change payment_replay to `constant-arrival-rate`
- default to 2 requests/second for 30 seconds
- preallocate 2 VUs, max 5
- keep the existing preflight requiring an already-known PayPal order id
- keep provider egress blocked
- do NOT treat 429 as replay success

This profile remains correctness/idempotency evidence, not PayPal or payment throughput capacity evidence.

No runtime, API, rate-limit, payment, or provider semantics change.

After merge, rerun one `payment_replay` probe.