### PR TITLE
fix(performance): isolate catalog capacity from per-client quota

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -60,6 +60,7 @@ jobs:
       POSTGRES_IMAGE: postgres:16-alpine
       API_IMAGE: neon-arsenal-loadtest:${{ github.sha }}
       K6_IMAGE: grafana/k6:2.2.0
+      CATALOG_BENCHMARK_RATE_LIMIT_MAX: 100000
       API_CONTAINER: neon-arsenal-api
       POSTGRES_CONTAINER: neon-arsenal-postgres
       LOAD_NETWORK: neon-arsenal-loadtest
@@ -288,6 +289,10 @@ jobs:
           api_image_id=$(docker image inspect --format '{{.Id}}' "$API_IMAGE")
           postgres_image_id=$(docker image inspect --format '{{.Id}}' "$POSTGRES_IMAGE")
           k6_image_id=$(docker image inspect --format '{{.Id}}' "$K6_IMAGE")
+          effective_api_rate_limit="production-default"
+          if [[ "$LOAD_PROFILE" == "catalog" ]]; then
+            effective_api_rate_limit="$CATALOG_BENCHMARK_RATE_LIMIT_MAX"
+          fi
           node_version=$(docker run --rm --entrypoint node "$API_IMAGE" --version)
           postgres_version=$(docker exec "$POSTGRES_CONTAINER" psql -X -A -t -U neon -d neon_arsenal_loadtest -c 'SHOW server_version')
           api_limits=$(docker inspect --format '{{json .HostConfig}}' "$API_CONTAINER" | jq '{NanoCpus, Memory, MemorySwap, RestartPolicy}')
@@ -313,7 +318,7 @@ jobs:
             --arg startUtc "$(cat "$ARTIFACT_DIR/start-utc.txt" 2>/dev/null || echo unavailable)" \
             --arg endUtc "$(cat "$ARTIFACT_DIR/end-utc.txt" 2>/dev/null || echo unavailable)" \
             --arg apiImage "$API_IMAGE" --arg apiImageId "$api_image_id" --arg postgresImage "$POSTGRES_IMAGE" \
-            --arg postgresImageId "$postgres_image_id" --arg k6Image "$K6_IMAGE" --arg k6ImageId "$k6_image_id" --arg nodeVersion "$node_version" \
+            --arg postgresImageId "$postgres_image_id" --arg k6Image "$K6_IMAGE" --arg k6ImageId "$k6_image_id" --arg apiRateLimitMax "$effective_api_rate_limit" --arg nodeVersion "$node_version" \
             --arg postgresVersion "$postgres_version" --arg postgresMaxConnections "$POSTGRES_MAX_CONNECTIONS" \
             --arg postgresSharedBuffers "$POSTGRES_SHARED_BUFFERS" \
             --arg k6Version "$(cat "$ARTIFACT_DIR/k6-version.txt" 2>/dev/null || echo unavailable)" \
@@ -327,7 +332,7 @@ jobs:
               workload: {profile: $profile, offeredRps: ($targetRps | tonumber), orderListingCount: ($orderListingCount | tonumber)},
               api: {image: $apiImage, imageId: $apiImageId, nodeVersion: $nodeVersion, replicas: 1, limits: $apiLimits, finalState: $apiState},
               postgres: {image: $postgresImage, imageId: $postgresImageId, version: $postgresVersion, maxConnections: ($postgresMaxConnections | tonumber), sharedBuffers: $postgresSharedBuffers, limits: $postgresLimits},
-              dataset: $dataset, k6: {image: $k6Image, imageId: $k6ImageId, version: $k6Version},
+              dataset: $dataset, apiRateLimitMax: $apiRateLimitMax, k6: {image: $k6Image, imageId: $k6ImageId, version: $k6Version},
               externalNetwork: "API, PostgreSQL, and k6 run only on the internal Docker network; provider egress is unavailable."
             }' > "$ARTIFACT_DIR/environment.json"
 

--- a/docs/operations/load-test-ci.md
+++ b/docs/operations/load-test-ci.md
@@ -49,3 +49,12 @@ The workflow uploads evidence before enforcing the final k6-threshold and invari
 Successful three-run bundles can support an environment-qualified controlled CI capacity statement. They are **not** a Render or production capacity claim: GitHub runner CPU/network, host contention, and local loopback traffic differ from a public deployment. A material spread between equivalent repetitions means runner variability or another unknown is unresolved; report it and do not claim a stable point.
 
 Do not use these results to justify Redis, SQS/Kafka or AWS. Revisit those only after a concrete production constraint exists. If a real deployed capacity test becomes necessary later, provision a dedicated paid/free provider environment only after deciding its budget and observability requirements.
+
+
+### Catalog benchmark and the production per-client limiter
+
+The `catalog` profile measures the read hot path and PostgreSQL capacity, not the public per-client request quota. The production default limiter (`100 requests / 15 minutes`) would otherwise terminate every sustained catalog probe from the single k6 source IP before backend capacity is exercised.
+
+Only for `LOAD_PROFILE=catalog` in this disposable internal CI environment, the workflow sets `RATE_LIMIT_API_MAX=100000`. The value is recorded in the evidence metadata. Other profiles keep the production limiter behavior unchanged.
+
+A catalog result therefore means **controlled CI API + PostgreSQL hot-path capacity with the per-client quota lifted for measurement**. It is not evidence that a single production client is permitted to send that request rate, and it is not Render/production capacity.

--- a/docs/performance/load-testing.md
+++ b/docs/performance/load-testing.md
@@ -70,3 +70,8 @@ After evidence exists, compare the bottleneck to `docs/architecture/scaling-path
 - Kafka requires an independently demonstrated ordering, replay, partition-throughput, or multi-consumer requirement. SQS remains the current backlog candidate; do not substitute Kafka by name alone.
 
 Use `docs/performance/load-test-report-template.md` for every accepted run.
+
+
+### Interpreting catalog probes
+
+For isolated catalog capacity probes, the harness may raise the configurable per-client API limiter ceiling so the limiter does not become the measurement boundary before the catalog/API/PostgreSQL hot path is exercised. Any such override must be isolated to the disposable benchmark environment, recorded with the run evidence, and must not be interpreted as a production client quota or as a weakening of the deployed security policy.


### PR DESCRIPTION
## Root cause

Catalog probe #34421156122 at target 20 RPS did not hit backend capacity.

Observed:
- 1,724 requests
- 0 dropped iterations
- p95 ~4.34 ms
- p99 ~5.99 ms
- ~94% HTTP failure rate

The production API limiter is 100 requests / 15 minutes per client. k6 uses one source IP, so after the first ~100 requests the benchmark measured 429s instead of catalog/API/PostgreSQL capacity.

## Fix

- keep the production limiter behavior unchanged for smoke, orders, payment_replay and webhook_rejection
- only for the disposable isolated `catalog` benchmark, set a bounded high `RATE_LIMIT_API_MAX=100000`
- record the effective limiter ceiling in environment evidence
- document that catalog results measure the API + PostgreSQL hot path with the per-client quota lifted for measurement
- explicitly state this is not a production client quota and not Render/production capacity

We do NOT accept 429 as a successful catalog response.

No application/runtime/schema business behavior changes.

After merge, rerun catalog at 20 RPS, repetition 1.