### PR TITLE
fix(performance): pass catalog limiter override into API container

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -120,6 +120,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          catalog_rate_limit_args=()
+          if [[ "$LOAD_PROFILE" == "catalog" ]]; then
+            catalog_rate_limit_args+=(--env "RATE_LIMIT_API_MAX=$CATALOG_BENCHMARK_RATE_LIMIT_MAX")
+          fi
+
           docker run --detach \
             --name "$API_CONTAINER" \
             --network "$LOAD_NETWORK" \
@@ -135,6 +140,7 @@ jobs:
             --env JWT_SECRET=ephemeral-load-test-access-secret \
             --env JWT_REFRESH_SECRET=ephemeral-load-test-refresh-secret \
             --env PAYPAL_WEBHOOK_ID=controlled-ci-invalid-signature-only \
+            "${catalog_rate_limit_args[@]}" \
             "$API_IMAGE"
 
       - name: Wait for API readiness


### PR DESCRIPTION
## Root cause

Catalog rerun #34422509506 still failed with the production 100/15m client quota.

The previous PR added the benchmark ceiling and evidence metadata, but the actual API `docker run` command did not receive `RATE_LIMIT_API_MAX`. The job log confirms the variable was present in the workflow environment but absent from the container invocation.

## Fix

For `LOAD_PROFILE=catalog` only:
- build a Docker env arg for `RATE_LIMIT_API_MAX=$CATALOG_BENCHMARK_RATE_LIMIT_MAX`
- pass that arg explicitly into the API container

Other profiles receive no override.

No application/runtime/schema/security-policy code changes.

After merge, rerun catalog at 20 RPS, repetition 1.