### PR TITLE
fix(performance): restore registered k6 workflow

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -33,51 +33,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  prepare:
-    name: Freeze load-test images
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    env:
-      API_IMAGE: neon-arsenal-loadtest:${{ github.sha }}
-      POSTGRES_IMAGE: postgres:16-alpine
-      K6_IMAGE: grafana/k6:2.2.0
-    outputs:
-      postgres_image: ${{ steps.freeze.outputs.postgres_image }}
-      k6_image: ${{ steps.freeze.outputs.k6_image }}
-      api_image_id: ${{ steps.freeze.outputs.api_image_id }}
-    steps:
-      - name: Checkout exact revision
-        uses: actions/checkout@v7
-      - name: Build and freeze production API image
-        id: freeze
-        shell: bash
-        run: |
-          set -euo pipefail
-          docker build --pull --tag "$API_IMAGE" server
-          api_image_id=$(docker image inspect --format '{{.Id}}' "$API_IMAGE")
-          docker save "$API_IMAGE" --output api-image.tar
-          docker pull "$POSTGRES_IMAGE"
-          postgres_image=$(docker image inspect --format '{{index .RepoDigests 0}}' "$POSTGRES_IMAGE")
-          docker pull "$K6_IMAGE"
-          k6_image=$(docker image inspect --format '{{index .RepoDigests 0}}' "$K6_IMAGE")
-          {
-            echo "api_image_id=$api_image_id"
-            echo "postgres_image=$postgres_image"
-            echo "k6_image=$k6_image"
-          } >> "$GITHUB_OUTPUT"
-      - name: Upload frozen API image
-        uses: actions/upload-artifact@v4
-        with:
-          name: controlled-ci-api-image-${{ github.run_id }}-${{ github.run_attempt }}
-          path: api-image.tar
-          if-no-files-found: error
-          retention-days: 1
-
   k6:
     name: k6 (${{ inputs.profile }}, repetition ${{ matrix.repetition }})
-    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -100,9 +57,9 @@ jobs:
       POSTGRES_MEMORY_LIMIT: 1g
       POSTGRES_MAX_CONNECTIONS: "100"
       POSTGRES_SHARED_BUFFERS: 256MB
-      POSTGRES_IMAGE: ${{ needs.prepare.outputs.postgres_image }}
+      POSTGRES_IMAGE: postgres:16-alpine
       API_IMAGE: neon-arsenal-loadtest:${{ github.sha }}
-      K6_IMAGE: ${{ needs.prepare.outputs.k6_image }}
+      K6_IMAGE: grafana/k6:2.2.0
       CATALOG_BENCHMARK_RATE_LIMIT_MAX: 100000
       API_CONTAINER: neon-arsenal-api
       POSTGRES_CONTAINER: neon-arsenal-postgres
@@ -124,20 +81,12 @@ jobs:
           echo "ARTIFACT_DIR=artifacts/k6/$run_id" >> "$GITHUB_ENV"
           mkdir -p "artifacts/k6/$run_id"
 
-      - name: Load frozen production API image
-        uses: actions/download-artifact@v4
-        with:
-          name: controlled-ci-api-image-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .load-test-image
-      - name: Verify frozen production API image
+      - name: Build production API image
         shell: bash
         run: |
           set -euo pipefail
-          docker load --input .load-test-image/api-image.tar
-          actual_api_image_id=$(docker image inspect --format '{{.Id}}' "$API_IMAGE")
-          expected_api_image_id='${{ needs.prepare.outputs.api_image_id }}'
-          [[ "$actual_api_image_id" == "$expected_api_image_id" ]]
-          printf '%s\n' "$actual_api_image_id" > "$ARTIFACT_DIR/api-image-id.txt"
+          docker build --pull --tag "$API_IMAGE" server
+          docker image inspect --format '{{.Id}}' "$API_IMAGE" > "$ARTIFACT_DIR/api-image-id.txt"
 
       - name: Start isolated PostgreSQL 16
         shell: bash
@@ -398,7 +347,7 @@ jobs:
         shell: bash
         run: |
           {
-            echo "## Controlled CI k6 evidence  ${LOAD_PROFILE}  repetition ${{ matrix.repetition }}"
+            echo "## Controlled CI k6 evidence — ${LOAD_PROFILE} — repetition ${{ matrix.repetition }}"
             echo
             echo "This is not Render or production capacity. GitHub-hosted runner variability remains explicit."
             echo

--- a/docs/operations/load-test-ci.md
+++ b/docs/operations/load-test-ci.md
@@ -7,9 +7,8 @@ This is the executable path for issue #55 without a cloud account, external cred
 - The API is the production image built from `server/Dockerfile`, limited to 1 CPU and 512 MiB, with one replica and `NODE_ENV=production`.
 - PostgreSQL uses `postgres:16-alpine`, limited to 1 CPU and 1 GiB, with `max_connections=100` and `shared_buffers=256MB`.
 - API, PostgreSQL, and k6 use the same per-job internal Docker network. The API is not published to the runner host; the containers have no provider egress.
-- A preparation job builds the production API image once per workflow dispatch, saves that exact image as a short-lived workflow artifact, and resolves PostgreSQL/k6 to immutable digest references. Every repetition loads/pulls those frozen artifacts instead of rebuilding or re-resolving mutable tags independently.
 - Every repetition starts a fresh PostgreSQL container, applies migrations, seeds the demo catalog, and creates equivalent disposable fixtures. API readiness is checked from inside the API container so the workflow does not depend on host port publishing.
-- k6 runs from the same resolved image digest on the same internal Docker network. Its CPU still shares the GitHub-hosted runner with the API/PostgreSQL containers, so noisy-neighbor variability remains a material uncertainty in cross-workflow comparisons.
+- k6 runs as a pinned container on the same internal Docker network. Its CPU still shares the GitHub-hosted runner with the API/PostgreSQL containers, so noisy-neighbor variability remains a material uncertainty in cross-workflow comparisons.
 
 No GitHub Environment, external URL, PayPal credential, Blueprint, Vercel configuration, Render configuration, or card is required.
 
@@ -26,7 +25,7 @@ No GitHub Environment, external URL, PayPal credential, Blueprint, Vercel config
 2. Go to **Actions → Controlled CI k6 evidence → Run workflow**.
 3. Select one of all five profiles. Use one repetition while proving connectivity and selecting a stable catalog offered rate.
 4. For catalog, raise `target_rps` in separate one-run probes until a threshold, errors, dropped iterations, API/container limit, PostgreSQL signal, or runner/client limit identifies the knee. Offered RPS is configuration; achieved RPS is `http_reqs.rate` in the k6 summary.
-5. Once a stable point is selected, dispatch with exactly three repetitions. The matrix runs serially at the same commit and input configuration, with a fresh equivalent dataset per repetition. The preparation job must succeed first so all repetitions load the same frozen API image ID and use the same resolved PostgreSQL/k6 digests. Confirm the recorded image IDs, versions, limits and dataset cardinalities still match before treating the set as equivalent.
+5. Once a stable point is selected, dispatch with exactly three repetitions. The matrix runs serially at the same commit and input configuration, with a fresh equivalent dataset per repetition. Before treating them as equivalent, confirm the recorded API/PostgreSQL image IDs, versions, limits and dataset cardinalities match; mutable upstream base-image tags can otherwise invalidate the set.
 6. Download all three artifacts and complete `docs/performance/load-test-report-template.md`. Report each run, median statistics, worst error rate, dropped iterations, variability, first bottleneck and residual uncertainty.
 
 Run all five profiles at least once before evaluating SPEC-0009 AC-07. Do not mark AC-07 complete in the enablement PR; only subsequent successful workflow artifacts can supply that evidence.


### PR DESCRIPTION
## Problem

PR #237 introduced a workflow-definition error. GitHub stopped registering the workflow as **Controlled CI k6 evidence** and instead emitted a failed run named after the raw workflow path with zero jobs.

## Fix

Restore the last known-valid `.github/workflows/load-test.yml` and matching runbook text from commit `fb54772e1c818ae07603288214e62e0df213eb6d`.

## Scope

Emergency restoration only. No runtime, API, schema, payment, deployment, or rate-limit behavior changes.

The image-freezing reproducibility improvement from #237 will be reimplemented separately after workflow registration is restored and validated.