### PR TITLE
docs(performance): close reproducible k6 capacity evidence

### DIFF
--- a/docs/architecture/capacity.md
+++ b/docs/architecture/capacity.md
@@ -1,27 +1,57 @@
-# Capacity hypotheses and scale model
+# Capacity evidence and scale model
 
-Issue #74. These are **hypotheses** for a portfolio/demo marketplace on Render, tied to measurements that already exist. They are **not** k6 results. Issue #55 (load testing) is not done; do not invent RPS, p95-under-load, or error-rate numbers.
+Issue #74. This document separates **measured controlled-CI evidence** from deployment hypotheses. The k6 result below is not Render or production capacity; it describes a bounded GitHub Actions topology using the production Docker image.
 
-Evidence that **is** in-repo:
+Evidence in the repository:
 
-- `docs/performance.md` — `EXPLAIN ANALYZE` + `listingsService.list` timings at 2 500 `ACTIVE` listings (`cd server && npm run perf:evidence`)
-- `docs/architecture/scaling-path.md` — measured triggers; explicit non-goals (Redis/Kafka/SQS)
-- `docs/adr/0006-hot-path-indexes.md` — why those indexes exist
-- `render.yaml` — one Docker API + one managed PostgreSQL (ADR 0007)
+- `docs/performance/load-test-report-2026-09-10-catalog.md` — reproducible controlled-CI catalog capacity evidence from three equivalent k6 repetitions.
+- `docs/performance.md` — `EXPLAIN ANALYZE` + `listingsService.list` timings at 2,500 `ACTIVE` listings (`cd server && npm run perf:evidence`).
+- `docs/architecture/scaling-path.md` — measured triggers and explicit non-goals (Redis/Kafka/SQS).
+- `docs/adr/0006-hot-path-indexes.md` — why the hot-path indexes exist.
+- `render.yaml` — one Docker API + one managed PostgreSQL (ADR 0007).
 
-## Hypotheses (planning, not SLOs)
+## Measured controlled-CI catalog capacity
 
-| Dimension | Hypothesis | What we actually measured |
+On commit `87c73d3ee974d1de92a0bce4c4369bb7be806e1b`, workflow run `34439840030` executed three serial equivalent catalog repetitions with the exact same frozen API image.
+
+Controlled topology:
+
+- API: one production container, `1 CPU`, `512 MiB`, `NODE_ENV=production`.
+- PostgreSQL 16: `1 CPU`, `1 GiB`, `max_connections=100`, `shared_buffers=256MB`.
+- k6: `grafana/k6:2.2.0` on the same GitHub-hosted worker, API/PostgreSQL traffic on an internal no-egress Docker network.
+- Catalog benchmark only: the per-client production quota is lifted inside the disposable environment (`RATE_LIMIT_API_MAX=100000`) so the API/PostgreSQL hot path is measured. The deployed production default is unchanged.
+
+The catalog profile ramps from 5 to 150 RPS for 30 seconds, holds **150 RPS for 60 seconds**, then cools down for 15 seconds. All three repetitions completed with zero HTTP failures and zero dropped iterations:
+
+| Run | p50 | p95 | p99 | API CPU peak | PG CPU peak |
+|---|---:|---:|---:|---:|---:|
+| 1 | 4.32 ms | 6.08 ms | 10.81 ms | 72.74% | 11.18% |
+| 2 | 4.13 ms | 5.81 ms | 12.27 ms | 67.06% | 12.35% |
+| 3 | 4.31 ms | 6.01 ms | 11.82 ms | 67.27% | 12.46% |
+
+The whole-run `http_reqs.rate` is about `118.56 RPS` because it includes ramp-up and cooldown; it is not the hold rate. k6 execution logs show the configured 60-second hold at `150.00 iterations/s`.
+
+Qualification intentionally went beyond this point. A single 200-RPS-target probe happened to pass, but a later three-repetition 200-RPS set was not reproducible: all repetitions crossed the latency threshold and dropped iterations. Targets 205, 210, 225, 250, 300 and 400 also saturated. Correlated evidence at the failed 200-RPS boundary showed the API consuming approximately its full 1-CPU budget while PostgreSQL remained in the low-teens CPU range, without deadlocks, OOM or API restarts.
+
+**First measured bottleneck:** API CPU under the 1-CPU controlled-CI limit. The evidence does not identify PostgreSQL, the network, or the public per-client limiter as the first capacity bottleneck for this isolated catalog benchmark.
+
+Qualified statement:
+
+> In the controlled GitHub Actions topology, one production API container limited to 1 CPU/512 MiB sustained a 150-RPS catalog hold for 60 seconds in three equivalent repetitions, with 0 HTTP failures, 0 dropped iterations, p95 5.81–6.08 ms and p99 10.81–12.27 ms. This is controlled-CI evidence, not Render or production capacity.
+
+## Remaining deployment hypotheses
+
+| Dimension | Current position | Evidence / uncertainty |
 |---|---|---|
-| Users | Single-operator demo: tens of concurrent browsers, not a claimed MAU | None. No analytics-backed user count in this repo. |
-| RPS | Browse-dominated. Checkout and webhooks are rare relative to `GET /listings`. A single Render instance is assumed enough until a **measured** listing p95 or CPU trigger fires | No k6. Listing list p95 **~4 ms** on the evidence VM at 2.5k rows — that is query time, not offered load |
-| Read / write mix | ~browse/PDP reads vs reserve/payment writes. Writes are PK/conditional updates, not scans | Hot-path table in `docs/performance.md`. Write cost is the listing row lock, not a sequential scan |
-| Catalog size | Comfortable at a few thousand `ACTIVE` listings (current evidence set). Re-run `perf:evidence` after ~10× growth | 2 500 `ACTIVE` + 80 `RESERVED` + 80 `SOLD` in the evidence fixture |
-| Checkout concurrency | Unique listings: N buyers on the **same** listing → one `ACTIVE → RESERVED` winner. Buyers on **different** listings contend on different rows | Integration tests for concurrent reserve; not a load-test RPS |
-| PostgreSQL connections | Prisma default pool is roughly `num_physical_cpus * 2 + 1` per API process (no `connection_limit` in `DATABASE_URL` today; do not add an env var here). Render current-gen Postgres **under 8 GB RAM** typically allows **100** connections. `replicas × pool` must stay under that, plus one for migrations/ops | No production `pg_stat_activity` capture in-repo |
-| Events | Webhook + reconcile volume ≈ captured checkouts. Sweeps: expiry 30s; PayPal GET batch 20 / 60s; ledger 60s; outbox skip-locked | Intervals from ADR 0001 / 0002 / 0011 / 0012, not event-bus throughput |
+| Users | Single-operator portfolio/demo; no MAU/concurrency claim | No analytics-backed user count. |
+| Render RPS | No production RPS claim. Controlled CI demonstrates the bounded result above only | Render CPU scheduling, network, cold starts and managed PostgreSQL differ from GitHub Actions. |
+| Read / write mix | Browse/PDP reads are expected to dominate reserve/payment writes | Catalog has measured load evidence; write throughput is not published as a capacity number. |
+| Catalog size | Comfortable at a few thousand `ACTIVE` listings in the current evidence fixture; re-run after roughly 10× growth | Existing query-plan fixture has 2,500 `ACTIVE` + 80 `RESERVED` + 80 `SOLD`. |
+| Checkout concurrency | Same listing → one `ACTIVE → RESERVED` winner; different listings contend on different rows | Integration tests prove correctness; no checkout RPS claim is published. |
+| PostgreSQL connections | Replica count × client pool must retain connection headroom | Controlled catalog evidence peaked at 6 PostgreSQL connections in the bounded topology; production pool/host behavior still needs deployment observation. |
+| Events | Webhook + reconcile volume tracks captured checkouts; sweeps remain database-coordinated | Intervals come from ADR 0001 / 0002 / 0011 / 0012, not an event-bus throughput benchmark. |
 
-## Scale-out (what we will actually do)
+## Scale-out path
 
 ```text
 Internet → N × Render web instances (same Docker image)
@@ -29,14 +59,14 @@ Internet → N × Render web instances (same Docker image)
                 → PayPal / Resend
 ```
 
-1. **API:** add Render instances of `neon-arsenal-api`. Invariants live in PostgreSQL, so replicas are safe (duplicate in-process timers are no-ops).
-2. **PostgreSQL:** stay on one primary. The ceiling is **connections and row locks**, not “add Kafka.” If lock waits dominate on **different** listings, more API replicas + watching the connection budget is the first move (`scaling-path.md`).
-3. **Do not** add Redis, Kafka, SQS, a worker service, or read replicas for correctness.
+1. **API:** if deployed evidence shows CPU saturation similar to controlled CI, test more API CPU or additional Render instances first. The correctness invariants live in PostgreSQL, so replicas do not require Redis for correctness.
+2. **PostgreSQL:** stay on one primary until measured connection, lock, I/O or query evidence says otherwise. Additional API replicas must preserve connection-budget headroom.
+3. **Do not** add Redis, Kafka, SQS, a worker service, or read replicas solely because the catalog benchmark found an API-CPU ceiling.
 
-Free Render web instances spin down after ~15 minutes idle; a sleeping instance cannot sweep until the next request (`docs/operations/runbook.md`). That is an operational limit, not a capacity number.
+Free Render web instances may sleep while idle; that is an operational deployment characteristic, not a capacity result.
 
-## When to replace hypotheses with measurements
+## When to run the next capacity experiment
 
-Run issue #55 with the committed harness and procedure in `load-tests/k6/` and `docs/performance/load-testing.md` against a production-like API + Postgres **before** quoting RPS targets in SLOs. Until then, operators use `docs/operations/slos.md` (instrument-based) and `docs/performance.md` (plan shape), not invented load-test tables.
+Re-run controlled evidence when application behavior, Node/runtime image, database shape, catalog cardinality or relevant hot-path code changes materially. For a **Render/production capacity** number, run an explicitly approved deployed benchmark with provider/resource evidence and a separate report; never relabel this GitHub-hosted result.
 
-If `GET /listings` p95 exceeds ~50 ms with an EXPLAIN that blames `COUNT(*)` or deep `OFFSET`, follow `scaling-path.md` (cursor mode is already shipped). That still does not justify Redis (ADR 0018).
+If higher catalog throughput becomes a concrete requirement, the lowest-complexity next experiment is more API CPU/replicas while observing PostgreSQL connections and waits. Redis, brokers or read replicas require their own measured trigger and ADR review.

--- a/docs/performance/load-test-report-2026-09-10-catalog.md
+++ b/docs/performance/load-test-report-2026-09-10-catalog.md
@@ -1,0 +1,92 @@
+# Load-test report — 2026-09-10 — catalog
+
+Evidence class: controlled CI capacity evidence
+
+This report is **not Render or production capacity**. It describes one explicitly bounded GitHub-hosted CI topology. The catalog-only benchmark lifts the public per-client API quota inside the disposable no-egress environment so the API/PostgreSQL hot path, rather than the single-source-IP quota, is measured.
+
+## Identity
+
+- Git SHA: `87c73d3ee974d1de92a0bce4c4369bb7be806e1b`
+- Workflow run: `34439840030` — `Controlled CI catalog claim evidence`
+- Frozen API image ID, identical in all three repetitions: `sha256:0f301df67fd9d92e8f703d7c9f2c28d695694a45ce4bf0800a1a09e6bfd484eb`
+- Frozen API artifact digest: `sha256:90a9590a5294a16448f2fda5e4fb850b0b9c7265ecd85541ad5278fce2bc1a3c`
+- PostgreSQL image ID, identical in all three repetitions: `sha256:75f5a96988cdf694a215073c3e9c001b706b371e2f94df3967f2efdec2787f6b`
+- k6 image ID, identical in all three repetitions: `sha256:00cfdae7945825029ce3270b3479992e411f309c2dc968820543d2183d0bbe5e`
+- Operator: GitHub Actions `workflow_dispatch`
+
+## Environment
+
+- API: one production Docker image replica, `NODE_ENV=production`, `1.0 CPU`, `512 MiB` memory.
+- PostgreSQL: `postgres:16-alpine`, `1.0 CPU`, `1 GiB` memory, `max_connections=100`, `shared_buffers=256MB`.
+- k6: `grafana/k6:2.2.0`, co-located on the GitHub-hosted runner but outside the API container CPU/memory limits.
+- Network: API, PostgreSQL and k6 on an internal Docker network; no provider egress and no host-published API port.
+- Dataset: fresh seeded database and equivalent disposable fixture shape for each repetition; catalog invariant verification retained 20 disposable `ACTIVE` listings and observed no order or webhook side effect.
+- Catalog benchmark rate-limit override: `RATE_LIMIT_API_MAX=100000` only inside this isolated benchmark. This does not change the deployed production default or authorize a client to send this rate publicly.
+- Runner uncertainty: GitHub-hosted runner allocation remains external to the repository. The repetitions nevertheless stayed close despite running on separate hosted workers; this is controlled-CI evidence, not a hardware certification.
+
+## Workload
+
+- Profile: `catalog` / `catalog_browse`.
+- Endpoint: existing `GET /api/v1/listings?cursor=&limit=20` path.
+- Executor: ramping arrival rate.
+- Start: `5 RPS`.
+- Ramp: `30s` to `150 RPS`.
+- Hold: `60s` at `150 RPS`.
+- Cooldown: `15s` to zero.
+- k6 allocation: `20` preallocated VUs, `100` maximum VUs.
+- Mutation: none through the API. Disposable fixtures exist only to keep invariant checks equivalent to the general harness.
+
+The `http_reqs.rate` below is the average across ramp + hold + cooldown. It is therefore approximately `118.56 RPS`; it must not be confused with the `150 RPS` sustained hold target. The execution logs show the 60-second hold maintaining `150.00 iterations/s` with no dropped iterations.
+
+## Equivalent repetitions
+
+| Repetition | Requests | Global avg RPS | p50 | p95 | p99 | HTTP failures | Dropped |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 12,449 | 118.56 | 4.32 ms | 6.08 ms | 10.81 ms | 0% | 0 |
+| 2 | 12,450 | 118.56 | 4.13 ms | 5.81 ms | 12.27 ms | 0% | 0 |
+| 3 | 12,449 | 118.56 | 4.31 ms | 6.01 ms | 11.82 ms | 0% | 0 |
+| Median | — | 118.56 | 4.31 ms | 6.01 ms | 11.82 ms | 0% | 0 |
+
+Thresholds remained green in all three repetitions (`catalog` p95 `<500 ms`, p99 `<1000 ms`, checks/failure guardrails). The small percentile spread, zero failures and zero drops support treating this point as reproducible within this controlled CI environment.
+
+## Correlated resource evidence
+
+Each repetition captured 18 synchronized two-second resource samples over the k6 window.
+
+| Repetition | API CPU median / max | API container memory median / max | API RSS median / max | PG CPU median / max | PG max connections | PG max active | PG max waiting | Deadlocks |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 59.13% / 72.74% | 43.29 / 43.96 MiB | 95.67 / 96.11 MiB | 7.12% / 11.18% | 6 | 1 | 5 | 0 |
+| 2 | 57.29% / 67.06% | 43.35 / 44.75 MiB | 95.64 / 96.02 MiB | 6.12% / 12.35% | 6 | 1 | 5 | 0 |
+| 3 | 59.37% / 67.27% | 43.38 / 43.76 MiB | 95.73 / 95.94 MiB | 7.07% / 12.46% | 6 | 1 | 5 | 0 |
+
+The PostgreSQL `waiting` samples are not evidence of lock contention by themselves: idle connections can report wait events while waiting for client activity. The post-run snapshots and counters recorded zero deadlocks, and the healthy 150-RPS runs show no latency or throughput symptom consistent with a database bottleneck.
+
+## Invariant verification
+
+All three repetitions passed the post-run invariant gate:
+
+- all 20 disposable order-test listings remained `ACTIVE`;
+- zero orders consumed those listings;
+- zero unexpected webhook events were persisted;
+- no seller/payment side effect was created by the read-only catalog traffic.
+
+## Boundary experiments and first bottleneck
+
+The qualification process deliberately tested beyond the stable point before committing a number. A single earlier 200-RPS-target probe passed, but a subsequent three-repetition set at the same target was **not reproducible**: all three runs crossed the catalog latency threshold and dropped iterations. Targets `205`, `210`, `225`, `250`, `300` and `400` also showed saturation.
+
+At the failed 200-RPS three-run boundary, the API consumed approximately its full `1 CPU` container budget while PostgreSQL remained around the low-teens CPU range, with no deadlocks, OOM or API restart. The first observed bottleneck is therefore **API CPU under the 1-CPU controlled-CI limit**, not PostgreSQL capacity.
+
+This evidence does not justify Redis, Kafka, SQS, read replicas or a database change. If a higher catalog rate is required in a comparable topology, the lowest-complexity next experiment is additional API CPU/replicas while retaining PostgreSQL connection-budget observation.
+
+## Qualified capacity statement
+
+> In the controlled GitHub Actions topology — one production API container limited to 1 CPU/512 MiB and PostgreSQL limited to 1 CPU/1 GiB — the catalog workload sustained its configured **150 RPS hold for 60 seconds** in three serial equivalent repetitions using the exact same frozen API image. All three runs had **0 HTTP failures**, **0 dropped iterations**, p95 between **5.81–6.08 ms**, and p99 between **10.81–12.27 ms**. API CPU peaked between **67.06–72.74%** at this qualified point. This is controlled-CI evidence, not Render or production capacity.
+
+## Artifacts
+
+- Workflow run: `https://github.com/Bruno2K/neon-arsenal-market/actions/runs/34439840030`
+- Repetition 1 artifact: `catalog-claim-r1-34439840030-1` (`10137599050`)
+- Repetition 2 artifact: `catalog-claim-r2-34439840030-1` (`10137661550`)
+- Repetition 3 artifact: `catalog-claim-r3-34439840030-1` (`10137722220`)
+- Frozen API image artifact: `catalog-claim-api-image-34439840030-1` (`10137539189`)
+- Each repetition includes k6 summary/inspect output, synchronized resource samples, PostgreSQL pre/post snapshots, API/PostgreSQL logs, image IDs, exact commit, resource limits and invariant output.

--- a/docs/plans/PLAN-0006-k6-load-testing.md
+++ b/docs/plans/PLAN-0006-k6-load-testing.md
@@ -1,13 +1,13 @@
 ---
 id: PLAN-0006
 status: Ready
-version: 3
+version: 4
 source_spec: SPEC-0009
-source_spec_version: 3
+source_spec_version: 4
 baseline_revision: 9f4c60885d8a1c9c11362d1b236c6179b7f787e9
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # [PLAN-0006] — k6 load testing and capacity evidence
@@ -16,16 +16,20 @@ updated: 2026-09-09
 
 `Ready`
 
+`Ready` is retained because the documentation contract has no terminal Plan status. Implementation and runtime qualification are complete and recorded below.
+
 ## Source
 
-- Specification: `SPEC-0009` v3
+- Specification: `SPEC-0009` v4
 - External tracker: `#55` (optional)
 - Planning task: performance evidence before infrastructure expansion
 - Baseline: `9f4c60885d8a1c9c11362d1b236c6179b7f787e9`
 
 ## Current State
 
-The baseline contains the five-profile k6 harness and a safe but incomplete ephemeral workflow. The workflow runs `npm start`, exposes only three profiles, has no explicit container limits, fixtures, invariant gate or synchronized resource evidence, and is explicitly ineligible for a capacity claim.
+The five-profile k6 harness, controlled no-egress CI topology, disposable fixture/invariant gates and synchronized API/PostgreSQL resource capture are implemented. All five profiles have successful isolated runtime evidence. The catalog capacity statement is qualified by three equivalent repetitions on commit `87c73d3ee974d1de92a0bce4c4369bb7be806e1b` using the same frozen API image.
+
+The committed controlled-CI point is a 150-RPS catalog hold for 60 seconds with zero HTTP failures and zero dropped iterations across all three repetitions. This is not Render or production capacity.
 
 ## Goal
 
@@ -54,8 +58,10 @@ No schema change. The opt-in orders profile mutates disposable fixture rows thro
 3. Document environment/resource capture and reporting.
 4. Validate documentation contracts and inspect the k6 script when the binary is available.
 5. Build the controlled CI topology, fixture preparation, synchronized sampling, invariant gate and one/three repetition dispatch modes.
-6. In subsequent workflow runs, execute all profiles and repeat each claimed stable point three times.
-7. Update capacity evidence and evaluate whether an ADR 0018/0019 review is triggered.
+6. Execute all profiles and repeat each claimed stable point three times.
+7. Publish the qualified capacity evidence and evaluate whether an ADR 0018/0019 review is triggered.
+
+All seven steps are complete for the current controlled-CI evidence scope.
 
 ## Task Graph
 
@@ -67,7 +73,7 @@ The sequence is intentionally serial because architecture conclusions depend on 
 
 ## Testing Strategy
 
-`k6 inspect` validates script/options. Smoke validates connectivity. Each profile has status/shape checks and a custom failure rate. Existing backend tests prove no runtime regression because the diff is test/docs only. Runtime validation includes post-run invariant queries.
+`k6 inspect` validates script/options. Smoke validates connectivity. Each profile has status/shape checks and a custom failure rate. Existing backend tests prove no runtime regression because the performance work does not change the application API/schema/deploy contract. Runtime validation includes post-run invariant queries.
 
 ## Verification Strategy
 
@@ -78,7 +84,7 @@ k6 inspect load-tests/k6/neon-arsenal.js
 k6 run load-tests/k6/neon-arsenal.js
 ```
 
-AC-01–04 map to harness inspection/runtime; AC-05–06 to procedure/template review; AC-07 to subsequent controlled CI run artifacts; AC-08 to diff and existing CI.
+AC-01–04 map to harness inspection/runtime; AC-05–06 to procedure/template review; AC-07 to controlled CI run artifacts; AC-08 remains a standing regression criterion in the Accepted Spec.
 
 ## Risks
 
@@ -86,10 +92,11 @@ AC-01–04 map to harness inspection/runtime; AC-05–06 to procedure/template r
 - Payment replay fixture not pre-warmed could call PayPal. Mitigation: setup preflights `paypalOrderId` and aborts before payment traffic; there is no capture profile.
 - Provisional thresholds could be misquoted as SLOs. Mitigation: spec/docs label them guardrails and require environment-qualified reports.
 - k6-only results could misdiagnose the bottleneck. Mitigation: correlated API/PostgreSQL evidence is mandatory.
+- GitHub-hosted runners vary. Mitigation: claims require three equivalent repetitions and remain explicitly qualified as controlled-CI evidence.
 
 ## Dependencies
 
-Successful controlled CI workflow artifacts are required for AC-07. PayPal credentials and valid-event load are neither required nor authorized; payment replay uses a completed local fixture on a no-egress container network.
+The required controlled CI workflow artifacts now exist. PayPal credentials and valid-event load are neither required nor authorized; payment replay uses a completed local fixture on a no-egress container network.
 
 ## Stop Conditions
 
@@ -100,7 +107,7 @@ Successful controlled CI workflow artifacts are required for AC-07. PayPal crede
 
 ## Definition of Done
 
-Enablement is reviewed and inspects successfully; then all five profiles run in controlled CI, three equivalent repetitions support every published claim, resource and invariant evidence is attached, and #55 receives the qualified report. The enablement PR alone does not complete AC-07.
+Enablement is reviewed; all five profiles run in controlled CI; three equivalent repetitions support every published claim; resource and invariant evidence is attached; and the qualified report is committed. These conditions are satisfied for the current scope.
 
 ## Traceability
 
@@ -109,14 +116,16 @@ SPEC → PLAN → TASK(S) → PR → EVIDENCE
 ```
 
 - External tracker: `#55` (optional)
-- Specification: `SPEC-0009` v3
-- Plan: `PLAN-0006` v3
-- Tasks: `TASK-0010` v3
-- PR: pending
-- Evidence: pending isolated runtime
+- Specification: `SPEC-0009` v4
+- Plan: `PLAN-0006` v4
+- Task: `TASK-0010` v4
+- Implementation/qualification PRs: `#229`–`#239`
+- Successful profile runs: smoke `34401063625`; webhook rejection `34403607329`; orders `34418517461`; payment replay `34420854485`; catalog `34439840030`
+- Final report: `docs/performance/load-test-report-2026-09-10-catalog.md`
 
 ## Change History
 
+- `v4` — Recorded completion of the implementation/runtime sequence and the three-repetition frozen-image catalog qualification; Plan remains `Ready` per repository contract — 2026-09-10
 - `v3` — Replaced the missing external environment dependency with a controlled, production-image CI topology and deferred capacity claims to subsequent runs — 2026-09-09
 - `v2` — Migrated validation commands, baseline and traceability to the direct-agent documentation contract — 2026-09-08
 - `v1` — Ready plan for SPEC-0009 — 2026-09-07

--- a/docs/specs/SPEC-0009-load-testing-and-capacity-evidence.md
+++ b/docs/specs/SPEC-0009-load-testing-and-capacity-evidence.md
@@ -1,11 +1,11 @@
 ---
 id: SPEC-0009
 status: Accepted
-version: 3
+version: 4
 source_issue: "#55"
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # [SPEC-0009] — Reproducible load testing and capacity evidence
@@ -98,14 +98,14 @@ No runtime, API, schema, deploy or client behavior changes. This adds an operato
 
 ## Acceptance Criteria
 
-- [ ] `AC-01` — A default read-only smoke profile and a configurable catalog arrival-rate profile produce JSON summaries with RPS and latency percentiles. **Evidence:** k6 inspect/runtime
-- [ ] `AC-02` — Order creation is impossible without explicit write opt-in and disposable listing IDs. **Evidence:** static check/runtime
-- [ ] `AC-03` — Payment replay and invalid-webhook profiles exercise existing safety/idempotency boundaries without authorizing capture or valid forged events. **Evidence:** static check/manual review
-- [ ] `AC-04` — Profile thresholds fail on checks/custom failures and p95/p99 regressions. **Evidence:** k6 inspect
-- [ ] `AC-05` — The procedure requires correlated CPU, memory, connections, waits, deadlocks and invariant evidence. **Evidence:** static check
-- [ ] `AC-06` — A report template separates measured facts from hypotheses and records the first bottleneck. **Evidence:** static check
-- [ ] `AC-07` — At least one controlled, isolated production-like run covers each profile and three equivalent repetitions support any committed capacity claim. GitHub-hosted evidence must disclose runner variability and must not be called Render or production capacity. **Evidence:** runtime artifacts
-- [ ] `AC-08` — Existing API/payment/schema/deploy behavior is unchanged. **Evidence:** diff review and existing tests
+- [x] `AC-01` — A default read-only smoke profile and a configurable catalog arrival-rate profile produce JSON summaries with RPS and latency percentiles. **Evidence:** runtime
+- [x] `AC-02` — Order creation is impossible without explicit write opt-in and disposable listing IDs. **Evidence:** static check
+- [x] `AC-03` — Payment replay and invalid-webhook profiles exercise existing safety/idempotency boundaries without authorizing capture or valid forged events. **Evidence:** manual review
+- [x] `AC-04` — Profile thresholds fail on checks/custom failures and p95/p99 regressions. **Evidence:** runtime
+- [x] `AC-05` — The procedure requires correlated CPU, memory, connections, waits, deadlocks and invariant evidence. **Evidence:** static check
+- [x] `AC-06` — A report template separates measured facts from hypotheses and records the first bottleneck. **Evidence:** static check
+- [x] `AC-07` — At least one controlled, isolated production-like run covers each profile and three equivalent repetitions support any committed capacity claim. GitHub-hosted evidence must disclose runner variability and must not be called Render or production capacity. **Evidence:** runtime
+- [ ] `AC-08` — Existing API/payment/schema/deploy behavior remains unchanged as a standing regression criterion. **Evidence:** integration
 
 ## Verification Strategy
 
@@ -120,6 +120,7 @@ No runtime, API, schema, deploy or client behavior changes. This adds an operato
 
 - ADR 0006 (hot-path indexes), ADR 0007 (current Render platform), ADR 0018 (Redis not adopted), ADR 0019 (broker/worker not adopted)
 - `docs/architecture/capacity.md`, `docs/architecture/scaling-path.md`, `docs/performance.md`
+- `docs/performance/load-test-report-2026-09-10-catalog.md`
 
 ## Traceability
 
@@ -128,14 +129,16 @@ SPEC → PLAN → TASK(S) → PR → EVIDENCE
 ```
 
 - External tracker: `#55` (optional)
-- Spec: `SPEC-0009`
-- Plan: `PLAN-0006` v3
-- Tasks: `TASK-0010` v3
-- PR: pending
-- Evidence: pending runtime evidence
+- Spec: `SPEC-0009` v4
+- Plan: `PLAN-0006` v4
+- Task: `TASK-0010` v4
+- Implementation/qualification PRs: `#229`–`#239`
+- Per-profile controlled runs: smoke `34401063625`; webhook rejection `34403607329`; orders `34418517461`; payment replay `34420854485`; catalog qualification `34439840030`
+- Committed catalog capacity evidence: workflow run `34439840030`, three equivalent repetitions at a 150-RPS hold target, with frozen API image and synchronized resource/invariant artifacts.
 
 ## Change History
 
+- `v4` — Closed runtime qualification: all five profiles have controlled evidence and catalog has three equivalent frozen-image repetitions supporting a qualified 150-RPS controlled-CI claim; AC-08 remains a standing regression criterion — 2026-09-10
 - `v3` — Accepted a no-cloud-credential controlled CI environment as eligible AC-07 evidence when all profile, repetition, resource and uncertainty requirements are satisfied — 2026-09-09
 - `v2` — Migrated validation commands and traceability to the direct-agent documentation contract — 2026-09-08
 - `v1` — Accepted harness and evidence contract — 2026-09-07

--- a/docs/tasks/TASK-0010-k6-harness.md
+++ b/docs/tasks/TASK-0010-k6-harness.md
@@ -1,33 +1,33 @@
 ---
 id: TASK-0010
-status: InProgress
-version: 3
+status: Done
+version: 4
 source_issue: "#55"
 source_spec: SPEC-0009
-source_spec_version: 3
+source_spec_version: 4
 source_plan: PLAN-0006
-source_plan_version: 3
+source_plan_version: 4
 baseline_revision: 9f4c60885d8a1c9c11362d1b236c6179b7f787e9
 owner: "Neon Arsenal Engineering"
 created: 2026-09-07
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # [TASK-0010] — Build and run the k6 capacity harness
 
 ## Status
 
-`Ready`
+`Done`
 
 ## Source
 
-- Specification: `SPEC-0009` v3
-- Plan: `PLAN-0006` v3
+- Specification: `SPEC-0009` v4
+- Plan: `PLAN-0006` v4
 - External tracker: #55 (optional)
 
 ## Objective
 
-Enable a no-cloud-credential controlled CI environment that can later produce safe, correlated capacity evidence for all five profiles.
+Enable a no-cloud-credential controlled CI environment that produces safe, correlated capacity evidence for all five profiles.
 
 ## Scope
 
@@ -35,20 +35,20 @@ Enable a no-cloud-credential controlled CI environment that can later produce sa
 
 ## Allowed Files
 
-`load-tests/k6/`, `docs/performance/`, `.github/workflows/load-test.yml`, and the directly related SPEC/PLAN/TASK artifacts. Stop for runtime, schema, deploy or provider-contract changes.
+`load-tests/k6/`, `docs/performance/`, `.github/workflows/load-test.yml`, catalog evidence workflow, and the directly related SPEC/PLAN/TASK artifacts. Stop for runtime, schema, deploy or provider-contract changes.
 
 ## Preconditions
 
-`SPEC-0009` Accepted; `PLAN-0006` Ready. Runtime phase requires GitHub Actions with Docker support; it uses only disposable local credentials and data.
+`SPEC-0009` Accepted; `PLAN-0006` Ready. Runtime phase uses GitHub Actions with Docker support and only disposable local credentials/data.
 
 ## Acceptance Criteria
 
-- [ ] `AC-01` — Production Docker image and PostgreSQL 16 run with explicit recorded resource limits. **Evidence:** static check
-- [ ] `AC-02` — All five profiles are manually dispatchable; only orders receives write opt-in and disposable unique listings. **Evidence:** static check
-- [ ] `AC-03` — Payment replay is prepared locally and cannot reach PayPal; webhook verification remains intact. **Evidence:** manual review
-- [ ] `AC-04` — Raw k6, API, resource, PostgreSQL and invariant evidence is retained for the same UTC window. **Evidence:** static check
-- [ ] `AC-05` — One/three repetition modes preserve the same commit and configuration with a fresh equivalent dataset. **Evidence:** static check
-- [ ] `AC-06` — Subsequent successful runs cover all profiles and three repetitions support any controlled CI capacity statement. **Evidence:** runtime
+- [x] `AC-01` — Production Docker image and PostgreSQL 16 run with explicit recorded resource limits. **Evidence:** runtime
+- [x] `AC-02` — All five profiles are manually dispatchable; only orders receives write opt-in and disposable unique listings. **Evidence:** static check
+- [x] `AC-03` — Payment replay is prepared locally and cannot reach PayPal; webhook verification remains intact. **Evidence:** manual review
+- [x] `AC-04` — Raw k6, API, resource, PostgreSQL and invariant evidence is retained for the same UTC window. **Evidence:** runtime
+- [x] `AC-05` — Repeated claim evidence preserves the same commit/configuration and exact frozen API image with a fresh equivalent dataset. **Evidence:** runtime
+- [x] `AC-06` — Successful controlled runs cover all profiles and three equivalent repetitions support the committed controlled-CI catalog capacity statement. **Evidence:** runtime
 
 ## Dependencies
 
@@ -56,7 +56,7 @@ None
 
 ## Risks
 
-Accidental mutation of shared data; external PayPal side effects; mistaking client-side metrics for server saturation.
+Accidental mutation of shared data; external PayPal side effects; mistaking client-side metrics for server saturation; GitHub-hosted runner variability.
 
 ## Verification Command
 
@@ -69,7 +69,7 @@ k6 run load-tests/k6/neon-arsenal.js
 
 ## Expected Evidence
 
-Enablement validation exits 0 and the workflow is statically valid. Subsequent workflow execution supplies per-profile JSON, synchronized API/PostgreSQL evidence and post-run invariant proof. AC-07 remains open until those runs exist.
+Satisfied. The repository has successful controlled runs for smoke, webhook rejection, orders and payment replay, plus final catalog workflow run `34439840030` with three equivalent repetitions using the same frozen API image. The catalog report correlates k6 with API/PostgreSQL resource signals and invariant proof.
 
 ## Stop Conditions
 
@@ -79,8 +79,17 @@ Stop if the target is not disposable, writes could reach shared data, PayPal cap
 
 SPEC → PLAN → TASK(S) → PR → EVIDENCE
 
+- Implementation/qualification PRs: `#229`–`#239`
+- Smoke: `34401063625`
+- Webhook rejection: `34403607329`
+- Orders: `34418517461`
+- Payment replay: `34420854485`
+- Catalog final evidence: `34439840030`
+- Report: `docs/performance/load-test-report-2026-09-10-catalog.md`
+
 ## Change History
 
-- 2026-09-09 — v3 — Started controlled CI capacity-evidence enablement; runtime evidence and AC-07 remain pending.
+- 2026-09-10 — v4 — Marked Done after all profiles produced controlled evidence and the catalog claim passed three equivalent frozen-image repetitions with correlated resource/invariant artifacts.
+- 2026-09-09 — v3 — Started controlled CI capacity-evidence enablement; runtime evidence and AC-07 remained pending.
 - 2026-09-08 — v2 — Migrated dependencies, validation commands, baseline and traceability to the direct-agent documentation contract.
 - 2026-09-08 — v1 — Migrated to the task artifact contract.


### PR DESCRIPTION
## Goal

Close PR05 / `TASK-0010` with the runtime evidence produced after the reproducibility fix.

## Final catalog evidence

Workflow run `34439840030` executed three serial equivalent catalog repetitions at a configured 150-RPS hold using the exact same frozen API image on commit `87c73d3ee974d1de92a0bce4c4369bb7be806e1b`.

All three repetitions:

- sustained the 60-second 150 RPS hold;
- had 0 HTTP failures;
- had 0 dropped iterations;
- passed k6 thresholds and post-run invariants;
- used the same API/PostgreSQL/k6 image IDs;
- retained synchronized API/PostgreSQL resource evidence.

Observed p95: `5.81–6.08 ms`; p99: `10.81–12.27 ms`. API CPU peak: `67.06–72.74%` at the qualified point.

The earlier failed 200-RPS three-run boundary correlates with API CPU reaching approximately the 1-CPU container budget while PostgreSQL remained in the low-teens CPU range. The first measured bottleneck is API CPU in this controlled topology.

## Documentation changes

- Add the concrete catalog load-test report with run/artifact identities and resource correlation.
- Mark `TASK-0010` `Done`.
- Advance `SPEC-0009`/`PLAN-0006` traceability to v4 while retaining the repository status contracts (`PLAN-0006 = Ready`; `SPEC-0009` keeps AC-08 open as a standing regression criterion).
- Replace the obsolete “no k6 evidence” capacity hypothesis with the qualified controlled-CI result.

## Qualification

This is **controlled GitHub Actions CI capacity evidence**, not Render or production capacity. The catalog-only isolated benchmark lifts the per-client quota for measurement; deployed production rate-limit defaults are unchanged.

## Scope

Documentation/evidence only. No application runtime, API, schema, migration, payment semantics, deployment topology, or production rate-limit behavior changes.