### PR TITLE
feat(tooling): add reproducible repository verification entrypoint

### DIFF
--- a/.github/workflows/repository-verification.yml
+++ b/.github/workflows/repository-verification.yml
@@ -1,0 +1,27 @@
+name: Repository verification
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    name: Agent harness and documentation contracts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Run canonical repository verification
+        run: python3 scripts/verify.py

--- a/docs/agents/verification.md
+++ b/docs/agents/verification.md
@@ -1,0 +1,40 @@
+# Repository verification
+
+The canonical deterministic verification entrypoint for the repository-native agent harness is:
+
+```bash
+python scripts/verify.py
+```
+
+CI executes the same entrypoint with the platform Python alias:
+
+```bash
+python3 scripts/verify.py
+```
+
+## Contract
+
+`scripts/verify.py` is dependency-free orchestration for deterministic repository checks. It does not select work, generate prompts, invoke an LLM, access an external tracker, or change product state.
+
+The entrypoint currently:
+
+1. records the exact Git revision and Python interpreter version;
+2. verifies that the canonical verification surfaces exist;
+3. rejects retired orchestrator/AI-factory entrypoints from active agent guidance;
+4. validates documentation and artifact contracts through `scripts/docs/validate_contracts.py`;
+5. runs the validator regression suite in `tests/tooling/test_docs_contracts.py`;
+6. stops on the first failed stage and preserves that stage's exit code.
+
+The lower-level commands remain individually runnable for focused debugging, but they are implementation details of the verification entrypoint rather than separate agent procedures.
+
+## Reproducibility boundary
+
+The dedicated `Repository verification` GitHub Actions workflow checks out full Git history because artifact baselines are validated as real repository commits. It uses Python 3.12 and calls the same repository entrypoint used locally.
+
+A green run proves the repository artifact graph, harness surfaces, and validator tests under that revision. It does not prove application runtime behavior; product changes still require the Task-specific checks and the broader CI jobs justified by their risk.
+
+## Drift policy
+
+Active guidance must not direct agents back to removed `scripts/ai-factory/`, orchestrator wrappers, or retired `next` scripts. Historical completed Tasks and verification records may mention those paths when describing work that actually happened; historical statements are not executable guidance.
+
+When the verification implementation changes, update this document and the dedicated CI workflow in the same PR so local and CI entrypoints remain aligned.

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -2,6 +2,7 @@
 """Run the deterministic repository verification entrypoint used by agents and CI."""
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -40,6 +41,22 @@ def fail(message: str) -> int:
     return 1
 
 
+def is_executable_guidance(line: str, retired: str) -> bool:
+    """Reject instructions that direct execution of a retired entrypoint, not historical mentions."""
+    if retired not in line:
+        return False
+    normalized = line.strip().lower()
+    if any(marker in normalized for marker in ("retired", "removed", "historical", "must not", "do not")):
+        return False
+    command_patterns = (
+        r"^(?:[-*]\s*)?(?:run|execute|invoke|call|use)\b",
+        r"^(?:\$\s*)?(?:python\d*|bash|sh|powershell|pwsh)\b",
+        r"^(?:\$\s*)?\./",
+        r"^run:\s*",
+    )
+    return any(re.search(pattern, normalized) for pattern in command_patterns)
+
+
 def validate_entrypoint_contract() -> int:
     required = (
         ROOT / "scripts" / "docs" / "validate_contracts.py",
@@ -67,12 +84,12 @@ def validate_entrypoint_contract() -> int:
         for path in paths:
             if not path.is_file():
                 continue
-            content = path.read_text(encoding="utf-8")
-            for retired in RETIRED_GUIDANCE_REFERENCES:
-                if retired in content:
-                    return fail(
-                        f"active guidance {path.relative_to(ROOT)} references retired entrypoint {retired}"
-                    )
+            for line in path.read_text(encoding="utf-8").splitlines():
+                for retired in RETIRED_GUIDANCE_REFERENCES:
+                    if is_executable_guidance(line, retired):
+                        return fail(
+                            f"active guidance {path.relative_to(ROOT)} directs execution of retired entrypoint {retired}"
+                        )
     return 0
 
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -8,9 +8,17 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CANONICAL_COMMAND = "scripts/verify.py"
-RETIRED_ENTRYPOINTS = (
+RETIRED_GUIDANCE_REFERENCES = (
     "scripts/ai-factory/",
-    "scripts/orchestrator/",
+    "scripts/next.sh",
+    "scripts/p-back-next.sh",
+    "scripts/p-front-next.sh",
+)
+RETIRED_PATHS = (
+    "scripts/ai-factory",
+    "scripts/orchestrator",
+    "scripts/p-back",
+    "scripts/p-front",
     "scripts/next.sh",
     "scripts/p-back-next.sh",
     "scripts/p-front-next.sh",
@@ -43,6 +51,10 @@ def validate_entrypoint_contract() -> int:
     if missing:
         return fail(f"missing verification surfaces: {', '.join(missing)}")
 
+    reintroduced = [path for path in RETIRED_PATHS if (ROOT / path).exists()]
+    if reintroduced:
+        return fail(f"retired agent tooling was reintroduced: {', '.join(reintroduced)}")
+
     verification_doc = (ROOT / "docs" / "agents" / "verification.md").read_text(encoding="utf-8")
     workflow = (ROOT / ".github" / "workflows" / "repository-verification.yml").read_text(encoding="utf-8")
     if CANONICAL_COMMAND not in verification_doc:
@@ -56,7 +68,7 @@ def validate_entrypoint_contract() -> int:
             if not path.is_file():
                 continue
             content = path.read_text(encoding="utf-8")
-            for retired in RETIRED_ENTRYPOINTS:
+            for retired in RETIRED_GUIDANCE_REFERENCES:
                 if retired in content:
                     return fail(
                         f"active guidance {path.relative_to(ROOT)} references retired entrypoint {retired}"

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -7,20 +7,85 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-
+CANONICAL_COMMAND = "scripts/verify.py"
+RETIRED_ENTRYPOINTS = (
+    "scripts/ai-factory/",
+    "scripts/orchestrator/",
+    "scripts/next.sh",
+    "scripts/p-back-next.sh",
+    "scripts/p-front-next.sh",
+)
+ACTIVE_GUIDANCE_GLOBS = (
+    "AGENTS.md",
+    "docs/agents/*.md",
+    ".cursor/rules/*.mdc",
+    ".github/workflows/repository-verification.yml",
+)
 COMMANDS = (
     ("documentation contracts", [sys.executable, "scripts/docs/validate_contracts.py"]),
     ("documentation validator tests", [sys.executable, "tests/tooling/test_docs_contracts.py"]),
 )
 
 
+def fail(message: str) -> int:
+    print(f"FAILED: {message}", file=sys.stderr)
+    return 1
+
+
+def validate_entrypoint_contract() -> int:
+    required = (
+        ROOT / "scripts" / "docs" / "validate_contracts.py",
+        ROOT / "tests" / "tooling" / "test_docs_contracts.py",
+        ROOT / "docs" / "agents" / "verification.md",
+        ROOT / ".github" / "workflows" / "repository-verification.yml",
+    )
+    missing = [path.relative_to(ROOT).as_posix() for path in required if not path.is_file()]
+    if missing:
+        return fail(f"missing verification surfaces: {', '.join(missing)}")
+
+    verification_doc = (ROOT / "docs" / "agents" / "verification.md").read_text(encoding="utf-8")
+    workflow = (ROOT / ".github" / "workflows" / "repository-verification.yml").read_text(encoding="utf-8")
+    if CANONICAL_COMMAND not in verification_doc:
+        return fail("docs/agents/verification.md does not name scripts/verify.py")
+    if CANONICAL_COMMAND not in workflow:
+        return fail("repository verification workflow does not invoke scripts/verify.py")
+
+    for pattern in ACTIVE_GUIDANCE_GLOBS:
+        paths = [ROOT / pattern] if "*" not in pattern else sorted(ROOT.glob(pattern))
+        for path in paths:
+            if not path.is_file():
+                continue
+            content = path.read_text(encoding="utf-8")
+            for retired in RETIRED_ENTRYPOINTS:
+                if retired in content:
+                    return fail(
+                        f"active guidance {path.relative_to(ROOT)} references retired entrypoint {retired}"
+                    )
+    return 0
+
+
+def describe_revision() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unresolved"
+
+
 def main() -> int:
+    print(f"Repository verification: revision={describe_revision()} python={sys.version.split()[0]}")
+    if validate_entrypoint_contract() != 0:
+        return 1
+
     for label, command in COMMANDS:
         print(f"==> {label}")
         result = subprocess.run(command, cwd=ROOT, check=False)
         if result.returncode != 0:
-            print(f"FAILED: {label} (exit {result.returncode})", file=sys.stderr)
-            return result.returncode
+            return fail(f"{label} (exit {result.returncode})")
+
     print("Repository verification passed.")
     return 0
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Run the deterministic repository verification entrypoint used by agents and CI."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+COMMANDS = (
+    ("documentation contracts", [sys.executable, "scripts/docs/validate_contracts.py"]),
+    ("documentation validator tests", [sys.executable, "tests/tooling/test_docs_contracts.py"]),
+)
+
+
+def main() -> int:
+    for label, command in COMMANDS:
+        print(f"==> {label}")
+        result = subprocess.run(command, cwd=ROOT, check=False)
+        if result.returncode != 0:
+            print(f"FAILED: {label} (exit {result.returncode})", file=sys.stderr)
+            return result.returncode
+    print("Repository verification passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Goal

Deliver PR06 with one deterministic, provider-neutral verification entrypoint that agents and CI can execute without the removed orchestrator/AI-factory runtime.

## Change

- Add `scripts/verify.py` as the dependency-free repository verification entrypoint.
- Add `docs/agents/verification.md` defining its scope, reproducibility boundary and drift policy.
- Add a dedicated `Repository verification` workflow that checks out full history, pins Python 3.12 and invokes exactly `python3 scripts/verify.py`.
- Make the entrypoint reject physical reintroduction of retired agent tooling and executable references to retired wrappers in active guidance.
- Reuse the existing real validator and regression suite instead of recreating validation logic.

## Why

The repository's current deterministic implementation is `scripts/docs/validate_contracts.py` plus `tests/tooling/test_docs_contracts.py`, while historical completed artifacts still mention the removed `scripts/ai-factory/` implementation. PR06 makes the current executable path explicit and reproducible without rebuilding a custom orchestrator.

## Verification contract

Local:

```bash
python scripts/verify.py
```

CI:

```bash
python3 scripts/verify.py
```

The dedicated workflow is intentionally the acceptance proof for this PR. It must pass before merge.

## Scope

Developer/agent tooling and documentation only. No product runtime, API, schema, migration, payment semantics, deployment topology, or production configuration changes.

## Follow-up boundary

Historical completed Tasks may truthfully retain references to tooling that existed when they were executed. Broader documentation consolidation belongs to PR07; PR06 only prevents retired interfaces from becoming active executable guidance again.