### PR TITLE
refactor(payments): introduce explicit PayPal provider boundary

### DIFF
--- a/docs/adr/0025-paypal-provider-boundary.md
+++ b/docs/adr/0025-paypal-provider-boundary.md
@@ -1,0 +1,57 @@
+# ADR 0025 — Keep outbound PayPal mechanics behind one Payments gateway
+
+## Status
+
+Accepted
+
+## Context
+
+`payments.service.ts` directly consumed PayPal order creation, capture, lookup, approval-link parsing, status helpers, and the provider-specific already-captured error predicate. `refunds.service.ts` separately consumed capture-refund POST, refund GET, PayPal status types, and PayPal error-message classification. The application services still correctly owned PostgreSQL transactions, reservation validation, ledger mutations, webhook state, and reconciliation policy, but focused tests had to mock low-level functions from two provider implementation modules.
+
+ADR 0016 rejected a broad Payments layering rewrite because it could obscure the `confirmPayment` transaction. ADR 0024 explicitly left a future payment/refund provider seam available if it showed measurable testability benefit. PR09 found that a narrow outbound PayPal gateway provides that benefit without moving any business or persistence responsibility.
+
+## Decision
+
+1. `paypal-provider.gateway.ts` is the only outbound PayPal dependency consumed by payment and refund application services.
+2. The gateway owns Orders create/get/capture calls, the already-captured GET fallback, approval-link normalization, refund POST/GET calls, and refund failure classification.
+3. The contract is deliberately PayPal-specific. It is not a generic multi-provider framework and does not predict a Stripe implementation.
+4. Payment and refund application services continue to own orchestration, trusted status decisions, reservation checks, durable claims, bounded reconciliation, PostgreSQL transactions, ledger changes, and compensation.
+5. Prisma remains explicit. Provider calls remain outside critical PostgreSQL transactions.
+6. Webhook signature verification and parsing remain separate inbound trust-boundary utilities; this ADR covers outbound provider I/O only.
+7. Existing low-level PayPal utilities remain the concrete SDK/HTTP implementation and keep their observability, timeout, and retry semantics.
+
+## Evidence
+
+| Signal | Before | After | Benefit |
+|---|---:|---:|---|
+| Low-level outbound PayPal modules imported by application services | 2 | 0 | Services depend only on the gateway |
+| Outbound PayPal symbols imported directly by `payments.service.ts` | 9 | 0 | Order orchestration no longer knows helper layout or capture replay mechanics |
+| Outbound PayPal symbols imported directly by `refunds.service.ts` | 3 | 0 | Refund execution and observation use one contract |
+| Provider modules mocked by focused refund reconciliation tests | 2 | 1 | One small provider object represents POST and GET behavior |
+| Low-level PayPal functions mocked by the focused payment service suite | 7 | 0 | Application behavior is isolated from SDK/HTTP implementation details |
+| Provider-specific refund failure classification in application services | 1 | 0 | Normalization lives at the provider boundary |
+
+The improvement is structural and test-visible; it does not rely on lower line count or hypothetical future providers.
+
+## Rejected alternatives
+
+- **Cancel PR09:** rejected because direct-import and mock counts demonstrate concrete coupling reduction.
+- **Generic `PaymentProvider` framework:** rejected because PayPal is the only provider and speculative extensibility adds cost.
+- **Prisma repositories or a DI container:** rejected because neither is required for the seam and both would broaden risk.
+- **Move webhook trust into the gateway:** rejected because inbound authenticity is a distinct security boundary.
+
+## Consequences
+
+- Focused application tests can replace one `paypalProvider` object.
+- Low-level PayPal parsing/HTTP tests remain focused on the concrete utilities and refund client.
+- The gateway is a small module-local seam; Payments remains one application service and all transactional invariants remain visible.
+- Some intentional coupling remains: application logic knows PayPal status labels and webhook event semantics because PayPal is the current provider.
+
+## Rollback
+
+Restore direct utility imports in the two services, move capture replay and refund classification back, and delete the gateway and its focused test. No data or API rollback is required.
+
+## Amends
+
+- ADR 0016: Payments remains unsplit, but outbound PayPal mechanics now have an explicit module-local gateway rather than being consumed directly from `shared/utils`.
+- ADR 0024: implements only the optional provider seam anticipated there; refund semantics are unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ Issue #71 inventory. Decisions already recorded before this change are listed, n
 | [0022](./0022-single-checkout-currency.md) | Single BRL checkout currency; cs2.sh USD remains catalog reference only |
 | [0023](./0023-rate-limit-client-identity.md) | Explicit, non-spoofable client identity at the Render edge |
 | [0024](./0024-refund-compensation.md) | Idempotent full refund compensation for captured-but-unfulfillable payments |
+| [0025](./0025-paypal-provider-boundary.md) | Narrow outbound PayPal gateway for payment/refund orchestration |
 
 ADR identifiers are unique and durable. Historical references to refund compensation as `ADR 0023` refer to the same decision now canonicalized as `ADR 0024`; the renumber corrected an accidental duplicate identifier and did not change the decision.
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -59,7 +59,7 @@ Prisma / PostgreSQL
 
 Shared infrastructure belongs in `server/src/shared/`. Business behavior belongs in `server/src/modules/<domain>/`.
 
-Logical module names, allowed import edges, and composition-root exceptions are in `docs/architecture/modular-monolith.md`. The executable graph is `server/src/shared/architecture/moduleBoundaries.ts` (ADR 0016, `SPEC-0006`). Catalog is the `products` folder; Ledger is the `commissions` folder. Do not rename those folders. Payments stays one application service: PayPal HTTP is already in `shared/utils`, and `confirmPayment` remains a single local transaction. Do not add a module-to-module service call to look layered.
+Logical module names, allowed import edges, and composition-root exceptions are in `docs/architecture/modular-monolith.md`. The executable graph is `server/src/shared/architecture/moduleBoundaries.ts` (ADR 0016, `SPEC-0006`). Catalog is the `products` folder; Ledger is the `commissions` folder. Do not rename those folders. Payments stays one application service: outbound PayPal mechanics are consumed through the narrow module-local gateway from ADR 0025, while `confirmPayment` remains a single local transaction. Do not add a module-to-module service call to look layered.
 
 ### Important current inconsistency
 

--- a/docs/architecture/modular-monolith.md
+++ b/docs/architecture/modular-monolith.md
@@ -79,13 +79,14 @@ Ledger *writes* on confirm belong to Payments. Ledger *projection reconcile* bel
 
 ## Payments layering
 
-Payments is **not** split into application/domain/infrastructure here.
+Payments is **not** split into application/domain/infrastructure.
 
-- PayPal HTTP and webhook crypto already sit in `shared/utils`.
+- Payment and refund orchestration consume one module-local outbound PayPal gateway (ADR 0025).
+- The gateway delegates to the existing PayPal SDK/HTTP utilities and owns provider response/error normalization.
+- Webhook verification/parsing remains a separate inbound trust boundary in `shared/utils`.
 - `confirmPayment` must remain one local transaction.
 - `OrdersCreate` and `OrdersCapture` are not retried.
-
-A later change may split the file only with a Specification that preserves those rules.
+- Prisma is intentionally not abstracted by the provider seam.
 
 ## How to add a dependency
 

--- a/server/src/__tests__/observability.integration.test.ts
+++ b/server/src/__tests__/observability.integration.test.ts
@@ -2,14 +2,17 @@ import { randomUUID } from "node:crypto";
 import { SpanStatusCode } from "@opentelemetry/api";
 import { describe, expect, it, beforeAll, afterAll, beforeEach, vi } from "vitest";
 
-vi.mock("../shared/utils/paypal.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../shared/utils/paypal.js")>();
+vi.mock("../modules/payments/paypal-provider.gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../modules/payments/paypal-provider.gateway.js")>();
   return {
     ...actual,
-    refundPayPalCapture: vi.fn(async (captureId: string) => ({
-      id: `REFUND-${captureId}`,
-      status: "COMPLETED" as const,
-    })),
+    paypalProvider: {
+      ...actual.paypalProvider,
+      refundCapture: vi.fn(async (captureId: string) => ({
+        id: `REFUND-${captureId}`,
+        status: "COMPLETED" as const,
+      })),
+    },
   };
 });
 import { prisma } from "../shared/database/index.js";

--- a/server/src/__tests__/payment.link.idempotency.integration.test.ts
+++ b/server/src/__tests__/payment.link.idempotency.integration.test.ts
@@ -3,16 +3,18 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../shared/database/index.js";
 import { createCheckoutGraph, createOrder, orderKey } from "./helpers/index.js";
 
-vi.mock("../shared/utils/paypal.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../shared/utils/paypal.js")>();
+vi.mock("../modules/payments/paypal-provider.gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../modules/payments/paypal-provider.gateway.js")>();
   return {
     ...actual,
-    createPayPalOrder: vi.fn(),
-    getPayPalApprovalLink: vi.fn(),
+    paypalProvider: {
+      ...actual.paypalProvider,
+      createOrder: vi.fn(),
+    },
   };
 });
 
-import { createPayPalOrder, getPayPalApprovalLink } from "../shared/utils/paypal.js";
+import { paypalProvider } from "../modules/payments/paypal-provider.gateway.js";
 import { paymentsService } from "../modules/payments/payments.service.js";
 
 function uniqueViolation(error: unknown) {
@@ -22,8 +24,7 @@ function uniqueViolation(error: unknown) {
 
 describe("payment link idempotency (postgres)", () => {
   beforeEach(() => {
-    vi.mocked(createPayPalOrder).mockReset();
-    vi.mocked(getPayPalApprovalLink).mockReset();
+    vi.mocked(paypalProvider.createOrder).mockReset();
   });
   it("replays POST /payments without a second PayPal OrdersCreate", async () => {
     const fixture = await createCheckoutGraph();
@@ -33,8 +34,10 @@ describe("payment link idempotency (postgres)", () => {
       orderKey("payment-replay")
     );
 
-    vi.mocked(createPayPalOrder).mockResolvedValue({ id: "PAYPAL-REPLAY", links: [] } as never);
-    vi.mocked(getPayPalApprovalLink).mockReturnValue("https://www.sandbox.paypal.com/checkoutnow?token=PAYPAL-REPLAY");
+    vi.mocked(paypalProvider.createOrder).mockResolvedValue({
+      id: "PAYPAL-REPLAY",
+      approvalUrl: "https://www.sandbox.paypal.com/checkoutnow?token=PAYPAL-REPLAY",
+    });
 
     const first = await paymentsService.createPaymentLink(fixture.customer.id, { orderId: order.id });
     const second = await paymentsService.createPaymentLink(fixture.customer.id, { orderId: order.id });
@@ -42,7 +45,7 @@ describe("payment link idempotency (postgres)", () => {
     const links = await prisma.paymentLink.findMany({ where: { orderId: order.id } });
     const stored = await prisma.order.findUnique({ where: { id: order.id } });
 
-    expect(createPayPalOrder).toHaveBeenCalledTimes(1);
+    expect(paypalProvider.createOrder).toHaveBeenCalledTimes(1);
     expect(second).toEqual(first);
     expect(links).toHaveLength(1);
     expect(links[0].status).toBe("COMPLETED");
@@ -59,14 +62,11 @@ describe("payment link idempotency (postgres)", () => {
     );
 
     let createCalls = 0;
-    vi.mocked(createPayPalOrder).mockImplementation(async () => {
+    vi.mocked(paypalProvider.createOrder).mockImplementation(async () => {
       createCalls += 1;
       await Promise.resolve();
-      return { id: "PAYPAL-CONCURRENT", links: [] };
+      return { id: "PAYPAL-CONCURRENT" };
     });
-    vi.mocked(getPayPalApprovalLink).mockReturnValue(
-      "https://www.sandbox.paypal.com/checkoutnow?token=PAYPAL-CONCURRENT"
-    );
 
     const results = await Promise.allSettled([
       paymentsService.createPaymentLink(fixture.customer.id, { orderId: order.id }),
@@ -109,12 +109,9 @@ describe("payment link idempotency (postgres)", () => {
       orderKey("payment-paypal-fail")
     );
 
-    vi.mocked(createPayPalOrder)
+    vi.mocked(paypalProvider.createOrder)
       .mockRejectedValueOnce(new Error("PayPal unavailable"))
-      .mockResolvedValueOnce({ id: "PAYPAL-RETRY", links: [] } as never);
-    vi.mocked(getPayPalApprovalLink).mockReturnValue(
-      "https://www.sandbox.paypal.com/checkoutnow?token=PAYPAL-RETRY"
-    );
+      .mockResolvedValueOnce({ id: "PAYPAL-RETRY" });
 
     await expect(
       paymentsService.createPaymentLink(fixture.customer.id, { orderId: order.id })
@@ -125,7 +122,7 @@ describe("payment link idempotency (postgres)", () => {
     const retry = await paymentsService.createPaymentLink(fixture.customer.id, { orderId: order.id });
 
     expect(retry.paypalOrderId).toBe("PAYPAL-RETRY");
-    expect(createPayPalOrder).toHaveBeenCalledTimes(2);
+    expect(paypalProvider.createOrder).toHaveBeenCalledTimes(2);
     expect(await prisma.paymentLink.count({ where: { orderId: order.id } })).toBe(1);
   });
 

--- a/server/src/__tests__/paypal.webhook.integration.test.ts
+++ b/server/src/__tests__/paypal.webhook.integration.test.ts
@@ -1,14 +1,17 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../shared/utils/paypal.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../shared/utils/paypal.js")>();
+vi.mock("../modules/payments/paypal-provider.gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../modules/payments/paypal-provider.gateway.js")>();
   return {
     ...actual,
-    refundPayPalCapture: vi.fn(async (captureId: string) => ({
-      id: `REFUND-${captureId}`,
-      status: "COMPLETED" as const,
-    })),
+    paypalProvider: {
+      ...actual.paypalProvider,
+      refundCapture: vi.fn(async (captureId: string) => ({
+        id: `REFUND-${captureId}`,
+        status: "COMPLETED" as const,
+      })),
+    },
   };
 });
 import { prisma } from "../shared/database/index.js";

--- a/server/src/__tests__/refund.execution.integration.test.ts
+++ b/server/src/__tests__/refund.execution.integration.test.ts
@@ -5,23 +5,26 @@ const providerState = vi.hoisted(() => ({
   refunds: new Map<string, { id: string; status: "COMPLETED" }>(),
 }));
 
-vi.mock("../shared/utils/paypal.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../shared/utils/paypal.js")>();
+vi.mock("../modules/payments/paypal-provider.gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../modules/payments/paypal-provider.gateway.js")>();
   return {
     ...actual,
-    refundPayPalCapture: vi.fn(async (captureId: string, requestId: string) => {
-      providerState.calls.push({ captureId, requestId });
-      const replay = providerState.refunds.get(requestId);
-      if (replay) return replay;
-      const created = { id: `PROVIDER-REFUND-${providerState.refunds.size + 1}`, status: "COMPLETED" as const };
-      providerState.refunds.set(requestId, created);
-      return created;
-    }),
+    paypalProvider: {
+      ...actual.paypalProvider,
+      refundCapture: vi.fn(async (captureId: string, requestId: string) => {
+        providerState.calls.push({ captureId, requestId });
+        const replay = providerState.refunds.get(requestId);
+        if (replay) return replay;
+        const created = { id: `PROVIDER-REFUND-${providerState.refunds.size + 1}`, status: "COMPLETED" as const };
+        providerState.refunds.set(requestId, created);
+        return created;
+      }),
+    },
   };
 });
 
 import { prisma } from "../shared/database/index.js";
-import { refundPayPalCapture } from "../shared/utils/paypal.js";
+import { paypalProvider } from "../modules/payments/paypal-provider.gateway.js";
 import { paymentsService } from "../modules/payments/payments.service.js";
 import {
   buildPayPalRefundRequestId,
@@ -165,14 +168,14 @@ describe("TASK-0014 idempotent PayPal refund execution (postgres)", () => {
     );
     const refund = await obligation(order.id, "CAPTURE-TIMEOUT");
     const timeout = Object.assign(new Error("timeout"), { statusCode: 504 });
-    vi.mocked(refundPayPalCapture).mockRejectedValueOnce(timeout);
+    vi.mocked(paypalProvider.refundCapture).mockRejectedValueOnce(timeout);
 
     await expect(refundsService.executeProviderRefund(refund.id)).rejects.toBe(timeout);
     const unresolved = await prisma.refund.findUniqueOrThrow({ where: { id: refund.id } });
     expect(unresolved.status).toBe("PROCESSING");
     expect(unresolved.completedAt).toBeNull();
 
-    vi.mocked(refundPayPalCapture).mockImplementationOnce(async (captureId, requestId) => {
+    vi.mocked(paypalProvider.refundCapture).mockImplementationOnce(async (captureId, requestId) => {
       providerState.calls.push({ captureId, requestId });
       const result = { id: "PROVIDER-REFUND-TIMEOUT", status: "COMPLETED" as const };
       providerState.refunds.set(requestId, result);
@@ -180,7 +183,7 @@ describe("TASK-0014 idempotent PayPal refund execution (postgres)", () => {
     });
     await refundsService.executeProviderRefund(refund.id);
 
-    const requestIds = vi.mocked(refundPayPalCapture).mock.calls.map((call) => call[1]);
+    const requestIds = vi.mocked(paypalProvider.refundCapture).mock.calls.map((call) => call[1]);
     expect(requestIds).toEqual([
       buildPayPalRefundRequestId(refund.id),
       buildPayPalRefundRequestId(refund.id),
@@ -198,7 +201,7 @@ describe("TASK-0014 idempotent PayPal refund execution (postgres)", () => {
       orderKey("refund-provider-pending")
     );
     const refund = await obligation(order.id, "CAPTURE-PENDING");
-    vi.mocked(refundPayPalCapture).mockResolvedValueOnce({
+    vi.mocked(paypalProvider.refundCapture).mockResolvedValueOnce({
       id: "PROVIDER-REFUND-PENDING",
       status: "PENDING",
     });

--- a/server/src/__tests__/refund.reconciliation.integration.test.ts
+++ b/server/src/__tests__/refund.reconciliation.integration.test.ts
@@ -10,33 +10,33 @@ const provider = vi.hoisted(() => ({
   getFailures: [] as Error[],
 }));
 
-vi.mock("../shared/utils/paypal.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../shared/utils/paypal.js")>();
+vi.mock("../modules/payments/paypal-provider.gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../modules/payments/paypal-provider.gateway.js")>();
   return {
     ...actual,
-    refundPayPalCapture: vi.fn(async (captureId: string, requestId: string) => {
-      provider.postCalls.push({ captureId, requestId });
-      const failure = provider.postFailures.shift();
-      if (failure) throw failure;
-      let providerRefundId = provider.refundsByRequest.get(requestId);
-      if (!providerRefundId) {
-        providerRefundId = `PROVIDER-${provider.refundsByRequest.size + 1}`;
-        provider.refundsByRequest.set(requestId, providerRefundId);
-        provider.statuses.set(providerRefundId, "COMPLETED");
-      }
-      return { id: providerRefundId, status: provider.statuses.get(providerRefundId) ?? "PENDING" };
-    }),
+    paypalProvider: {
+      ...actual.paypalProvider,
+      refundCapture: vi.fn(async (captureId: string, requestId: string) => {
+        provider.postCalls.push({ captureId, requestId });
+        const failure = provider.postFailures.shift();
+        if (failure) throw failure;
+        let providerRefundId = provider.refundsByRequest.get(requestId);
+        if (!providerRefundId) {
+          providerRefundId = `PROVIDER-${provider.refundsByRequest.size + 1}`;
+          provider.refundsByRequest.set(requestId, providerRefundId);
+          provider.statuses.set(providerRefundId, "COMPLETED");
+        }
+        return { id: providerRefundId, status: provider.statuses.get(providerRefundId) ?? "PENDING" };
+      }),
+      getRefund: vi.fn(async (providerRefundId: string) => {
+        provider.getCalls.push(providerRefundId);
+        const failure = provider.getFailures.shift();
+        if (failure) throw failure;
+        return { id: providerRefundId, status: provider.statuses.get(providerRefundId) ?? "PENDING" };
+      }),
+    },
   };
 });
-
-vi.mock("../modules/payments/paypal-refunds.client.js", () => ({
-  getPayPalRefund: vi.fn(async (providerRefundId: string) => {
-    provider.getCalls.push(providerRefundId);
-    const failure = provider.getFailures.shift();
-    if (failure) throw failure;
-    return { id: providerRefundId, status: provider.statuses.get(providerRefundId) ?? "PENDING" };
-  }),
-}));
 
 import { prisma } from "../shared/database/index.js";
 import { commissionsService } from "../modules/commissions/commissions.service.js";

--- a/server/src/modules/payments/__tests__/payments.service.test.ts
+++ b/server/src/modules/payments/__tests__/payments.service.test.ts
@@ -41,15 +41,15 @@ vi.mock("../../../shared/database/index.js", () => ({
   },
 }));
 
-vi.mock("../../../shared/utils/paypal.js", () => ({
-  createPayPalOrder: vi.fn(),
-  capturePayPalOrder: vi.fn(),
-  getPayPalApprovalLink: vi.fn(),
-  getPayPalOrder: vi.fn(),
-  isPayPalApprovedStatus: (value: unknown) => value === "APPROVED",
-  isPayPalCompletedStatus: (value: unknown) => value === "COMPLETED",
-  isPayPalOrderAlreadyCapturedError: (err: unknown) =>
-    err instanceof Error && /ORDER_ALREADY_CAPTURED/i.test(err.message),
+vi.mock("../paypal-provider.gateway.js", () => ({
+  paypalProvider: {
+    createOrder: vi.fn(),
+    captureOrder: vi.fn(),
+    getOrder: vi.fn(),
+    refundCapture: vi.fn(),
+    getRefund: vi.fn(),
+    classifyRefundFailure: vi.fn(),
+  },
 }));
 
 vi.mock("../refunds.service.js", () => ({
@@ -69,7 +69,7 @@ vi.mock("../refunds.service.js", () => ({
 }));
 
 import { prisma } from "../../../shared/database/index.js";
-import { createPayPalOrder, capturePayPalOrder, getPayPalApprovalLink, getPayPalOrder } from "../../../shared/utils/paypal.js";
+import { paypalProvider } from "../paypal-provider.gateway.js";
 import { paymentsService } from "../payments.service.js";
 import { refundsService } from "../refunds.service.js";
 import { Prisma } from "@prisma/client";
@@ -102,8 +102,10 @@ describe("paymentsService", () => {
       vi.mocked(prisma.$transaction).mockImplementation(async (fn: (client: typeof prisma) => unknown) =>
         fn(prisma)
       );
-      vi.mocked(createPayPalOrder).mockResolvedValue({ id: "paypal-order-1", links: [] } as never);
-      vi.mocked(getPayPalApprovalLink).mockReturnValue("https://paypal.com/approve/123");
+      vi.mocked(paypalProvider.createOrder).mockResolvedValue({
+        id: "paypal-order-1",
+        approvalUrl: "https://paypal.com/approve/123",
+      });
       vi.mocked(prisma.order.update).mockResolvedValue({} as never);
     };
 
@@ -112,7 +114,12 @@ describe("paymentsService", () => {
 
       const result = await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
 
-      expect(createPayPalOrder).toHaveBeenCalledWith("150.00", "BRL", "order-1", undefined);
+      expect(paypalProvider.createOrder).toHaveBeenCalledWith({
+        amount: "150.00",
+        currency: "BRL",
+        orderId: "order-1",
+        checkoutUrls: undefined,
+      });
       expect(result.approvalUrl).toBe("https://paypal.com/approve/123");
       expect(result.orderId).toBe("order-1");
     });
@@ -128,9 +135,11 @@ describe("paymentsService", () => {
         cancelUrl,
       });
 
-      expect(createPayPalOrder).toHaveBeenCalledWith("150.00", "BRL", "order-1", {
-        returnUrl,
-        cancelUrl,
+      expect(paypalProvider.createOrder).toHaveBeenCalledWith({
+        amount: "150.00",
+        currency: "BRL",
+        orderId: "order-1",
+        checkoutUrls: { returnUrl, cancelUrl },
       });
     });
 
@@ -139,7 +148,7 @@ describe("paymentsService", () => {
 
       await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
 
-      const urls = vi.mocked(createPayPalOrder).mock.calls[0]?.[3];
+      const urls = vi.mocked(paypalProvider.createOrder).mock.calls[0]?.[0].checkoutUrls;
       expect(urls).toBeUndefined();
     });
 
@@ -173,8 +182,7 @@ describe("paymentsService", () => {
 
     it("falls back to the PayPal checkout URL when the approve link is missing", async () => {
       setupCreateLink();
-      vi.mocked(createPayPalOrder).mockResolvedValue({ id: "paypal-1", links: [] } as never);
-      vi.mocked(getPayPalApprovalLink).mockReturnValue(undefined);
+      vi.mocked(paypalProvider.createOrder).mockResolvedValue({ id: "paypal-1" });
 
       const result = await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
 
@@ -184,8 +192,10 @@ describe("paymentsService", () => {
 
     it("stores paypalOrderId on the order", async () => {
       setupCreateLink();
-      vi.mocked(createPayPalOrder).mockResolvedValue({ id: "paypal-order-99" } as never);
-      vi.mocked(getPayPalApprovalLink).mockReturnValue("https://approve.url");
+      vi.mocked(paypalProvider.createOrder).mockResolvedValue({
+        id: "paypal-order-99",
+        approvalUrl: "https://approve.url",
+      });
 
       await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
 
@@ -212,7 +222,7 @@ describe("paymentsService", () => {
         cancelUrl: "https://app.example/orders/order-1/cancel",
       });
 
-      expect(createPayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.createOrder).not.toHaveBeenCalled();
       expect(prisma.paymentLink.create).not.toHaveBeenCalled();
       expect(result).toEqual({
         orderId: "order-1",
@@ -239,7 +249,7 @@ describe("paymentsService", () => {
         statusCode: 409,
         message: expect.stringContaining("still in progress"),
       });
-      expect(createPayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.createOrder).not.toHaveBeenCalled();
     });
 
     it("replays when a concurrent claim has already completed", async () => {
@@ -265,13 +275,13 @@ describe("paymentsService", () => {
 
       const result = await paymentsService.createPaymentLink("user-1", { orderId: "order-1" });
 
-      expect(createPayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.createOrder).not.toHaveBeenCalled();
       expect(result.paypalOrderId).toBe("paypal-won");
     });
 
     it("releases the in-progress claim when OrdersCreate fails", async () => {
       setupCreateLink();
-      vi.mocked(createPayPalOrder).mockRejectedValue(new Error("PayPal unavailable"));
+      vi.mocked(paypalProvider.createOrder).mockRejectedValue(new Error("PayPal unavailable"));
 
       await expect(
         paymentsService.createPaymentLink("user-1", { orderId: "order-1" })
@@ -643,12 +653,12 @@ describe("paymentsService", () => {
       vi.mocked(prisma.order.findMany).mockResolvedValue([
         { id: "order-1", paypalOrderId: "paypal-1" },
       ] as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
       setupWebhookTransaction();
 
       const result = await paymentsService.reconcilePendingPaypalOrders();
 
-      expect(getPayPalOrder).toHaveBeenCalledWith("paypal-1");
+      expect(paypalProvider.getOrder).toHaveBeenCalledWith("paypal-1");
       expect(prisma.order.updateMany).toHaveBeenCalled();
       expect(result).toEqual({ scanned: 1, confirmed: 1 });
     });
@@ -657,11 +667,11 @@ describe("paymentsService", () => {
       vi.mocked(prisma.order.findMany).mockResolvedValue([
         { id: "order-1", paypalOrderId: "paypal-1", items: [] },
       ] as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "CREATED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "CREATED" });
 
       const result = await paymentsService.reconcilePendingPaypalOrders();
 
-      expect(capturePayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.captureOrder).not.toHaveBeenCalled();
       expect(prisma.$transaction).not.toHaveBeenCalled();
       expect(result).toEqual({ scanned: 1, confirmed: 0 });
     });
@@ -683,13 +693,13 @@ describe("paymentsService", () => {
           ],
         },
       ] as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
-      vi.mocked(capturePayPalOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
+      vi.mocked(paypalProvider.captureOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
       setupWebhookTransaction();
 
       const result = await paymentsService.reconcilePendingPaypalOrders();
 
-      expect(capturePayPalOrder).toHaveBeenCalledWith("paypal-1");
+      expect(paypalProvider.captureOrder).toHaveBeenCalledWith("paypal-1");
       expect(prisma.order.updateMany).toHaveBeenCalled();
       expect(result).toEqual({ scanned: 1, confirmed: 1 });
     });
@@ -711,11 +721,11 @@ describe("paymentsService", () => {
           ],
         },
       ] as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
 
       const result = await paymentsService.reconcilePendingPaypalOrders();
 
-      expect(capturePayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.captureOrder).not.toHaveBeenCalled();
       expect(prisma.$transaction).not.toHaveBeenCalled();
       expect(result).toEqual({ scanned: 1, confirmed: 0 });
     });
@@ -741,13 +751,13 @@ describe("paymentsService", () => {
 
     it("captures APPROVED PayPal orders and confirms locally", async () => {
       vi.mocked(prisma.order.findUnique).mockResolvedValue(liveOrder() as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
-      vi.mocked(capturePayPalOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
+      vi.mocked(paypalProvider.captureOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
       setupWebhookTransaction();
 
       const result = await paymentsService.capturePayment("user-1", "order-1");
 
-      expect(capturePayPalOrder).toHaveBeenCalledWith("paypal-1");
+      expect(paypalProvider.captureOrder).toHaveBeenCalledWith("paypal-1");
       expect(prisma.order.updateMany).toHaveBeenCalled();
       expect(result).toMatchObject({
         orderId: "order-1",
@@ -758,12 +768,12 @@ describe("paymentsService", () => {
 
     it("confirms without capturing when PayPal already reports COMPLETED", async () => {
       vi.mocked(prisma.order.findUnique).mockResolvedValue(liveOrder() as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
       setupWebhookTransaction();
 
       await paymentsService.capturePayment("user-1", "order-1");
 
-      expect(capturePayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.captureOrder).not.toHaveBeenCalled();
       expect(prisma.order.updateMany).toHaveBeenCalled();
     });
 
@@ -776,7 +786,7 @@ describe("paymentsService", () => {
           paymentStatus: "PENDING",
           totalAmount: stale.totalAmount,
         } as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({
         id: "paypal-1",
         status: "COMPLETED",
         captureId: "capture-1",
@@ -809,7 +819,7 @@ describe("paymentsService", () => {
           paymentStatus: "PENDING",
           totalAmount: stale.totalAmount,
         } as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "COMPLETED" });
       vi.mocked(prisma.$transaction).mockRejectedValue(
         new AppError(409, "Reservation expired or listing is no longer reserved")
       );
@@ -838,12 +848,12 @@ describe("paymentsService", () => {
           ],
         }) as never
       );
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1", status: "APPROVED" });
 
       await expect(paymentsService.capturePayment("user-1", "order-1")).rejects.toMatchObject({
         statusCode: 409,
       });
-      expect(capturePayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.captureOrder).not.toHaveBeenCalled();
     });
 
     it("rejects another customer's order", async () => {
@@ -851,16 +861,16 @@ describe("paymentsService", () => {
       await expect(paymentsService.capturePayment("other-user", "order-1")).rejects.toMatchObject({
         statusCode: 403,
       });
-      expect(getPayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.getOrder).not.toHaveBeenCalled();
     });
 
     it("does not confirm when PayPal status is a local or unknown label", async () => {
       vi.mocked(prisma.order.findUnique).mockResolvedValue(liveOrder() as never);
-      vi.mocked(getPayPalOrder).mockResolvedValue({ id: "paypal-1" });
+      vi.mocked(paypalProvider.getOrder).mockResolvedValue({ id: "paypal-1" });
 
       const result = await paymentsService.capturePayment("user-1", "order-1");
 
-      expect(capturePayPalOrder).not.toHaveBeenCalled();
+      expect(paypalProvider.captureOrder).not.toHaveBeenCalled();
       expect(prisma.order.updateMany).not.toHaveBeenCalled();
       expect(result).toMatchObject({
         orderId: "order-1",

--- a/server/src/modules/payments/__tests__/paypal-provider.gateway.test.ts
+++ b/server/src/modules/payments/__tests__/paypal-provider.gateway.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "../../../shared/errors/AppError.js";
+
+vi.mock("../../../shared/utils/paypal.js", () => ({
+  createPayPalOrder: vi.fn(),
+  capturePayPalOrder: vi.fn(),
+  getPayPalApprovalLink: vi.fn(),
+  getPayPalOrder: vi.fn(),
+  isPayPalOrderAlreadyCapturedError: vi.fn(),
+  refundPayPalCapture: vi.fn(),
+}));
+
+vi.mock("../paypal-refunds.client.js", () => ({
+  getPayPalRefund: vi.fn(),
+}));
+
+import {
+  capturePayPalOrder,
+  createPayPalOrder,
+  getPayPalApprovalLink,
+  getPayPalOrder,
+  isPayPalOrderAlreadyCapturedError,
+  refundPayPalCapture,
+} from "../../../shared/utils/paypal.js";
+import { getPayPalRefund } from "../paypal-refunds.client.js";
+import { paypalProvider } from "../paypal-provider.gateway.js";
+
+describe("paypalProvider gateway", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes order creation to the application-facing shape", async () => {
+    vi.mocked(createPayPalOrder).mockResolvedValue({
+      id: "PAYPAL-1",
+      status: "CREATED",
+      links: [{ rel: "approve", href: "https://paypal.example/approve" }],
+    });
+    vi.mocked(getPayPalApprovalLink).mockReturnValue("https://paypal.example/approve");
+
+    await expect(
+      paypalProvider.createOrder({
+        amount: "150.00",
+        currency: "BRL",
+        orderId: "order-1",
+      })
+    ).resolves.toEqual({
+      id: "PAYPAL-1",
+      status: "CREATED",
+      captureId: undefined,
+      approvalUrl: "https://paypal.example/approve",
+    });
+    expect(createPayPalOrder).toHaveBeenCalledWith("150.00", "BRL", "order-1", undefined);
+  });
+
+  it("recovers an already-captured response through the trusted GET", async () => {
+    const alreadyCaptured = new Error("ORDER_ALREADY_CAPTURED");
+    vi.mocked(capturePayPalOrder).mockRejectedValue(alreadyCaptured);
+    vi.mocked(isPayPalOrderAlreadyCapturedError).mockReturnValue(true);
+    vi.mocked(getPayPalOrder).mockResolvedValue({ id: "PAYPAL-1", status: "COMPLETED" });
+
+    await expect(paypalProvider.captureOrder("PAYPAL-1")).resolves.toMatchObject({
+      status: "COMPLETED",
+    });
+    expect(isPayPalOrderAlreadyCapturedError).toHaveBeenCalledWith(alreadyCaptured);
+    expect(getPayPalOrder).toHaveBeenCalledWith("PAYPAL-1");
+  });
+
+  it("does not hide unrelated capture failures", async () => {
+    const failure = new Error("provider unavailable");
+    vi.mocked(capturePayPalOrder).mockRejectedValue(failure);
+    vi.mocked(isPayPalOrderAlreadyCapturedError).mockReturnValue(false);
+
+    await expect(paypalProvider.captureOrder("PAYPAL-1")).rejects.toBe(failure);
+    expect(getPayPalOrder).not.toHaveBeenCalled();
+  });
+
+  it("exposes refund POST and GET through one provider fake point", async () => {
+    vi.mocked(refundPayPalCapture).mockResolvedValue({ id: "REFUND-1", status: "PENDING" });
+    vi.mocked(getPayPalRefund).mockResolvedValue({ id: "REFUND-1", status: "COMPLETED" });
+
+    await expect(paypalProvider.refundCapture("CAPTURE-1", "request-1")).resolves.toMatchObject({
+      status: "PENDING",
+    });
+    await expect(paypalProvider.getRefund("REFUND-1")).resolves.toMatchObject({
+      status: "COMPLETED",
+    });
+  });
+
+  it.each([
+    [new AppError(504, "PayPal timed out"), "paypal_timeout"],
+    [new Error("PREVIOUS_REQUEST_IN_PROGRESS"), "paypal_request_in_progress"],
+    [new Error("PayPal failed: 429"), "paypal_throttled"],
+    [new Error("PayPal failed: 503"), "paypal_provider_unavailable"],
+    [new Error("unexpected"), "reconciliation_technical_failure"],
+  ])("normalizes refund failure %s as %s", (error, expected) => {
+    expect(paypalProvider.classifyRefundFailure(error)).toBe(expected);
+  });
+});

--- a/server/src/modules/payments/payments.service.ts
+++ b/server/src/modules/payments/payments.service.ts
@@ -2,17 +2,6 @@ import { prisma } from "../../shared/database/index.js";
 import { AppError } from "../../shared/errors/AppError.js";
 import { logger } from "../../shared/logger.js";
 import {
-  capturePayPalOrder,
-  createPayPalOrder,
-  getPayPalApprovalLink,
-  getPayPalOrder,
-  isPayPalApprovedStatus,
-  isPayPalCompletedStatus,
-  isPayPalOrderAlreadyCapturedError,
-  type ParsedPayPalOrder,
-  type PayPalOrderStatus,
-} from "../../shared/utils/paypal.js";
-import {
   PAYPAL_EVENT_CAPTURE_COMPLETED,
   PAYPAL_EVENT_ORDER_APPROVED,
   parsePayPalWebhookEvent,
@@ -43,6 +32,11 @@ import {
 import { outboxRepository } from "../../shared/outbox/outbox.repository.js";
 import { OutboxEventType } from "../../shared/outbox/outbox.types.js";
 import { refundsService } from "./refunds.service.js";
+import {
+  paypalProvider,
+  type PaypalOrderStatus,
+  type PaypalProviderOrder,
+} from "./paypal-provider.gateway.js";
 
 const WEBHOOK_PROVIDER = PaymentProvider.PAYPAL;
 
@@ -82,13 +76,17 @@ export const paymentsService = {
           input.returnUrl || input.cancelUrl
             ? { returnUrl: input.returnUrl, cancelUrl: input.cancelUrl }
             : undefined;
-        const paypalOrder = await createPayPalOrder(amount, MONEY_CURRENCY, order.id, checkoutUrls);
+        const paypalOrder = await paypalProvider.createOrder({
+          amount,
+          currency: MONEY_CURRENCY,
+          orderId: order.id,
+          checkoutUrls,
+        });
         openedPaypalOrderId = paypalOrder.id;
         if (!openedPaypalOrderId) {
           throw new AppError(500, "Failed to create PayPal order");
         }
-        const approvalLink =
-          getPayPalApprovalLink(paypalOrder) ?? paypalCheckoutUrl(openedPaypalOrderId);
+        const approvalLink = paypalOrder.approvalUrl ?? paypalCheckoutUrl(openedPaypalOrderId);
 
         await prisma.$transaction(async (tx) => {
           await tx.paymentLink.update({
@@ -465,7 +463,7 @@ type OrderForPaypalSync = {
 
 type RemotePaypalSyncOutcome = {
   paymentStatus: Extract<PaymentStatus, "PAID" | "PENDING" | "REFUNDED">;
-  paypalStatus?: PayPalOrderStatus;
+  paypalStatus?: PaypalOrderStatus;
 };
 
 function orderHoldAllowsCapture(order: OrderForPaypalSync, now = new Date()): boolean {
@@ -482,17 +480,6 @@ function orderHoldAllowsCapture(order: OrderForPaypalSync, now = new Date()): bo
   });
 }
 
-async function captureApprovedPaypalOrder(paypalOrderId: string): Promise<ParsedPayPalOrder> {
-  try {
-    return await capturePayPalOrder(paypalOrderId);
-  } catch (err) {
-    if (isPayPalOrderAlreadyCapturedError(err)) {
-      return getPayPalOrder(paypalOrderId);
-    }
-    throw err;
-  }
-}
-
 /**
  * Trusted PayPal REST only. APPROVED does not sell listings. Capture is skipped
  * when the local hold is dead so we do not take funds after expiry.
@@ -505,17 +492,17 @@ async function syncRemotePaypalPayment(
     return { paymentStatus: "PENDING" };
   }
 
-  let remote = await getPayPalOrder(order.paypalOrderId);
+  let remote: PaypalProviderOrder = await paypalProvider.getOrder(order.paypalOrderId);
 
-  if (isPayPalApprovedStatus(remote.status) && options.captureIfApproved) {
+  if (remote.status === "APPROVED" && options.captureIfApproved) {
     if (!orderHoldAllowsCapture(order)) {
       logger.warn({ orderId: order.id }, "paypal capture skipped: reservation expired");
       throw new AppError(409, "Reservation expired or listing is no longer reserved");
     }
-    remote = await captureApprovedPaypalOrder(order.paypalOrderId);
+    remote = await paypalProvider.captureOrder(order.paypalOrderId);
   }
 
-  if (isPayPalCompletedStatus(remote.status)) {
+  if (remote.status === "COMPLETED") {
     const outcome = await applyTrustedCompletedCapture(order.id, remote.captureId);
     return { paymentStatus: outcome.paymentStatus, paypalStatus: remote.status };
   }

--- a/server/src/modules/payments/paypal-provider.gateway.ts
+++ b/server/src/modules/payments/paypal-provider.gateway.ts
@@ -1,0 +1,104 @@
+import { AppError } from "../../shared/errors/AppError.js";
+import {
+  capturePayPalOrder,
+  createPayPalOrder,
+  getPayPalApprovalLink,
+  getPayPalOrder,
+  isPayPalOrderAlreadyCapturedError,
+  refundPayPalCapture,
+  type PayPalCheckoutUrls,
+  type PayPalOrderStatus,
+  type PayPalRefundStatus,
+} from "../../shared/utils/paypal.js";
+import { getPayPalRefund } from "./paypal-refunds.client.js";
+
+export type PaypalProviderOrder = {
+  id?: string;
+  status?: PaypalOrderStatus;
+  captureId?: string;
+  approvalUrl?: string;
+};
+
+export type PaypalProviderRefund = {
+  id: string;
+  status: PaypalRefundStatus;
+};
+
+export type PaypalOrderStatus = PayPalOrderStatus;
+export type PaypalRefundStatus = PayPalRefundStatus;
+
+export type PaypalRefundFailureReason =
+  | "paypal_timeout"
+  | "paypal_request_in_progress"
+  | "paypal_throttled"
+  | "paypal_provider_unavailable"
+  | "reconciliation_technical_failure";
+
+export interface PaypalProviderGateway {
+  createOrder(input: {
+    amount: string;
+    currency: "BRL";
+    orderId: string;
+    checkoutUrls?: PayPalCheckoutUrls;
+  }): Promise<PaypalProviderOrder>;
+  getOrder(paypalOrderId: string): Promise<PaypalProviderOrder>;
+  captureOrder(paypalOrderId: string): Promise<PaypalProviderOrder>;
+  refundCapture(captureId: string, requestId: string): Promise<PaypalProviderRefund>;
+  getRefund(providerRefundId: string): Promise<PaypalProviderRefund>;
+  classifyRefundFailure(error: unknown): PaypalRefundFailureReason;
+}
+
+/**
+ * The single application-facing PayPal seam. SDK/HTTP helpers, response-link
+ * parsing, capture replay recovery, and provider error classification stay here.
+ */
+export const paypalProvider: PaypalProviderGateway = {
+  async createOrder(input) {
+    const order = await createPayPalOrder(
+      input.amount,
+      input.currency,
+      input.orderId,
+      input.checkoutUrls
+    );
+    return {
+      id: order.id,
+      status: order.status,
+      captureId: order.captureId,
+      approvalUrl: getPayPalApprovalLink(order),
+    };
+  },
+
+  getOrder(paypalOrderId) {
+    return getPayPalOrder(paypalOrderId);
+  },
+
+  async captureOrder(paypalOrderId) {
+    try {
+      return await capturePayPalOrder(paypalOrderId);
+    } catch (error) {
+      if (isPayPalOrderAlreadyCapturedError(error)) {
+        return getPayPalOrder(paypalOrderId);
+      }
+      throw error;
+    }
+  },
+
+  refundCapture(captureId, requestId) {
+    return refundPayPalCapture(captureId, requestId);
+  },
+
+  getRefund(providerRefundId) {
+    return getPayPalRefund(providerRefundId);
+  },
+
+  classifyRefundFailure(error) {
+    const message = error instanceof Error ? error.message : "unknown_error";
+    if (error instanceof AppError && error.statusCode === 504) return "paypal_timeout";
+    if (/PREVIOUS_REQUEST_IN_PROGRESS|failed: 409/i.test(message)) {
+      return "paypal_request_in_progress";
+    }
+    if (/failed: 429/i.test(message)) return "paypal_throttled";
+    if (/failed: 5\d\d/i.test(message)) return "paypal_provider_unavailable";
+    return "reconciliation_technical_failure";
+  },
+};

--- a/server/src/modules/payments/refunds.service.ts
+++ b/server/src/modules/payments/refunds.service.ts
@@ -15,10 +15,10 @@ import {
   PAYPAL_REFUND_RECONCILE_BATCH_SIZE,
 } from "../../shared/config/paypal.js";
 import {
-  refundPayPalCapture,
-  type PayPalRefundStatus,
-} from "../../shared/utils/paypal.js";
-import { getPayPalRefund } from "./paypal-refunds.client.js";
+  paypalProvider,
+  type PaypalProviderRefund,
+  type PaypalRefundStatus,
+} from "./paypal-provider.gateway.js";
 
 export type CreateRefundObligationInput = {
   orderId: string;
@@ -32,7 +32,7 @@ export type RecordProviderConfirmedRefundInput = {
 };
 
 export type RecordProviderRefundObservationInput = RecordProviderConfirmedRefundInput & {
-  status: Exclude<PayPalRefundStatus, "COMPLETED">;
+  status: Exclude<PaypalRefundStatus, "COMPLETED">;
 };
 
 export type RefundReconciliationResult = {
@@ -182,7 +182,7 @@ export const refundsService = {
     }
 
     const requestId = buildPayPalRefundRequestId(refund.id);
-    const providerResult = await refundPayPalCapture(
+    const providerResult = await paypalProvider.refundCapture(
       refund.providerCaptureId,
       requestId
     );
@@ -273,7 +273,7 @@ export const refundsService = {
               const reconciled = candidate.providerRefundId
                 ? await applyProviderObservation(
                     candidate.id,
-                    await getPayPalRefund(candidate.providerRefundId)
+                    await paypalProvider.getRefund(candidate.providerRefundId)
                   )
                 : await refundsService.executeProviderRefund(candidate.id);
 
@@ -302,7 +302,7 @@ export const refundsService = {
                 logger.error(refundLog(candidate, reconciled.refund.status, "unresolved_age_threshold"), "refund reconciliation requires operator investigation");
               }
             } catch (err) {
-              const reason = classifyRetryableRefundFailure(err);
+              const reason = paypalProvider.classifyRefundFailure(err);
               await recordRetryableFailure(candidate.id, candidate.status, reason);
               itemSpan.setAttribute("refund.status_after", candidate.status === "FAILED" ? "FAILED" : "PROCESSING");
               itemSpan.setAttribute("refund.reconciliation_reason", reason);
@@ -327,7 +327,7 @@ export const refundsService = {
   },
 };
 
-async function applyProviderObservation(refundId: string, provider: { id: string; status: PayPalRefundStatus }) {
+async function applyProviderObservation(refundId: string, provider: PaypalProviderRefund) {
   if (provider.status === "COMPLETED") {
     return refundsService.recordProviderConfirmedCompletion({
       refundId,
@@ -354,15 +354,6 @@ async function recordRetryableFailure(
       failureReason: previousStatus === "FAILED" ? undefined : reason,
     },
   });
-}
-
-function classifyRetryableRefundFailure(err: unknown): string {
-  const message = err instanceof Error ? err.message : "unknown_error";
-  if (err instanceof AppError && err.statusCode === 504) return "paypal_timeout";
-  if (/PREVIOUS_REQUEST_IN_PROGRESS|failed: 409/i.test(message)) return "paypal_request_in_progress";
-  if (/failed: 429/i.test(message)) return "paypal_throttled";
-  if (/failed: 5\d\d/i.test(message)) return "paypal_provider_unavailable";
-  return "reconciliation_technical_failure";
 }
 
 function refundLog(


### PR DESCRIPTION
## Context

PR09 evaluates one emblematic architecture seam around outbound PayPal calls:

payment/refund orchestration -> PaypalProviderGateway -> existing PayPal SDK/HTTP utilities

The seam passed the roadmap benefit test because application services directly depended on multiple low-level provider helpers and focused tests mocked provider details across two modules. ADR 0025 records the durable boundary.

## Change

- Added one PayPal-specific gateway for order create/get/capture, refund POST/GET, capture replay fallback, approval-link normalization, and refund error classification.
- Updated payments.service.ts and refunds.service.ts to consume that gateway.
- Preserved explicit Prisma transactions, reservation checks, ledger writes, durable refund state, webhook handling, and bounded reconciliation.
- Updated focused tests to replace one provider object.

No schema, migration, API, OpenAPI, retry-policy, money, webhook, or reconciliation-timing change.

## Architectural benefit

| Signal | Before | After | Benefit |
|---|---:|---:|---|
| Low-level outbound PayPal modules imported by application services | 2 | 0 | Services depend only on the gateway |
| Outbound PayPal symbols imported directly by payments.service.ts | 9 | 0 | Orchestration no longer knows helper layout or capture replay mechanics |
| Outbound PayPal symbols imported directly by refunds.service.ts | 3 | 0 | Refund execution and observation use one contract |
| Provider modules mocked by focused refund reconciliation tests | 2 | 1 | One provider object represents POST and GET behavior |
| Low-level PayPal functions mocked by the focused payment service suite | 7 | 0 | Application tests are isolated from SDK/HTTP details |
| Provider-specific refund failure classification in application services | 1 | 0 | Normalization lives at the provider boundary |

Decision: **PASS — the seam provides concrete coupling and testability benefit.**

## Risk

The high-risk paths are capture completion, expired reservations, already-captured recovery, unfulfillable-capture refunds, refund reconciliation, and seller compensation. The refactor moves only provider invocation and normalization. Trusted COMPLETED checks, hold validation, local transactions, durable claims, idempotency keys, append-only ledger changes, and outbox writes remain in their existing application paths. Provider I/O remains outside critical PostgreSQL transactions.

## Verification

- npm ci --prefix server — PASS (baseline reports 2 moderate dependency vulnerabilities and an engine warning under local Node 20.10.0)
- npm run db:generate --prefix server — PASS
- npm run lint --prefix server — PASS
- npm run typecheck --prefix server — PASS
- npm run test:unit --prefix server — PASS (72 files, 430 tests)
- npm run test:contract --prefix server — PASS (1 file, 19 tests)
- npm run build --prefix server — PASS
- python scripts/verify.py — PASS
- git diff --check — PASS
- npm run test:integration --prefix server — unavailable locally: fail-closed setup rejected the environment before collection because no TEST_DATABASE_URL/usable PostgreSQL instance is configured. Remote CI provides PostgreSQL evidence.

## Remaining risk

- Application logic intentionally still knows PayPal status labels and webhook event semantics because PayPal remains the only provider.
- Inbound webhook signature verification/parsing remains a separate security boundary.
- Existing PayPal SDK/HTTP utilities and paypal-refunds.client.ts remain the concrete implementation.
- PostgreSQL integration evidence depends on CI.

## Material-change review

- Specification and acceptance fidelity: **2/2**
- Correctness, invariants, and failure behavior: **2/2**
- Security and governance: **2/2**
- Architecture and scope discipline: **2/2**
- Verification and operational evidence: **2/2**

Total: **10/10**, with local PostgreSQL integration unavailable and remote CI evidence required.